### PR TITLE
Engin configs cleanup

### DIFF
--- a/GameData/RP-0/FASA_Engines.cfg
+++ b/GameData/RP-0/FASA_Engines.cfg
@@ -97,3 +97,19 @@
 		}
 	}
 }
+// A4/A7
+@PART[FASA_Mercury_Redstone_Eng]:FOR[RP-0]
+{
+	@MODULE[ModuleEngineConfigs]
+	{
+		%configuration = A-6
+		@CONFIG[A-6]
+		{
+			%cost = 0
+		}
+		@CONFIG[A-7]
+		{
+			%cost = 50
+		}
+	}
+}

--- a/GameData/RP-0/VSR_Engines.cfg
+++ b/GameData/RP-0/VSR_Engines.cfg
@@ -91,7 +91,7 @@
 	%node_stack_top = 0.0, 0.721461, 0.0, 0.0, 1.0, 0.0, 1
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	%node_stack_bottom = 0.0, -0.727403, 0.0, 0.0, 1.0, 0.0, 1
-	%title = RKK Energiya RD-58 Vacuum Engine [1.25m]
+	%title = RD-58 Vacuum Engine [1.25m]
 	%manufacturer = RKK Energiya
 	@description = Kerolox restartable gas generator-cycle vacuum engine used in the Blok-D upper stage, lifted by the N1 and Proton rockets. Does not suffer boiloff as badly as hydrolox engines, has considerably denser propellants, but also has much lower specific impulse.
 	%attachRules = 1,0,1,0,0
@@ -213,7 +213,7 @@
 	@node_stack_top = 0.0, 0.7350625, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	@node_stack_bottom = 0.0, -1.332244, 0.0, 0.0, 1.0, 0.0, 2
-	@title = Rocketdyne H-1/RS-27 Series Booster [1.0m]
+	@title = H-1/RS-27 Series Booster [1.0m]
 	@manufacturer = Rocketdyne
 	@description = Kerolox gas-generator first-stage engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1, H-1B, and RS-27 are optimized for the first-stage main engine role; the RS-27A has a higher area ratio since it is not ignited until SRB burnout on the Delta II.
 	@attachRules = 1,0,1,0,0
@@ -414,7 +414,7 @@
 	%TechRequired = generalRocketry
 	%entryCost = 48000
 	%cost = 4000
-	@title = Rocketdyne LR-79/89 Series Booster [1m]
+	@title = LR-89 Series [1m]
 	@manufacturer = Rocketdyne
 	@description = Kerolox gas-generator engine that served as booster for Atlas and main engine for Thor/Thor-Delta/Delta and Jupiter/Juno II rockets. Late model LR-89s were upgraded with RS-27 components for higher efficiency.
 	@attachRules = 1,0,1,0,0
@@ -463,10 +463,10 @@
 		name = ModuleEngineConfigs
 		type = ModuleEngines
 		modded = false
-		configuration = LR-89-NA-3/5
+		configuration = LR-89-NA-5
 		CONFIG
 		{
-			name = LR-89-NA-3/5
+			name = LR-89-NA-5
 			minThrust = 758.7
 			maxThrust = 758.7
 			heatProduction = 100
@@ -676,7 +676,7 @@
 	%node_stack_top = 0.0, 0.8723286, 0.0, 0.0, 1.0, 0.0, 2
 	%node_stack_shroud = 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0
 	%node_stack_bottom = 0.0, -0.88252272, 0.0, 0.0, 1.0, 0.0, 2
-	%title = Lunar Module Descent Engine [1.5m]
+	%title = LM Descent Engine [1.5m]
 	%manufacturer = TRW
 	%description = Deeply throttleable pressure-fed vacuum engine used for the descent module of the Apollo lunar lander.
 	%attachRules = 1,0,1,0,0
@@ -718,11 +718,34 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = TDWDescent
+		configuration = LMDE-H
 		modded = false
 		CONFIG
 		{
-			name = TDWDescent
+			name = LMDE-H
+			minThrust = 4.67
+			maxThrust = 43.9
+			heatProduction = 100
+			PROPELLANT
+			{
+				name = Aerozine50
+				ratio = 0.502
+				DrawGauge = True
+			}
+			PROPELLANT
+			{
+				name = NTO
+				ratio = 0.498
+			}
+			atmosphereCurve
+			{
+				key = 0 311
+				key = 1 116
+			}
+		}
+		CONFIG
+		{
+			name = LMDE-J
 			minThrust = 4.67
 			maxThrust = 43.9
 			heatProduction = 100
@@ -834,7 +857,7 @@
 	%TechRequired = basicRocketry
 	%entryCost = 6000
 	%cost = 200
-	%title = AJ10 Upper Stage Engine (Early)
+	%title = AJ-10 Upper Stage Engine (Early)
 	%manufacturer = Aerojet
 	%description = Small pressure-fed hypergolic upper stage engine. Derivative of the first US liquid rocket engine, the AJ10 series is perhaps the longest-lived of any engine series, a part of the US's first satellite launch vehicle, Vanguard, the Apollo CSM, and even one projected Orion service module. This is the original Vanguard second stage / Able / Delta configuration, without restart capability. Note: includes integrated RCS.
 	%attachRules = 1,0,1,0,0
@@ -876,12 +899,12 @@
 	{
 		name = ModuleEngineConfigs
 		type = ModuleEngines
-		configuration = AJ10-37-Vanguard
+		configuration = AJ-10-37
 		modded = false
 		origMass = 0.08
 		CONFIG
 		{
-			name = AJ10-37-Vanguard
+			name = AJ10-37
 			minThrust = 33.8
 			maxThrust = 33.8
 			heatProduction = 100
@@ -905,7 +928,7 @@
 		}
 		CONFIG
 		{
-			name = AJ10-42-Able // The only advantage is this is slightly more reliable.
+			name = AJ-10-42 // The only advantage is this is slightly more reliable.
 			minThrust = 33.0
 			maxThrust = 33.0
 			heatProduction = 100
@@ -931,7 +954,7 @@
 		}
 		CONFIG
 		{
-			name = AJ10-142-Delta
+			name = AJ-10-142
 			minThrust = 34.25
 			maxThrust = 34.25
 			heatProduction = 100
@@ -1258,8 +1281,9 @@
 	}
 	@MODULE[ModuleEngineConfigs]
 	{
-		@CONFIG[SolidFuel]
+		@CONFIG[Castor-120]
 		{
+			@name = X-248
 			@maxThrust = 15
 			@atmosphereCurve
 			{

--- a/tree.yml
+++ b/tree.yml
@@ -267,6 +267,11 @@ start:
         entryCost: 0
         cost: 6
 
+    # XLR11
+    FASAGemini4X800Mini:
+        entryCost: 0
+        cost: 50
+
     # Tanks
 
     SXTFuel625m:
@@ -418,6 +423,8 @@ basicRocketry:
     US_Radial_Oxygen: *basicWedge
 
     # Engines
+    NP_lfe_25m_Orbitalbertha_Mini: #XLR99
+        entryCost: 60000
 
     liquidEngine2: # X-405 (Vanguard main engine)
         cost: 750 # very expensive for its performance.


### PR DESCRIPTION
** This will break save games **

Just like on the RO side, this is a pass to clean up all the engine configs to bring them into a neat orderly fashion with consistency across part packs, etc, etc.

**NOTE** At least one change in here requires the same change made to RO which is in this PR: https://github.com/KSP-RO/RealismOverhaul/pull/137

So the RO needs to be accepted before this one will work properly.
