### PR TITLE
Add HS-333 avionics

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -238,7 +238,7 @@
 }
 
 // Generic satellite bus
-@PART[probeCoreCube|novapod|UAEcubplate|torpod|sondex2pod|explonpod|mk2DroneCore|B9_Cockpit_D25|B9_Cockpit_MK1_Control_ACU|FASAICBMProbe]:FOR[RP-0]
+@PART[probeCoreCube|novapod|UAEcubplate|torpod|sondex2pod|neptuno|explonpod|mk2DroneCore|B9_Cockpit_D25|B9_Cockpit_MK1_Control_ACU|FASAICBMProbe]:FOR[RP-0]
 {
 	MODULE
 	{


### PR DESCRIPTION
Was missing from the generic probe core list.