### PR TITLE
Add exp to Manned Landing contract

### DIFF
--- a/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
@@ -118,4 +118,11 @@ CONTRACT_TYPE
 			completeInSequence = true
 		}				
 	}
+	BEHAVIOUR
+	{
+		name = AwardExperience
+		type = AwardExperience
+		parameter = vesselGroup
+		experience = 1
+	}
 }

--- a/GameData/RP-0/Contracts/Human Spaceflight/MarsLanding.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/MarsLanding.cfg
@@ -117,4 +117,11 @@ CONTRACT_TYPE
 			completeInSequence = true
 		}				
 	}
+	BEHAVIOUR
+	{
+		name = AwardExperience
+		type = AwardExperience
+		parameter = vesselGroup
+		experience = 1
+	}
 }


### PR DESCRIPTION
Since RO severely restricts the experience Kerbals can get (mainly because manned missions beyond Earth SOI are extremely difficult) this should grant 1 exp to each Kerbal that lands on the Moon.  The experience gain is repeatable so if Jeb makes 10 landings, he'll earn an exp for each contract.