### PR TITLE
Big Gemini - pricing

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -2906,15 +2906,18 @@ shortTermHabitation:
     # 1bln USD (1970) for development cost and 75mln USD (1970) for the unit cost 
     # 812mln USD (1965) for development and 59mln USD (1965) for the unit cost 
     FASAGeminiBigG: &BigG
-        cost: 31000
-        entryCost: 475000
+        cost: 21000
+        entryCost: 285000
     FASAGeminiBigGWhite: *BigG
     FASAGeminiNoseCone2Aero:
         cost: 3000
         entryCost: 52000
     FASABigGeminiRetroModule:
-        cost: 19000
+        cost: 10000
         entryCost: 75000
+    FASABigGDock: # Service Module
+        cost: 19000
+        entryCost: 190000
     FASAGeminiLES: # pricing based on Apollo LES
         cost: 5000
         entryCost: 175000

--- a/tree.yml
+++ b/tree.yml
@@ -2902,11 +2902,25 @@ shortTermHabitation:
         entryCost: 40000
         cost: 2000 #similar to mk1 lander, mk1 pod
         
-    FASAGeminiBigG:
-    FASAGeminiBigGWhite:
-    FASAGeminiLES:
+    # Gemini Big G
+    # 1bln USD (1970) for development cost and 75mln USD (1970) for the unit cost 
+    # 812mln USD (1965) for development and 59mln USD (1965) for the unit cost 
+    FASAGeminiBigG: &BigG
+        cost: 31000
+        entryCost: 475000
+    FASAGeminiBigGWhite: *BigG
     FASAGeminiNoseCone2Aero:
+        cost: 3000
+        entryCost: 52000
     FASABigGeminiRetroModule:
+        cost: 19000
+        entryCost: 75000
+    FASAGeminiLES: # pricing based on Apollo LES
+        cost: 5000
+        entryCost: 175000
+    FASA_BigGeminiParachute2:
+        cost: 1000 # based on the Apollo main parachute
+        entryCost: 35000
     
     # Salyut parts
     almaz3-5:


### PR DESCRIPTION
I found that Big Gemini development cost would be about 1,5bln USD with Titan III-M. I also found that Six-man Apollo spacecraft would cost 1bln USD (1970)  for development and 73mln USD (1970) for operatonal cost.

https://falsesteps.wordpress.com/2013/02/24/big-g-getting-to-orbit-post-apollo/ (at the bottom)

http://www.dtic.mil/dtic/tr/fulltext/u2/729770.pdf (page 42)

So I think that 1bln USD (1970) for development and 75mln USD (1970) for unit cost will be ok.