### PR TITLE
Fix DMagic USPresTemp description and mass.

### DIFF
--- a/GameData/RP-0/PartHacks.cfg
+++ b/GameData/RP-0/PartHacks.cfg
@@ -15,7 +15,7 @@
 // also has the x-ray experiment. The thermometer no longer requires
 // 200W to run.
 
-@PART[dmUSPresTemp]:AFTER[DMagic]:NEEDS[DMagic,UniversalStorage]
+@PART[dmUSPresTemp]:AFTER[RealismOverhaul]:NEEDS[DMagic]
 {
     @MODULE[DMEnviroSensor]:HAS[#sensorType[TEMP]]
     {
@@ -25,8 +25,8 @@
     @title = Univ. Storage - PresMat / 2Hot / X-Ray
     @description = Combines a barometer, temperature sensor, and geiger counter into a single convenient container. Use with New Horizon's Universal Storage System.
 
-    // Since we integrate the x-ray experiment, add its weight to our part.
-    @mass += #$@PART[RP0probeVanguardXray]/mass$
+    // Each of the three experiments weighs 0.001 on its own.
+    @mass = 0.003
 
     // The experiment itself is added in ExperimentAdder.cfg
 }


### PR DESCRIPTION
Fix dmUSPresTemp ("Univ. Storage - PresMat / 2Hot / X-Ray") description and mass to reflect that it now has 3 science experiments onboard.