### PR TITLE
Gemini Big G

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -2744,6 +2744,15 @@ commandModules: # Third generation capsules, it would seem.
     FASA_BigGeminiParachute2:
         cost: 1000 # based on the Apollo main parachute
         entryCost: 35000
+    FASAGeminiBigGDock:
+        entryCost: 90000
+        cost: 9000
+    FASAGeminiBigGDec:
+        entryCost: 3000
+        cost: 150
+    FASAGeminiBigGDockExt:
+        entryCost: 7000 # based on the Apollo docking device
+        cost: 2000
 
 spaceExploration: #crewed landing
     landerCabinSmall:


### PR DESCRIPTION
Place and price the "Big G" service module, docking ring and decoupler.
There is a part listed as "FASABigGDock" which I am guessing is the "FASAGeminiBigGDock".  I didn't remove "FASABigGDock" in case I'm mistaken but I did use the cost and entry cost for FASAGeminiBigGDock.
Pricing for the docking ring is based on the price for the Apollo docking device.
Pricing for the decoupler is based on Saturn SLA.