### PR TITLE
Titan I tank pricing

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -1116,6 +1116,10 @@ basicConstruction:
         cost: 380
     FASAMercuryFairing:
         cost: 15
+    TitanIUpper:
+        cost: 237 # estimated based on proc+premium Atlas pays for Avionics
+    FASAGeminiLFTTitan1:
+        cost: 144 # est based on proc
         
     FASATitanLR91Dec: # Aerojet LR-91 Decoupler
         cost: 75


### PR DESCRIPTION
Titan I first stage made the same as a procedural, despite the fact that the proc (Default) is a bit lighter.

Titan I upper charged 1.5/Ton avionics (already appears set to 120) + Proc cost.