### PR TITLE
Create dedicated hydrolox nodes.

### DIFF
--- a/GameData/RP-0/CTTChanges.cfg
+++ b/GameData/RP-0/CTTChanges.cfg
@@ -64,23 +64,124 @@
 		@pos = -2000,350,-1
 		@parents = node2_survivability, node3_scienceTech
 	}
-	@NODE[node3_generalConstruction]
-	{
-		@title = Early Hydrolox Engines
-		@icon = FUELSYSTEMS
-		@description = The first hydrolox engines. Much more efficient, especially for upper stages, but much more expensive (and much more difficult to research and build). 1962.
-		@cost = 60
-		@anyParent = False
+
+        NODE
+        {
+                name = rp0_hydroloxTL2
+                techID = hydroloxTL2
+                pos = -2150,1300,-1
+		icon = FUELSYSTEMS
+		cost = 60
+                title = Early Hydrolox Engines
+		description = The first hydrolox engines. Much more efficient, especially for upper stages, but much more expensive (and much more difficult to research and build). 1962.
+		anyParent = False
+                hideIfEmpty = False
+                hideIfNoBranchParts = False
+                parents = node2_generalRocketry
+                PARTS
+                {
+                }
 	}
-	@NODE[node4_advConstruction]
-	{
-		@title = Hydrolox Engines
-		@icon = GENERALROCKETRY
-		@description = Hydrolox engines suitable for mass employment; high thrust, high performance, and decent reliability. 1967.
-		@cost = 150
-		@anyParent = False
-		@parents = node3_generalConstruction, node3_advRocketry
+
+        NODE
+        {
+                name = rp0_hydroloxTL3
+                techID = hydroloxTL3
+                pos = -1800,1400,-1
+		icon = GENERALROCKETRY
+		cost = 150
+		title = Hydrolox Engines
+		description = Hydrolox engines suitable for mass employment; high thrust, high performance, and decent reliability. 1967.
+		anyParent = False
+                hideIfEmpty = False
+                hideIfNoBranchParts = False
+		parents = rp0_hydroloxTL2,node3_advRocketry
+                PARTS
+                {
+                }
 	}
+
+        NODE
+	{
+                name = rp0_hydroloxTL4
+                techID = hydroloxTL4
+                pos = -1600,1400,-1
+		icon = ADVROCKETRY
+		cost = 300
+		title = Mature Hydrolox Engines
+		description = With the maturation of hydrolox technology, performance enhances considerably and simplification allows the cost to lower. 1970.
+		anyParent = False
+                hideIfEmpty = False
+                hideIfNoBranchParts = False
+                parents = rp0_hydroloxTL3,node4_fuelSystems
+                PARTS
+                {
+                }
+	}
+
+        NODE
+	{
+                name = rp0_hydroloxTL5
+                techID = hydroloxTL5
+                pos = -1400,1400,-1
+		icon = ADVROCKETRY
+		cost = 400
+		title = Extra Mature Hydrolox Engines
+		description = Aged for twelves years in oak, these fine hydrolox engines suit even the most discerning palate.
+		anyParent = False
+                hideIfEmpty = False
+                hideIfNoBranchParts = False
+                parents = rp0_hydroloxTL4
+                PARTS
+                {
+                }
+	}
+
+        NODE
+	{
+                name = rp0_hydroloxTL6
+                techID = hydroloxTL6
+                pos = -1200,1400,-1
+		icon = ADVROCKETRY
+		cost = 500
+		title = Hydrolox TL6
+		description = Yo dawg, I heard you like hydrolox, so I put some hydrolox in your hydrolox...
+		anyParent = False
+                hideIfEmpty = False
+                hideIfNoBranchParts = False
+                parents = rp0_hydroloxTL5
+                PARTS
+                {
+                }
+	}
+
+        NODE
+	{
+                name = rp0_hydroloxTL7
+                techID = hydroloxTL7
+                pos = -1000,1400,-1
+		icon = ADVROCKETRY
+		cost = 600
+		title = What does the 'lox say?
+		description = Ring-ding-ding-ding-ding-a-hydro-lox.
+		anyParent = False
+                hideIfEmpty = False
+                hideIfNoBranchParts = False
+                parents = rp0_hydroloxTL6
+                PARTS
+                {
+                }
+	}
+
+
+        // Fuel systems is now staged combustion.
+        @NODE[node4_fuelSystems]
+        {
+                @title = Staged Combusion
+                @description = Combustion... in stages!
+                @pos = -1700, 1300, -1
+        }
+
 	@NODE[node4_electrics]
 	{
 		@description = Advanced electrical systems: longer-duration, foldable solar panels, fuel cells, and high-efficiency batteries. 1964.
@@ -92,14 +193,6 @@
 		@description = Avanced capsules that can sustain a crew for weeks at a time beyond low Earth orbit.
 		@cost = 200
 		@parents = ct_enhancedSurvivability, node3_flightControl
-	}
-	@NODE[node5_specializedConstruction]
-	{
-		@title = Mature Hydrolox Engines
-		@icon = ADVROCKETRY
-		@description = With the maturation of hydrolox technology, performance enhances considerably and simplification allows the cost to lower. 1970.
-		@cost = 300
-		@anyParent = False
 	}
 	// move, re-parent Orbital Surveys
 	@NODE[ct_orbitalSurveys]

--- a/GameData/RP-0/CTTChanges.cfg
+++ b/GameData/RP-0/CTTChanges.cfg
@@ -109,7 +109,7 @@
 		icon = ADVROCKETRY
 		cost = 300
 		title = Mature Hydrolox Engines
-		description = With the maturation of hydrolox technology, performance enhances considerably and simplification allows the cost to lower. 1970.
+		description = With the maturation of hydrolox technology, performance enhances considerably and simplification allows the cost to lower (for a given performance level). The first staged combustion engines appear. 1970.
 		anyParent = False
                 hideIfEmpty = False
                 hideIfNoBranchParts = False
@@ -126,8 +126,8 @@
                 pos = -1400,1400,-1
 		icon = ADVROCKETRY
 		cost = 400
-		title = Extra Mature Hydrolox Engines
-		description = Aged for twelves years in oak, these fine hydrolox engines suit even the most discerning palate.
+		title = Advanced Hydrolox Engines
+		description = Maturation of staged combustion allows high-efficiency hydrolox engines that for the first time offer excellent thrust at sea level. 1980.
 		anyParent = False
                 hideIfEmpty = False
                 hideIfNoBranchParts = False

--- a/GameData/RP-0/Hydrolox.cfg
+++ b/GameData/RP-0/Hydrolox.cfg
@@ -1,0 +1,37 @@
+// Sweep RO style engine configs into RP-0 hydrolox nodes.
+
+@PART[*]:HAS[@MODULE[ModuleEngineConfigs]]:FINAL
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG[*]:HAS[#techRequired[generalConstruction]]
+        {
+            %techRequired = hydroloxTL2
+        }
+
+        @CONFIG[*]:HAS[#techRequired[advConstruction]]
+        {
+            %techRequired = hydroloxTL3
+        }
+
+        @CONFIG[*]:HAS[#techRequired[specializedConstruction]]
+        {
+            %techRequired = hydroloxTL4
+        }
+
+        @CONFIG[*]:HAS[#techRequired[advMetalworks]]
+        {
+            %techRequired = hydroloxTL5
+        }
+
+        @CONFIG[*]:HAS[#techRequired[metaMaterials]]
+        {
+            %techRequired = hydroloxTL6
+        }
+
+        @CONFIG[*]:HAS[#techRequired[exoticAlloys]]
+        {
+            %techRequired = hydroloxTL7
+        }
+    }
+}

--- a/tree.yml
+++ b/tree.yml
@@ -847,8 +847,7 @@ scienceTech:
         entryCost: 10000
         cost: 1000
 
-#now this is Hydrolox TL2
-generalConstruction:
+hydroloxTL2:
 
     engineLargeSkipper: &RL10
         cost: 1800
@@ -940,12 +939,16 @@ flightControl:
         entryCost: 7000
         cost: 200
 
-#now this is Hydrolox TL3
-advConstruction:
+hydroloxTL3:
     # Skylab
     skylab-trs:
         entryCost: 50000
         cost: 3000
+
+hydroloxTL4:
+hydroloxTL5:
+hydroloxTL6:
+hydroloxTL7:
 
 advFlightControl:
     # Salyut parts


### PR DESCRIPTION
This PR adds a dedicated line of hydrolox nodes to the tech tree, from `hydroloxTL2` to `hydroloxTL7`. They fit near the top of the tree, and don't overlap with any other nodes.

Features:

- We no longer hijack the construction line, so dependencies make more sense, and there are no more weird misplaced parts.
- All Engine Configs are updated to use the new nodes through the power of ModuleManager. Regular RO players (without the CTT) are unaffected.
- `Tree.cfg` has the new nodes added.
- Tested. Oh goodness. So many hours of waiting for KSP to reload.
- New nodes have placeholder text and costs. Feel free to update these as appropriate.
- The PR branch is in the RP-0 repo, so any contributor can add to it. *Please do so* if you feel a change is required before this is merge-ready.

Closes #94.