### PR TITLE
Print altitude in kilometers without decimal places

### DIFF
--- a/GameData/RP-0/Contracts/Sounding Rocket Contracts/SoundingLow.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rocket Contracts/SoundingLow.cfg
@@ -33,8 +33,8 @@ CONTRACT_TYPE
 	weight = 10.0
 	DATA
 	{
-		type = double
-		altLow = @/VesselGroup/ReachAlt/minAltitude * 0.001
+		type = int
+		altLow = @/VesselGroup/ReachAlt/minAltitude / 1000
 	}
 	
 	REQUIREMENT


### PR DESCRIPTION
Changed altLow to int and used integer division