### PR TITLE
Added Bell Configs

### DIFF
--- a/GameData/RP-0/FASA_Engines.cfg
+++ b/GameData/RP-0/FASA_Engines.cfg
@@ -115,13 +115,13 @@
 		}
 		@CONFIG[Bell-8096]
 		{
-			techRequired = basicConstruction //  might need different unlock
+			techRequired = advRocketry //  might need tuning of the unlock
 			%cost = 250
 			%entryCost = 8200 // restarts & better ISP/thrust. estimates from percentage increase
 		}
 		@CONFIG[Bell-8096-39]
 		{
-			techRequired = basicConstruction //  might need different unlock
+			techRequired = heavyRocketry //  might need tuning of the unlock
 			%cost = 270
 			%entryCost = 8500 // restarts & better ISP/thrust. 
 		}

--- a/GameData/RP-0/FASA_Engines.cfg
+++ b/GameData/RP-0/FASA_Engines.cfg
@@ -113,6 +113,18 @@
 			%cost = 200
 			%entryCost = 8000 // restarts
 		}
+		@CONFIG[Bell-8096]
+		{
+			techRequired = basicConstruction //  might need different unlock
+			%cost = 250
+			%entryCost = 8200 // restarts & better ISP/thrust. estimates from percentage increase
+		}
+		@CONFIG[Bell-8096-39]
+		{
+			techRequired = basicConstruction //  might need different unlock
+			%cost = 270
+			%entryCost = 8500 // restarts & better ISP/thrust. 
+		}
 		@CONFIG[Bell-8247]
 		{
 			techRequired = flightControl // should require advRocketry too...


### PR DESCRIPTION
A few more configs were added in RO without changes here. Set estimated price increases, as without these changes the new configs unlock at the same price and tech as the base one.

If someone wants to research these engine configs, they might also belong at a higher tech node unlock, although they quickly become obsolete (in my opinion) as early hydrolox is shortly unlocked afterward.