### PR TITLE
Tweak first launch

### DIFF
--- a/GameData/RP-0/Contracts/Milestones/FirstLaunch.cfg
+++ b/GameData/RP-0/Contracts/Milestones/FirstLaunch.cfg
@@ -39,5 +39,6 @@ CONTRACT_TYPE
         name = ReachStateFlying
         type = ReachState
         situation = FLYING
+        minRateOfClimb = 1
     }
 }


### PR DESCRIPTION
Changes first launch contract to require the vessel to be moving upward at 1 m/s at some point. I originally set it to 0.1, but that showed as 0.0 in-game.