### PR TITLE
SSTU Tech Tree Size Limits

### DIFF
--- a/GameData/RP-0/SSTU_TechLimits.cfg
+++ b/GameData/RP-0/SSTU_TechLimits.cfg
@@ -1,0 +1,39 @@
+@TECHLIMITSET[Default]
+{
+	!TECHLIMIT,* {}
+	TECHLIMIT
+	{
+		name = start
+		diameter = 2.0
+	}
+	TECHLIMIT
+	{
+		name = engineering101
+		diameter = 3.0
+	}
+	TECHLIMIT
+	{
+		name = basicConstruction
+		diameter = 6.625
+	}
+	TECHLIMIT
+	{
+		name = generalConstruction
+		diameter = 7.0
+	}
+	TECHLIMIT
+	{
+		name = advConstruction
+		diameter = 10
+	}
+	TECHLIMIT
+	{
+		name = specializedConstruction
+		diameter = 16
+	}
+	TECHLIMIT
+	{
+		name = advMetalworks
+		diameter = 50
+	}	
+}


### PR DESCRIPTION
this patch is intended to set the max size for procedural or semi-procedural SSTU parts, like tanks, decouplers, fairings, interstages, it matches the ProceduralParts patches, using the very same node (NOTE: the values need to be a multiple of 0.125, as this is the default scaling for SSTU parts)

this patch is needed so these parts can actually work with RP-0 tech tree, as I said before, I copied the nodes from the Procedural Parts one, but if you want to set them on another node, feel free to change these

also, a new tech tree can be created, but I decided to replace the default SSTU one just so all parts using it would be affected, instead of going after each individual part and change, so if anyone wants to make a tech tree for tanks, one for fairings, one for decouplers, etc... all you need to do is copy this one, label a new name on it, and change the line "techLimitSet = Default" to match the tech tree you want for that part

keep in mind though that the payload fairing bases are NOT needed to be patched if Procedural Fairings is present, as SSTU has a patch file that turns them from default-style fairing bases to PF-style fairing bases, pretty much like PFE does, all other fairings (like those under tanks and service modules) on the other hand does need a techlimit, again this only applies to the payload fairing base