### PR TITLE
KVD1 engine - price

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -2282,7 +2282,9 @@ hydroloxTL4:
         entryCost: 770000
         cost: 22000
     RO_KVD1: #engine was tested in early 1970s as the RD-56, never flown as later N1 designs where cancelled
-    # look at links in comments
+        cost: 650
+        entryCost: 27750
+        
 precisionPropulsion:
     # Bobcat's Soviet Engines -Need Costing-
     # NK33 and NK43 config here, parts produced ~100 the program was scrapped and never flown

--- a/tree.yml
+++ b/tree.yml
@@ -2282,7 +2282,7 @@ hydroloxTL4:
         entryCost: 770000
         cost: 22000
     RO_KVD1: #engine was tested in early 1970s as the RD-56, never flown as later N1 designs where cancelled
-
+    # look at links in comments
 precisionPropulsion:
     # Bobcat's Soviet Engines -Need Costing-
     # NK33 and NK43 config here, parts produced ~100 the program was scrapped and never flown


### PR DESCRIPTION
http://in.rbth.com/blogs/2013/12/04/how_indias_cryogenic_programme_was_wrecked_31365

“Just then a third approach came, this time from the Soviet Union, offering two engines and technology transfer for the more reasonable price of $200 million,” writes Harvey.



https://en.m.wikipedia.org/wiki/User:Gaurav_Pruthi/KVD-1

"Later the design of the engine was sold to ISRO under the name "KVD-1" under a deal worth $120 million [8] with soviet agency Glavkosmos which enabled ISRO to import 2 KVD-1 engines and an agreement for transfer of technology from Russia."




http://isp.justthe80.com/isro-rocket-motors/isro-s-cryogenic-upper-stage-cus

"The GSLV project including the Soviet cryogenic engines was approved by the Space Commission and the GOI in October 1990. In 1991 ISRO entered into a  $120 million (Rs 750 crore) contract with Glavkosmos of Russia for the supply of two KVD-1 (RD-56) cryogenic engines and transfer the technology for their manufacture in India.

(...) India was forced to renegotiate the contract and complete development of the cryogenic engine on its own. Glavkosmos agreed to compensate India by providing four fully qualified cryo-engines and two mock ups, instead to two fully qualified cryo-engines as stipulated in the original contract. GK also consented to supply an additional three cryo-engines at a total cost of $9 million (1993)"