### PR TITLE
FASA Geiger Counter now does X-rays instead.

### DIFF
--- a/GameData/RP-0/ExperimentAdder.cfg
+++ b/GameData/RP-0/ExperimentAdder.cfg
@@ -1,4 +1,4 @@
-@PART[RP0probeVanguardXray]:FOR[RP-0]
+@PART[RP0probeVanguardXray|dmUSPresTemp]:FOR[RP-0]
 {
 	MODULE
 	{

--- a/GameData/RP-0/ExperimentAdder.cfg
+++ b/GameData/RP-0/ExperimentAdder.cfg
@@ -1,4 +1,4 @@
-@PART[RP0probeVanguardXray|dmUSPresTemp]:FOR[RP-0]
+@PART[RP0probeVanguardXray|dmUSPresTemp|FASAProbeGeigerCounter]:FOR[RP-0]
 {
 	MODULE
 	{

--- a/GameData/RP-0/PartHacks.cfg
+++ b/GameData/RP-0/PartHacks.cfg
@@ -54,3 +54,23 @@
 		}
 	}
 }
+
+// The Universal Storage version of the temp/pressure sensor now
+// also has the x-ray experiment. The thermometer no longer requires
+// 200W to run.
+
+@PART[dmUSPresTemp]:AFTER[DMagic]:NEEDS[DMagic,UniversalStorage]
+{
+    @MODULE[DMEnviroSensor]:HAS[#sensorType[TEMP]]
+    {
+        @powerConsumption = 0
+    }
+
+    @title = Univ. Storage - PresMat / 2Hot / X-Ray
+    @description = Combines a barometer, temperature sensor, and X-ray detector into a single convenient container. Use with New Horizon's Universal Storage System.
+
+    // Since we integrate the x-ray experiment, add its weight to our part.
+    @mass += #$@PART[RP0probeVanguardXray]/mass$
+
+    // The experiment itself is added in ExperimentAdder.cfg
+}

--- a/GameData/RP-0/PartHacks.cfg
+++ b/GameData/RP-0/PartHacks.cfg
@@ -74,3 +74,13 @@
 
     // The experiment itself is added in ExperimentAdder.cfg
 }
+
+// The FASA Geiger Counter is no more. It now gives player the X-ray
+// experiment (added in ExperimentAdder).
+
+@PART[FASAProbeGeigerCounter]:FOR[RP-0]
+{
+    !MODULE[ModuleScienceExperiment]:HAS[#experimentID[GeigerCounter]]
+    {
+    }
+}

--- a/tree.yml
+++ b/tree.yml
@@ -453,9 +453,10 @@ basicRocketry:
     US_f_Dec_SafetyDecoupler125:
         cost: 10
 
-    # This is a barometer and thermo in a single wedge. It looks cool. :)
+    # This is a barometer, thermo and x-ray doohicky in a single wedge. It
+    # also looks cool. :)
     dmUSPresTemp:
-        cost: 30
+        cost: 50
 
     # US unlocks with fuel wedges; they're just cool looking tanks.
     # We're giving this an alias so we can have lots of wedges with the


### PR DESCRIPTION
The old Geiger Counter experiment is no more.

This means that players with FASA installed don't get a buttload more
science, but they do have a cool alternative to putting a big sphere on
their craft. :)

Includes #119, to avoid merge conflicts.