### PR TITLE
Match RO-stock & FASA LR-105 entry costs

### DIFF
--- a/GameData/RP-0/EntryCostModifiers.cfg
+++ b/GameData/RP-0/EntryCostModifiers.cfg
@@ -112,7 +112,6 @@ ENTRYCOSTMODS
 	PART
 	{
 		name = liquidEngine
-		maxSubtraction = 5000
 		entryCostMultipliers
 		{
 			FASAMercuryAtlasEng = 0

--- a/GameData/RP-0/EntryCostModifiers.cfg
+++ b/GameData/RP-0/EntryCostModifiers.cfg
@@ -81,6 +81,7 @@ ENTRYCOSTMODS
 		entryCostSubtractors
 		{
 			liquidEngine1-2 = 12000
+			FASADeltaMB3LFE = 12000
 		}
 	}
 	PART
@@ -93,6 +94,7 @@ ENTRYCOSTMODS
 		entryCostSubtractors
 		{
 			liquidEngine1-2 = 12000
+			FASADeltaMB3LFE = 12000
 		}
 	}
 	
@@ -101,6 +103,24 @@ ENTRYCOSTMODS
 	{
 		name = liquidEngine1-2
 		maxSubtraction = 12000
+		entryCostMultipliers
+		{
+			FASADeltaMB3LFE = 0
+		}
+		entryCostSubtractors
+		{
+			RO-LR-89 = 12000
+			FASAMercuryAtlasEngBooster = 12000
+		}
+	}
+	PART
+	{
+		name = FASADeltaMB3LFE
+		maxSubtraction = 12000
+		entryCostMultipliers
+		{
+			liquidEngine1-2 = 0
+		}
 		entryCostSubtractors
 		{
 			RO-LR-89 = 12000
@@ -121,6 +141,7 @@ ENTRYCOSTMODS
 			RO-LR-89 = 4000
 			FASAMercuryAtlasEngBooster = 4000
 			liquidEngine1-2 = 1000
+			FASADeltaMB3LFE = 1000
 		}
 	}
 	PART
@@ -135,6 +156,7 @@ ENTRYCOSTMODS
 			RO-LR-89 = 4000
 			FASAMercuryAtlasEngBooster = 4000
 			liquidEngine1-2 = 1000
+			FASADeltaMB3LFE = 1000
 		}
 	}
 	


### PR DESCRIPTION
Long explanation for this. I am studying the related unlock costs of the LR89, LR79, and LR105 engines.

The smallest issue I noticed was this one; that one LR105 had a maxEntryCost and the other didn't. The initial LR105 entry cost is 11k if neither of the other two are unlocked. When the LR89 is bought (EntryCost paid) the FASA version of the 105 drops to a 3k entry price, while the RO was at 6k. After also unlocking the LR79, FASA 105 drops to 2k, while the RO version stays the same. Removing this line aligns them.

An aside. For future planning, should/could these unlock prices be linked to the global engine config, rather than to the part name? That may not be useful, as we may be phasing out the RO clone parts in 1.1 as we can just use a good model (ie. Raidernick ones) as the default. However, this idea may still be useful as it still may make it easier to expand support for other mods that include their own versions of engines we already have configured. In theory, using the Global Engine Config tag to prompt a script to set entry prices for all parts with that tag would save a lot of configing. Ideas? @SirKeplan @NathanKell