### PR TITLE
Add avionics for additional centaur tanks

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -369,6 +369,36 @@
 	}
 }
 
+// Centaur D3
+@PART[FASAGeminiLFTCentarCSM_D3]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 50.0
+	}
+}
+
+// Centaur D5
+@PART[FASAGeminiLFTCentarCSM_D5]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 55.0
+	}
+}
+
+// Centaur T
+@PART[FASAGeminiLFTCentarCSM_T]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 50.0
+	}
+}
+
 // ** Atlas
 // Atlas D / MALV
 @PART[FASA_Atlas_LFT_Cone]:FOR[RP-0]


### PR DESCRIPTION
Avionics added to the Centaur D3 as well as the new D5 and T models.