### PR TITLE
Goo standardisation

### DIFF
--- a/GameData/RP-0/PartHacks.cfg
+++ b/GameData/RP-0/PartHacks.cfg
@@ -74,3 +74,9 @@
 
     // The experiment itself is added in ExperimentAdder.cfg
 }
+
+// Goo mass standardisation. See KSP-RO/RP-0#91
+@PART[SXTProbeGooo]:FOR[RP-0]
+{
+    %mass = #$@PART[GooExperiment]/mass$
+}

--- a/tree.yml
+++ b/tree.yml
@@ -437,16 +437,14 @@ basicRocketry:
         cost: 40
 
     # Stock goo experiment
-    GooExperiment:
+    GooExperiment: &goo
         cost: 15
 
     # Goo in a can (stack mount)
-    SXTProbeGooo:
-        cost: 20
+    SXTProbeGooo: *goo
 
     # Goo as a science wedge (from DMagic Orbital Science)
-    dmUSGoo:
-        cost: 20
+    dmUSGoo: *goo
 
     # Decoupler
     stackDecoupler:


### PR DESCRIPTION
- Stack goo weighs the same as radial goo.
- Stack and wedge goo cost the same as radial goo.

Closes #91.