### PR TITLE
add smaller sizes for Stack Chute and Cone Chute

### DIFF
--- a/GameData/RP-0/RealChute.cfg
+++ b/GameData/RP-0/RealChute.cfg
@@ -1,0 +1,32 @@
+@PART[RC_cone]:FOR[RP-0]
+{
+    @MODULE[ProceduralChute]
+	{
+        SIZE
+        {
+            size = 0.24, 0.24, 0.24
+			sizeID = 0.3m
+			caseMass = 0.00288
+			bottomNode = 0, -0.0055308, 0
+			bottomNodeSize = 0
+			cost = 0.24
+        }
+    }
+}
+@PART[RC_stack]:FOR[RP-0]
+{
+    @MODULE[ProceduralChute]
+	{
+        SIZE
+        {
+            size = 0.24, 0.24, 0.24
+			sizeID = 0.3m
+			caseMass = 0.00288
+            topNode = 0, 0.037056, 0
+			topNodeSize = 0
+			bottomNode = 0, -0.031296, 0
+			bottomNodeSize = 0
+			cost = 0.24
+        }
+    }
+}


### PR DESCRIPTION
- they are now the biggest size  -> you have to press "previous size" to get them
- might also be integrated in RealismOverhaul but is probably RP-0 specific