### PR TITLE
Disable `rd` post-build-event.

### DIFF
--- a/Source/RP0.csproj
+++ b/Source/RP0.csproj
@@ -50,7 +50,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>git clean -Xdf ..\..\..\Source\obj</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
This let's us build on Linux and systems that don't have `rd` installed.
But I've no idea what `rd` is supposed to do, so I'm submitting this as
a pull-request. @NathanKell, halp!
