### PR TITLE
Centaur Avionics

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -376,6 +376,16 @@
 		techRequired = flightControl
 	}
 }
+// Centaur D-1T
+@PART[FASAGeminiLFTCentarCSM_D1T]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 40.0
+		techRequired = flightControl
+	}
+}
 // Centaur D2
 @PART[FASAGeminiLFTCentarCSM_D2]:FOR[RP-0]
 {
@@ -388,17 +398,6 @@
 }
 
 // Centaur D3
-@PART[FASAGeminiLFTCentarCSM_D3]:FOR[RP-0]
-{
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 300.0
-		techRequired = avionicsTL7
-	}
-}
-
-// Centaur D5
 @PART[FASAGeminiLFTCentarCSM_D5]:FOR[RP-0]
 {
 	MODULE


### PR DESCRIPTION
In RO Github 1126 I'm proposing adding a FASAGeminiLFTCentarCSM_D1T (a thermal insulated version of FASAGeminiLFTCentar used on Titan 3E) and removing FASAGeminiLFTCentarCSM_D3 since Atlas IIIB didn't use it's own version of Centaur.  I'm therefore adding avionics for the first, and removing the 2nd.