### PR TITLE
Correct node capitilization

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -3245,7 +3245,7 @@ largeControl:
     advSascr3: # AIES
         cost: 2500 # total guess
 
-advMetalWorks:
+advMetalworks:
     FASAAtlasH:
         cost: 500
 


### PR DESCRIPTION
Seems I accidentally capitalized an extra letter which results in the node not being found.  This should correct it so that the Advanced Metalworks (advMetalworks) tech node gets populated with the FASA Atlas H correctly.