### PR TITLE
Make CrewedMarsFlyby declinable

### DIFF
--- a/GameData/RP-0/Contracts/Human Spaceflight/CrewedMarsFlyby.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/CrewedMarsFlyby.cfg
@@ -15,8 +15,8 @@ CONTRACT_TYPE
 	maxExpiry = 0
 	maxCompletions = 1
 	maxSimultaneous = 1
-	cancellable = false
-	declinable = false
+	cancellable = true
+	declinable = true
 	autoAccept = false
 	prestige = Significant
 	


### PR DESCRIPTION
Not sure if it was done intentionally, but with the current contract you can't decline it or cancel it.  This corrects that, assuming it was a mistake in the first place.