### PR TITLE
Update rewards for Lunar Landing contract

### DIFF
--- a/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
@@ -23,12 +23,12 @@ CONTRACT_TYPE
 	maxSimultaneous = 1
 	
 	// reward block
-	// (double(@/LandDur)/43200) should give a result of 1 - 6 based on number of 12hr increments
-	advanceFunds = 50000.0 * (double(@/LandDur)/43200)
-	rewardReputation = 30.0 * (double(@/LandDur)/43200)
-	rewardFunds = 50000.0 * (double(@/LandDur)/43200)
-	failureReputation = 200.0 * (double(@/LandDur)/43200)
-	failureFunds = 75000.0 * (double(@/LandDur)/43200)
+	// (0.75+(double(@/LandDur)/172800)) should give a result of 1.00 - 2.25 based on number of 12hr increments
+	advanceFunds = 50000.0 * (0.75+(double(@/LandDur)/172800))
+	rewardReputation = 30.0 * (0.75+(double(@/LandDur)/172800))
+	rewardFunds = 50000.0 * (0.75+(double(@/LandDur)/172800))
+	failureReputation = 200.0 * (0.75+(double(@/LandDur)/172800))
+	failureFunds = 75000.0 * (0.75+(double(@/LandDur)/172800))
 	rewardReputation = 10
 	failureReputation = 10
 	


### PR DESCRIPTION
This change should adjust the rewards so there isn't such a huge change.  Now there is a 12.5k boost (25%) in the base reward for each additional 12hr over the minimum.