### PR TITLE
Update SCANsat contracts

### DIFF
--- a/GameData/RP-0/Contracts/SCANSat.cfg
+++ b/GameData/RP-0/Contracts/SCANSat.cfg
@@ -77,3 +77,11 @@
 		@diffModifier2 = Prestige() == Trivial ? 0 : Prestige() == Significant ? 10 : 20
 	}
 }
+
+!CONTRACT_TYPE[SCAN_M700]:FOR[RP-0]
+{
+}
+
+!CONTRACT_TYPE[SCAN_NarrowBand]:FOR[RP-0]
+{
+}


### PR DESCRIPTION
Remove the M700 and NarrowBand scanner contracts which don't currently work since we don't yet have RO/RP-0 parts.