### PR TITLE
Added AsteroidDay as dependency

### DIFF
--- a/RP-0.ckan
+++ b/RP-0.ckan
@@ -17,6 +17,7 @@
         { "name" : "SXT" },
         { "name" : "ProceduralFairings" },
         { "name" : "CommunityTechTree" }
+        { "name" : "AsteroidDay" }
     ],
     "recommends" : [
         { "name" : "ProceduralDyanmics" },


### PR DESCRIPTION
The recent changes to antenna stats use that mod's antenna as *the* mariner item.