### PR TITLE
probeCoreCube - cost revision

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -3750,7 +3750,7 @@ specializedElectrics:
 
 advUnmanned:
     probeCoreCube: # modern satellite bus
-        cost: 15000 #FIXME
+        cost: 1000 #FIXME
     
     #US Probes Integration
     neo_ds1: # Deep space 1


### PR DESCRIPTION
Not sure why it was more expensive than even Apollo CM. Now 15x cheaper - similar to AIES satelite buses