### PR TITLE
RO H-1/RS-27 P&P

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -2265,6 +2265,11 @@ heavyRocketry: #TL3 Mid-late 60s tech. F-1, H-1 uprated, etc.
         cost: 60 #total guess, 3x bigger than Atlas verniers (5kN)
         entryCost: 3000
 
+    # H-1/RS-27 engine (clone of RO LR79).
+    RO-H1-RS27: &H-1
+        cost: 700
+        entryCost: 33750
+
     FASAApolloLFEF1: &F-1
         entryCost: 409361
         cost: 15000 # Source for the $20m figure???? For now reducing to 15mil


### PR DESCRIPTION
* Place and price the RO copy of H-1. Cost values taken from the "entryCostModifiers" of this engine but i do not know if this is the correct thing to do.