### PR TITLE
RN&Tantares R7 re-placement

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -407,6 +407,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 120.0
+		techRequired = basicAvionics
 	}
 }
 // Atlas E/F
@@ -546,6 +547,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 280.0
+		techRequired = basicAvionics
 	}
 }
 // Config for RN R-7 (Block I)

--- a/tree.yml
+++ b/tree.yml
@@ -880,24 +880,6 @@ earlyAvionics:
     # RN_Soviet_Probes
 
     sputnik1: *sputnik
-    sputnik1_base: &sputnik_n_b
-        cost: 10
-    sputnik1_nosecone: *sputnik_n_b
-   
-    sputnik3_base: *sputnik_n_b
-    sputnik3_nosecone: *sputnik_n_b
-    sputnik2_base: *sputnik_n_b
-    sputnik2_nosecone: *sputnik_n_b
-
-    # Raidernick R-7
-    WING_R7:
-        cost: 10
-
-    r7_blok_bvgd_sput: &R7Booster
-        cost: 100
-
-    r7_blok_a_sput:
-        cost: 120
 
     # AVIONICS
     # These make your rockets actually controllable.
@@ -921,12 +903,6 @@ earlyAvionics:
     FASAExplorerNosecone:
         entryCost: 7000
         cost: 250
-    #Tantares R-7
-    TLV_LFO_A:
-        cost: 50
-    TLV_LFO_B:
-        cost: 70
-    TLV_LFO_C: *R7Booster
 
 aviation: # Mature Supersonic Flight: 50s afterburning jets, ramp intakes, etc.
     aje_j57: #J57-P21
@@ -1125,11 +1101,30 @@ basicConstruction:
         
     fairingSize3:
         cost: 0.1
+
     #Tantares R-7 and Vostok tanks
+    TLV_LFO_A:
+        cost: 50
+    TLV_LFO_B:
+        cost: 70
+    TLV_LFO_C: *R7Booster
     Alto_LFO_A:
         cost: 100
-        
-    #RaiderNick - Vostok, Molniya, tanks, fairings, decouplers, adapters
+
+    #RaiderNick - R-7, Vostok, Molniya, tanks, fairings, decouplers, adapters
+    sputnik1_base: &sputnik_n_b
+        cost: 10
+    sputnik1_nosecone: *sputnik_n_b  
+    sputnik3_base: *sputnik_n_b
+    sputnik3_nosecone: *sputnik_n_b
+    sputnik2_base: *sputnik_n_b
+    sputnik2_nosecone: *sputnik_n_b
+    WING_R7:
+        cost: 10
+    r7_blok_bvgd_sput: &R7Booster
+        cost: 100
+    r7_blok_a_sput:
+        cost: 120	
     r7_adapter_blok_e: #decoupler
         cost: 100
     r7_adapter_blok_e_m:

--- a/tree.yml
+++ b/tree.yml
@@ -1102,15 +1102,6 @@ basicConstruction:
     fairingSize3:
         cost: 0.1
 
-    #Tantares R-7 and Vostok tanks
-    TLV_LFO_A:
-        cost: 50
-    TLV_LFO_B:
-        cost: 70
-    TLV_LFO_C: *R7Booster
-    Alto_LFO_A:
-        cost: 100
-
     #RaiderNick - R-7, Vostok, Molniya, tanks, fairings, decouplers, adapters
     sputnik1_base: &sputnik_n_b
         cost: 10
@@ -1152,6 +1143,15 @@ basicConstruction:
         cost: 120 # the same as for the R7-Sputnik blok a
     r7_blok_a_molniya: # Molniya
         cost: 120
+
+    #Tantares R-7 and Vostok tanks
+    TLV_LFO_A:
+        cost: 50
+    TLV_LFO_B:
+        cost: 70
+    TLV_LFO_C: *R7Booster
+    Alto_LFO_A:
+        cost: 100
 
 basicAvionics:
      # *** Avionics


### PR DESCRIPTION
Re-placed RN and Tantares R7 tanks as well as RN sputnik fairings etc to the Basic Construction node. Mercury - Atlas LV was already there so it should be ok now with the avionics restriction.