### PR TITLE
Fixed "Have Part on Vessel" bug

### DIFF
--- a/GameData/RP-0/Contracts/StockContracts.cfg
+++ b/GameData/RP-0/Contracts/StockContracts.cfg
@@ -85,7 +85,9 @@
 		// ** Bio Sample
 		PART_REQUEST
 		{
-			Title = Have a biological sample on the satellite
+			Article = a
+			PartDescription = biological sample
+			VesselDescription = satellite
 			Keyword = Scientific
 			Module = ModuleTagBioSample
 			MinimumScience = 0
@@ -109,7 +111,9 @@
 		// ** Thermometer
 		PART_REQUEST
 		{
-			Title = Have a thermometer on the satellite
+			Article = a
+			PartDescription = thermometer
+			VesselDescription = satellite
 			Keyword = Scientific
 			Module = ModuleTagThermometer
 			MinimumScience = 0
@@ -132,7 +136,9 @@
 		// ** Barometer
 		PART_REQUEST
 		{
-			Title = Have a barometer on the satellite
+			Article = a
+			PartDescription = barometer
+			VesselDescription = satellite
 			Keyword = Scientific
 			Module = ModuleTagBarometer
 			MinimumScience = 0
@@ -155,7 +161,9 @@
 		// ** Orbital Perturbation
 		PART_REQUEST
 		{
-			Title = Determine orbital perturbation with the satellite
+			Article = an
+			PartDescription = orbital pertubation sensor
+			VesselDescription = satellite
 			Keyword = Scientific
 			Module = ModuleTagPerturbation
 			MinimumScience = 0
@@ -178,7 +186,9 @@
 		// ** Geiger counter
 		PART_REQUEST
 		{
-			Title = Have a Geiger-Muller tube on the satellite
+			Article = a
+			PartDescription = gieger counter
+			VesselDescription = satellite
 			Keyword = Scientific
 			Module = ModuleTagGeiger
 			MinimumScience = 0
@@ -201,7 +211,9 @@
 		// ** Film Return
 		PART_REQUEST
 		{
-			Title = Have a film-return camera on the satellite
+			Article = a
+			PartDescription = film return camera
+			VesselDescription = satellite
 			Keyword = Scientific // FIXME military?
 			Module = ModuleTagFilmReturn
 			MinimumScience = 0
@@ -225,7 +237,9 @@
 		// *** Parts
 		PART_REQUEST
 		{
-			Title = Use a standard satellite bus
+			Article = a
+			PartDescription = probe core cube
+			VesselDescription = satellite
 			Keyword = Commercial
 			Part = probeCoreCube
 			Trivial


### PR DESCRIPTION
I changed the "Title" section under PART_REQUEST to "Article/PartDescription/VesselDescription" which is the new syntax for 1.0.5. This should fix the bug that had contracts asking for "Part on Vessel." This is my first edit, so I hope I didn't screw up :)