### PR TITLE
Typo Fix

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -1668,7 +1668,7 @@ generalConstruction:
     HeatShield0:
         entryCost: 31000
         cost: 500
-    HeatShield1m:
+    Heatshield1m:
         entryCost: 32000
         cost: 750
     HeatShield1: # 2m


### PR DESCRIPTION
Better to change the name here (so the part shows on the proper spot on the techtree, rather than fix the name in RO and break craft.