### PR TITLE
Place new Centaur tank

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -1603,6 +1603,8 @@ advRocketry:
 hydroloxTL2:
     FASAGeminiLFTCentar: # Centaur A/B/C/D/D1 stage
         cost: 1201 # no cited research cost tho
+    FASAGeminiLFTCentarCSM_D1T: # Centaur D-1T stage
+        cost: 1301 # included a slight increase from the standard Centaur to account for the extra insulation
    
     engineLargeSkipper: &RL10
         cost: 1300 # lowered based off Centaur costs on Titan IIIE via http://www.astronautix.com/articles/costhing.htm
@@ -4114,7 +4116,6 @@ exoticAlloys:
         entryCost: 5000
 
 orbitalAssembly:
-    FASAGeminiLFTCentarCSM_D3: # Centaur D3 for Atlas III
     FASAGeminiLFTCentarCSM_D5: # Centaur D5 for Atlas V
 
 advAerospaceComposites:


### PR DESCRIPTION
In RO Github 1126 I'm proposing adding FASAGeminiLFTCentarCSM_D1T to represent the insulated Centaur D-1T used on Titan 3E.  Witht he exception of the added thermal insulation, it is basically identical to the standard FASAGeminiLFTCentar so I put it in the same node and added a slight increase in cost to account for the extra insulation.

In the same Github I'm suggesting removing FASAGeminiLFTCentarCSM_D3 since Atlas IIIB did not use it's own version of the Centaur.  I've therefore removed it's entry from the tree.