### PR TITLE
Dragon V2

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -2438,7 +2438,10 @@ giganticRocketry: #TL7, present day
     Size3EngineCluster: # SLS core (4x RS-25D/E)
         cost: 25000 # FIXME total guess based off RS-25 costs above.
     merlin1D: # StarShine Industries
+    LazTekFalcon9EngineCenter: #Merlin
     merlin1D_vac:
+    LazTekMerlin1dVacuumEngine:
+    
     liquidEngineMiniTurbo: #Blue Origin BE-4
 
 hydroloxTL7:
@@ -2842,6 +2845,26 @@ longTermHabitation:
     crewCabin:
         cost: 9000 # 2x bigger than mk2 lander can
         entryCost: 180000
+    
+    # Dragon V2
+    # development cost about 2700 mln USD http://spaceflightnow.com/news/n1405/29dragonv2/#.Vj0XBr-jAs0
+    # 2700 mln USD = 359,26 mln 1965 USD 
+    # unit cost 140mln USD per one flight (20mln per one seat) including Falcon 9 rocket (50mln) so 90mln? http://www.extremetech.com/extreme/183349-spacex-unveils-dragon-v2-the-worlds-first-commercial-manned-reusable-spaceship
+    # 90 mln USD = 11,98 mln 1965 USD 
+    LazTekDragonV2:
+        cost: 7375
+        entryCost: 227000 # about 63% of total development cost
+    LazTekDragonV2Trunk:
+        cost: 3688
+        entryCost: 113500 # about 31,5% of total development cost
+    LazTekSuperDracos:
+        cost: 125 # total guess
+    LazTekDragonV2Chute:
+        cost: 500 #2x less than Apollo chutes, total guess
+        entryCost: 17500 #2x less than Apollo chutes,  about 5% of total development cost (359260)
+    DragonLadder:
+        cost: 10
+        
 
 resourceUtilization:
 


### PR DESCRIPTION
according to new tech tree: https://camo.githubusercontent.com/7f7959e9a74bd0bd2e269a06d98a690770529d10/687474703a2f2f692e696d6775722e636f6d2f6b79746c704e502e706e67 Long term Habitation seems to be the best place for Dragon V2 parts.

development cost: about 2700mln USD  https://camo.githubusercontent.com/7f7959e9a74bd0bd2e269a06d98a690770529d10/687474703a2f2f692e696d6775722e636f6d2f6b79746c704e502e706e67

unit cost: 20 mln per seat = 140 mln including rocket. about 90 mln without rocket http://www.extremetech.com/extreme/183349-spacex-unveils-dragon-v2-the-worlds-first-commercial-manned-reusable-spaceship