### PR TITLE
P&P Early Soyuz SM, Voskhod chute: Tantares

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -1543,6 +1543,7 @@ enhancedSurvivability: # Early capsules
         entryCost: 1000
         cost: 100
     Almach_Parachute_A: *VostokParachute
+    Almach_Parachute_B: *VostokParachute
     
     moduldesspod: # 1-person descent module
         cost: 1800 # same as for Vostok
@@ -2094,7 +2095,7 @@ electrics:
         cost: 600
 
     # Soyuz parts
-    tg_sa:
+    tg_sa: &soyuzsm1
         entryCost: 70000
         cost: 2000
     s1_lsolar: &SalyutSolar
@@ -2107,6 +2108,9 @@ electrics:
     7k_ok_rsolar: *SoyuzSolar
     rn_7k_astp_lsolar:
     rn_7k_astp_rsolar:
+    
+    Tantares_Engine_A: *soyuzsm1
+    
     # Apollo parts
     FASAApollo_SM_Dish:
         entryCost: 35000


### PR DESCRIPTION
Voskhod chute for Tantares is identical to Vostok. So, same price and place.

We already have P&P for RN's soyuz SM, so I tagged 7 cloned that to the Tantares one.