### PR TITLE
Add a high-level RP0 group

### DIFF
--- a/GameData/RP-0/Contracts/Groups.cfg
+++ b/GameData/RP-0/Contracts/Groups.cfg
@@ -1,54 +1,60 @@
 CONTRACT_GROUP
 {
-	name = Milestones
-}
-CONTRACT_GROUP
-{
-	name = Records
-}
-CONTRACT_GROUP
-{
-	name = HumanRecords
-}
-CONTRACT_GROUP
-{
-	name = HumanContracts
-	maxSimultaneous = 2
-}
-CONTRACT_GROUP
-{
-	name = OrbitContracts
-	maxSimultaneous = 2
-}
-CONTRACT_GROUP
-{
-	name = SpecialOrbitContracts
-	maxSimultaneous = 2
-}
-CONTRACT_GROUP
-{
-	name = SCANsatContracts
-	maxSimultaneous = 2
-}
-CONTRACT_GROUP
-{
-	name = Fly-ByContracts
-	maxCompletions = 0
-}
-CONTRACT_GROUP
-{
-	name = LandingContracts
-	maxSimultaneous = 2
-}
+    name = RP0
+    minVersion = 1.5.4
 
-CONTRACT_GROUP
-{
-	name = StationContracts
-	maxCompletions = 1
-	maxSimultaneous = 1
-}
-CONTRACT_GROUP
-{
-	name = SoundingRocketContracts
-	maxSimultaneous = 2
+    CONTRACT_GROUP
+    {
+        name = Milestones
+    }
+    CONTRACT_GROUP
+    {
+        name = Records
+    }
+    CONTRACT_GROUP
+    {
+        name = HumanRecords
+    }
+    CONTRACT_GROUP
+    {
+        name = HumanContracts
+        maxSimultaneous = 2
+    }
+    CONTRACT_GROUP
+    {
+        name = OrbitContracts
+        maxSimultaneous = 2
+    }
+    CONTRACT_GROUP
+    {
+        name = SpecialOrbitContracts
+        maxSimultaneous = 2
+    }
+    CONTRACT_GROUP
+    {
+        name = SCANsatContracts
+        maxSimultaneous = 2
+    }
+    CONTRACT_GROUP
+    {
+        name = Fly-ByContracts
+        maxCompletions = 0
+    }
+    CONTRACT_GROUP
+    {
+        name = LandingContracts
+        maxSimultaneous = 2
+    }
+
+    CONTRACT_GROUP
+    {
+        name = StationContracts
+        maxCompletions = 1
+        maxSimultaneous = 1
+    }
+    CONTRACT_GROUP
+    {
+        name = SoundingRocketContracts
+        maxSimultaneous = 2
+    }
 }


### PR DESCRIPTION
Recommended for grouping in the debug menu (and a user-settings menu coming in 1.6.0).  Also allows you to put a min Contract Configurator version - use this post-release if you make a change that depends on a feature introduced in a new version of Contract Configurator, it'll save you from investigating bug reports from users that don't update the dependencies properly.