### PR TITLE
Station contract fix

### DIFF
--- a/GameData/RP-0/Contracts/Human Spaceflight/Station Crew Rotation.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Station Crew Rotation.cfg
@@ -61,7 +61,6 @@ CONTRACT_TYPE
 			name = Rendezvous
 			type = Rendezvous
 			vessel = spaceStation
-			vessel = crewCapsule
 			distance = 1000
 		}
 	}

--- a/GameData/RP-0/Contracts/Milestones/Station.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Station.cfg
@@ -135,7 +135,6 @@ CONTRACT_TYPE
 			name = Rendezvous
 			type = Rendezvous
 			vessel = spaceStation
-			vessel = crewCapsule
 			distance = 1000
 		}
 	}


### PR DESCRIPTION
According to the Contract Configuration documentation:
If this Rendezvous parameter is a child of a VesselParameterGroup parameter, then no more than *one* vessel should be provided (the other is the vessel being tracked under the VesselParameterGroup). If no vessel attributes are provided, the second vessel will match any vessel.

Since "Rendezvous" is a PARAMETER of "VesselParameterGroup", then the second "vessel" value is not needed and appears to be disabling the contract.