### PR TITLE
Add AJ10-104D

### DIFF
--- a/GameData/RP-0/VSR_Engines.cfg
+++ b/GameData/RP-0/VSR_Engines.cfg
@@ -931,6 +931,31 @@
 		}
 		CONFIG
 		{
+			name = AJ10-104D	// Main engine used on Ablestar
+			minThrust = 35.1
+			maxThrust = 35.1
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = UDMH
+				ratio = 0.406
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = IWFNA
+				ratio = 0.594
+			}
+			atmosphereCurve
+			{
+				key = 0 278
+				key = 1 248
+			}
+			massMult = 1.0
+			techRequired = advRocketry
+		}
+		CONFIG
+		{
 			name = AJ10-142-Delta
 			minThrust = 34.25
 			maxThrust = 34.25
@@ -949,7 +974,7 @@
 			}
 			atmosphereCurve
 			{
-				key = 0 272 // Guess
+				key = 0 270
 				key = 1 240
 			}
 			massMult = 1.0

--- a/GameData/RP-0/VSR_Engines.cfg
+++ b/GameData/RP-0/VSR_Engines.cfg
@@ -946,12 +946,25 @@
 				name = IWFNA
 				ratio = 0.594
 			}
+			ModuleEngineIgnitor
+			{
+				ignitionsAvailable = 5
+				autoIgnitionTemperature = 500
+				ignitorType = Hypergolic
+				useUllageSimulation = True
+				isPressureFed = False
+				IGNITOR_RESOURCE
+				{
+					name = ElectricCharge
+					amount = 0.2
+				}
+			}
 			atmosphereCurve
 			{
 				key = 0 278
 				key = 1 248
 			}
-			massMult = 1.0
+			massMult = 1.1
 			techRequired = advRocketry
 		}
 		CONFIG

--- a/GameData/RP-0/VSR_Engines.cfg
+++ b/GameData/RP-0/VSR_Engines.cfg
@@ -896,6 +896,19 @@
 				name = IWFNA
 				ratio = 0.594
 			}
+			ModuleEngineIgnitor
+			{
+				ignitionsAvailable = 1
+				autoIgnitionTemperature = 500
+				ignitorType = Hypergolic
+				useUllageSimulation = True
+				isPressureFed = False
+				IGNITOR_RESOURCE
+				{
+					name = ElectricCharge
+					amount = 0.2
+				}
+			}
 			atmosphereCurve
 			{
 				key = 0 271
@@ -920,6 +933,19 @@
 			{
 				name = IWFNA
 				ratio = 0.594
+			}
+			ModuleEngineIgnitor
+			{
+				ignitionsAvailable = 1
+				autoIgnitionTemperature = 500
+				ignitorType = Hypergolic
+				useUllageSimulation = True
+				isPressureFed = False
+				IGNITOR_RESOURCE
+				{
+					name = ElectricCharge
+					amount = 0.2
+				}
 			}
 			atmosphereCurve
 			{
@@ -984,6 +1010,19 @@
 			{
 				name = IWFNA
 				ratio = 0.594
+			}
+			ModuleEngineIgnitor
+			{
+				ignitionsAvailable = 1
+				autoIgnitionTemperature = 500
+				ignitorType = Hypergolic
+				useUllageSimulation = True
+				isPressureFed = False
+				IGNITOR_RESOURCE
+				{
+					name = ElectricCharge
+					amount = 0.2
+				}
 			}
 			atmosphereCurve
 			{


### PR DESCRIPTION
Yes I named my branch wrong.

This adds the AJ10-104D, the main engine used in Able Star launches.
ref: http://space.skyrocket.de/doc_lau/thor_ablestar.htm

Also a quick fix to the Isp of the -142