### PR TITLE
Create Lunar Landing 1 Repeat.cfg

### DIFF
--- a/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
@@ -23,12 +23,12 @@ CONTRACT_TYPE
 	maxSimultaneous = 1
 	
 	// reward block
-	// (double(@/LandDur)/43200) should give a result of 1 - 6 based on number of 12hr increments
-	advanceFunds = 50000.0 * (double(@/LandDur)/43200)
-	rewardReputation = 30.0 * (double(@/LandDur)/43200)
-	rewardFunds = 50000.0 * (double(@/LandDur)/43200)
-	failureReputation = 200.0 * (double(@/LandDur)/43200)
-	failureFunds = 75000.0 * (double(@/LandDur)/43200)
+	// (0.75+(double(@/LandDur)/172800)) should give a result of 1.00 - 2.25 based on number of 12hr increments
+	advanceFunds = 50000.0 * (0.75+(double(@/LandDur)/172800))
+	rewardReputation = 30.0 * (0.75+(double(@/LandDur)/172800))
+	rewardFunds = 50000.0 * (0.75+(double(@/LandDur)/172800))
+	failureReputation = 200.0 * (0.75+(double(@/LandDur)/172800))
+	failureFunds = 75000.0 * (0.75+(double(@/LandDur)/172800))
 	rewardReputation = 10
 	failureReputation = 10
 	

--- a/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
@@ -1,0 +1,105 @@
+// This contract resembles Apollo 11 - 17 missions
+CONTRACT_TYPE
+{
+	name = HSFLandingMoon1Repeatable
+	group = HumanContracts
+	
+	title = Human Moon Landing (1/Moon)
+	
+	description = Launch a crewed single-person spacecraft and land it on @/biome.  Explore the area for at least @/LandDur.  Then return safely to Earth.
+	
+	synopsis = Fly a single-person Lunar Landing mission.
+	
+	completedMessage = Crew alive and well after the mission--congratulations!
+
+	cancellable = true 
+	declinable = true		
+	deadline = 1460 // 1 year
+
+	prestige = Significant
+	
+	targetBody = Moon
+
+	maxSimultaneous = 1
+	
+	// reward block
+	// (double(@/LandDur)/43200) should give a result of 1 - 6 based on number of 12hr increments
+	advanceFunds = 50000.0 * (double(@/LandDur)/43200)
+	rewardReputation = 30.0 * (double(@/LandDur)/43200)
+	rewardFunds = 50000.0 * (double(@/LandDur)/43200)
+	failureReputation = 200.0 * (double(@/LandDur)/43200)
+	failureFunds = 75000.0 * (double(@/LandDur)/43200)
+	rewardReputation = 10
+	failureReputation = 10
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = first_MoonFlybyCrewed
+	}
+	REQUIREMENT
+	{
+		name = ReqLunarShields
+		type = CanResearchTech
+		tech = generalConstruction
+	}
+	DATA
+	{
+		type = Duration
+		LandDur = Round(Random(12h, 72h), 12h)
+	}
+	DATA
+	{
+		type = CelestialBody
+		cb = Moon
+	}
+	DATA
+	{
+		type = Biome
+		biome = @cb.Biomes().Random()
+	}
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Crewed Lunar Landing
+		define = lunarLandingCrewedSpacecraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+		PARAMETER
+		{
+			name = HasCrew
+			type = HasCrew
+			minCrew = 1
+		}
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Moon
+			situation = LANDED
+			biome = @/biome
+			disableOnStateChange = true
+			PARAMETER
+			{
+				name = Duration
+				type = Duration
+				duration = @/LandDur
+				preWaitText = Land on the moon.
+				waitingText = Exploring...
+				completionText = Exploration completed, you may return to Earth when ready.
+			}
+		}
+		PARAMETER
+		{
+			name = ReturnHome
+			type = ReturnHome
+			completeInSequence = true
+		}				
+	}
+}


### PR DESCRIPTION
New contract for manned landings on the moon.  I've setup this contract to randomly select a lunar biome so in addition to a time requirement, you also need to select an appropriate landing site rather than just being able to land anywhere.

NOTE: The rewards may be off.  I set them at a base 50k times the number of 12hr increments that you have to remain on the moon.  Everything looks right but on my first test the reward was significantly higher than anticipated.