### PR TITLE
Lunar Landing-Repeat

### DIFF
--- a/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
@@ -107,12 +107,6 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = ReachState
-			type = ReachState
-			
-		}
-		PARAMETER
-		{
 			name = ReturnHome
 			type = ReturnHome
 			completeInSequence = true


### PR DESCRIPTION
I'm not sure if it was left in place intentionally or not but the 4th parameter is resulting in the current contract being un-finishable.  Basically it seems to be requiring that the vehicle permanently retain a destination of the Moon, which you can't do while also returning home.  Since there is already a "ReachState" setup in parameter 3 which requires you land on the Moon at a specific Biome and remain landed for a specific amount of time, I don't think there's a need for the 4th parameter at all.  So now the parameters would just be:
1) Launch a new vehicle
2) Have at least 1 crew on the vehicle
3) Land on the Moon with at least one crew, in the specified biome and for the specified duration
4) Safely return home.