### PR TITLE
Ion engine - pricing

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -2560,7 +2560,7 @@ fieldScience:
         entryCost: 500
 
 ionPropulsion:
-    ionEngine: #stock ion engine
+    ionEngine: #stock ion engine - NSTAR
 
 largeElectrics:
     # Remote Tech

--- a/tree.yml
+++ b/tree.yml
@@ -2561,6 +2561,8 @@ fieldScience:
 
 ionPropulsion:
     ionEngine: #stock ion engine - NSTAR
+        cost: 380 # 20x less than development cost
+        entryCost: 7600 # 50mln (2007 USD) http://esto.nasa.gov/conferences/nstc2007/papers/Manzella_David_D10P2_NSTC-07-0116.pdf
 
 largeElectrics:
     # Remote Tech


### PR DESCRIPTION
look at page 3:
http://esto.nasa.gov/conferences/nstc2007/papers/Manzella_David_D10P2_NSTC-07-0116.pdf

"In fact more than 40mln USD in cost overruns were directly related to the ion propulsion systems xenon tank and ion thruster power sources placing the cost of the Dawn ion propulsion system at more than 50mln USD."

So 50mln USD for the xenon tank and 3 NSTAR engines? How much for one engine?