### PR TITLE
Fix bug with toggling avionics

### DIFF
--- a/Source/ModuleAvionics.cs
+++ b/Source/ModuleAvionics.cs
@@ -147,14 +147,15 @@ namespace RP0
             if (systemEnabled)
             {
                 Events["ToggleEvent"].guiName = "Activate Avionics";
-                Events["Activate"].active = true;
+                Actions["ActivateAction"].active = true;
+                Actions["ShutdownAction"].active = false;
                 systemEnabled = false;
             }
             else
             {
                 Events["ToggleEvent"].guiName = "Shutdown Avionics";
-                Events["Shutdown"].active = true;
-                Events["Activate"].active = false;
+                Actions["ShutdownAction"].active = true;
+                Actions["ActivateAction"].active = false;
                 systemEnabled = true;
             }
             UpdateRate();


### PR DESCRIPTION
The "Shutdown Avionics" event only updated the name to "Activate Avionics", and nothing else.