### PR TITLE
US Probes/RP-0 - Added Avionics/Added missing parts

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -74,7 +74,7 @@
 	MODULE
 	{
 		name = ModuleAvionics
-		massLimit = 0.05
+		massLimit = 0.1
 	}
 }
 
@@ -83,7 +83,7 @@
 	MODULE
 	{
 		name = ModuleAvionics
-		massLimit = 0.1
+		massLimit = 0.15
 	}
 }
 

--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -1,7 +1,7 @@
 // *** Non-control probe cores
 // Disable attitude control on non-control parts. FIXME Add to this patch
 // all probes which should not have independent attitude control.
-@PART[SXTSputnik|FASAExplorerProbe|RP0probeSounding0-3m]:FOR[RP-0]
+@PART[SXTSputnik|FASAExplorerProbe|RP0probeSounding0-3m|explorer_6|pioneer_0_1_2|pioneer_3_4|grab-1|tiros-1|transit2a|vanguard-1|vanguard-2|vanguard-3]:FOR[RP-0]
 {
 	MODULE
 	{
@@ -64,6 +64,107 @@
 	{
 		name = ModuleAvionics
 		massLimit = 0.0
+	}
+}
+
+// US Probes Integration Below, Probes with individual attitude control get
+// ~ 2x weight control in avionics, allows for extra attitude/propulsion
+@PART[pioneer_5]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 0.05
+	}
+}
+
+@PART[pioneer_6_7_8_9]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 0.1
+	}
+}
+
+@PART[pioneer_10_11]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 0.5
+	}
+}
+
+@PART[neo_ulysses|neo_ds1|neo_near|neo_stardust|rn_new_horizons]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 1.0
+	}
+}
+
+@PART[rn_voyager|rn_surveyor3]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 2.0
+	}
+}
+
+@PART[neo_dawn|rn_messenger|magellan]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 2.2
+	}
+}
+
+@PART[neo_deepimpact]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 3.0
+	}
+}
+
+@PART[ius_top]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 18.0
+	}
+}
+
+@PART[eos_terra]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 8.0
+	}
+}
+
+@PART[eos_aqua|eos_aura|galileo_mb]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 5.0
+	}
+}
+
+@PART[eos_tdrs]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 6.0
 	}
 }
 

--- a/tree.yml
+++ b/tree.yml
@@ -1932,7 +1932,6 @@ advFuelSystems: # TL4 solids
     FASA_RO_UA1207: &UA1207 # UA1207 7-seg SRM
         cost: 7218 # 24.36m nautix, assume 1985 dollars
         
-    
     # Ermergerd this thing is HUGE.
     # Costing source http://www.astronautix.com/stages/260lidfl.htm
     # (with thanks to @mcirish3)
@@ -2158,7 +2157,15 @@ unmannedTech:
     rn_galileo_scanner: # SCAN scanner for Galileo probe
         cost: 200
         entryCost: 2000
-
+    gdish_actual:
+        cost: 30
+        entryCost: 500
+    gdish_intended:
+        cost: 30
+        entryCost: 500
+    galileo_probe_parachute:
+        cost: 30
+        entryCost: 500
 largeControl:
     # Early Control Moment Gyroscope, see #103
     advSasModule:
@@ -2192,6 +2199,12 @@ advUnmanned:
     neo_stardust: # Stardust Probe
         cost: 1894
         entryCost: 37881
+    neo_stardust_collector:
+        cost: 30
+        entryCost: 500
+    neo_stardust_para:
+        cost: 30
+        entryCost: 500
         
 largeUnmanned:
     
@@ -2224,6 +2237,9 @@ artificialIntelligence:
     neo_deepimpact: # cost based on 333 mil project costs and probe at 1/20th
         cost: 2729
         entryCost: 54595
+    neo_deepimpact_impactor:
+        cost: 30
+        entryCost: 500
     rn_new_horizons: 
         cost: 5548
         entryCost: 110975


### PR DESCRIPTION
Forgot a few parts from the original pull request, added those.  Also removed avionics from all probes that do not come equipped with RCS, except pioneer 5, that gets some avionics lovin.  Gave IUS 2nd stage avionics, all other probes with RCS got ~ 2x their weight in avionics to allow for a bit of extra attitude/propulsion control. 

More balance may be on the way as I get a bit of a chance to experiment in game.

https://docs.google.com/spreadsheets/d/1nSpgjnR8j-CoM71H5H9RJS2xfRVuKFtgeVRqiMn419k/edit#gid=0