### PR TITLE
Adjusted all contract deadlines to use Earth days

### DIFF
--- a/GameData/RP-0/Contracts/Fly-by Contracts/DeimosFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/DeimosFlyByContract.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	targetBody = Deimos
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 	prestige = Significant
 	
 	// rewards

--- a/GameData/RP-0/Contracts/Fly-by Contracts/JupiterFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/JupiterFlyByContract.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	targetBody = Jupiter
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 7300 // 5 years
+	deadline = 1825 // 5 years
 	prestige = Exceptional
 	
 	// rewards

--- a/GameData/RP-0/Contracts/Fly-by Contracts/MarsFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/MarsFlyByContract.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	targetBody = Mars
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 	prestige = Significant
 	
 	// rewards

--- a/GameData/RP-0/Contracts/Fly-by Contracts/MercuryFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/MercuryFlyByContract.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	targetBody = Mercury
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 5840 // 4 years
+	deadline = 1460 // 4 years
 	prestige = Exceptional
 	
 	// rewards

--- a/GameData/RP-0/Contracts/Fly-by Contracts/NeptuneFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/NeptuneFlyByContract.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	targetBody = Neptune
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 21900 // 15 years
+	deadline = 5475 // 15 years
 	prestige = Exceptional
 	
 	// rewards

--- a/GameData/RP-0/Contracts/Fly-by Contracts/PhobosFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/PhobosFlyByContract.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	targetBody = Phobos
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 	prestige = Significant
 	
 	// rewards

--- a/GameData/RP-0/Contracts/Fly-by Contracts/PlutoFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/PlutoFlyByContract.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	targetBody = Pluto
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 19650 // 15 years
+	deadline = 5475 // 15 years
 	prestige = Exceptional
 	
 	// rewards

--- a/GameData/RP-0/Contracts/Fly-by Contracts/SaturnFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/SaturnFlyByContract.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	targetBody = Saturn
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 14600 // 10 years
+	deadline = 3650 // 10 years
 	prestige = Exceptional
 	
 	// rewards

--- a/GameData/RP-0/Contracts/Fly-by Contracts/UranusFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/UranusFlyByContract.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	targetBody = Uranus
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 21900 // 15 years
+	deadline = 5475 // 15 years
 	prestige = Exceptional
 	
 	// rewards

--- a/GameData/RP-0/Contracts/Fly-by Contracts/VenusFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/VenusFlyByContract.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	targetBody = Venus
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 	prestige = Significant
 	
 	// rewards

--- a/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Lunar Landing 1 Repeat.cfg
@@ -14,7 +14,7 @@ CONTRACT_TYPE
 
 	cancellable = true 
 	declinable = true		
-	deadline = 1460 // 1 year
+	deadline = 365 // 1 year
 
 	prestige = Significant
 	

--- a/GameData/RP-0/Contracts/Human Spaceflight/Lunar Orbital 1 Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Lunar Orbital 1 Repeat.cfg
@@ -15,7 +15,7 @@ CONTRACT_TYPE
 
 	cancellable = true 
 	declinable = true		
-	deadline = 1460 // 1 year
+	deadline = 365 // 1 year
 
 	prestige = Significant
 	

--- a/GameData/RP-0/Contracts/Human Spaceflight/Lunar Orbital Gen Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Lunar Orbital Gen Repeat.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 
 	cancellable = true 
 	declinable = true		
-	deadline = 1460 // 1 year
+	deadline = 365 // 1 year
 
 	prestige = Significant
 	

--- a/GameData/RP-0/Contracts/Human Spaceflight/MarsLanding.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/MarsLanding.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 
 	cancellable = true 
 	declinable = true		
-	deadline = 17520 // 12 years - lots of time for preparations
+	deadline = 4380 // 12 years - lots of time for preparations
 
 	prestige = Exceptional
 	

--- a/GameData/RP-0/Contracts/Human Spaceflight/Orbital 1 Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Orbital 1 Repeat.cfg
@@ -14,7 +14,7 @@ CONTRACT_TYPE
 	
 	cancellable = true
 	declinable = true
-	deadline = 720 // 6 months *4
+	deadline = 180 // 6 months
 	
 	prestige = Trivial
 	

--- a/GameData/RP-0/Contracts/Human Spaceflight/Orbital 2 Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Orbital 2 Repeat.cfg
@@ -14,7 +14,7 @@ CONTRACT_TYPE
 	
 	cancellable = true
 	declinable = true
-	deadline = 720 // 6 months *4
+	deadline = 180 // 6 months
 	
 	prestige = Trivial
 	

--- a/GameData/RP-0/Contracts/Human Spaceflight/Orbital 3 Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Orbital 3 Repeat.cfg
@@ -14,7 +14,7 @@ CONTRACT_TYPE
 	
 	cancellable = true
 	declinable = true
-	deadline = 720 // 6 months *4
+	deadline = 180 // 6 months
 	
 	prestige = Trivial
 	

--- a/GameData/RP-0/Contracts/Human Spaceflight/Station Crew Rotation.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Station Crew Rotation.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 
 	cancellable = true 
 	declinable = true		
-	deadline = 720 // 180 days
+	deadline = 180
 
 	prestige = Significant
 	

--- a/GameData/RP-0/Contracts/Human Spaceflight/Station Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Station Repeat.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 
 	cancellable = true 
 	declinable = true		
-	deadline = 1460 // 1 year
+	deadline = 365 // 1 year
 
 	prestige = Significant
 	

--- a/GameData/RP-0/Contracts/Human Spaceflight/Subortal Repeat.cfg
+++ b/GameData/RP-0/Contracts/Human Spaceflight/Subortal Repeat.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	
 	minExpiry = 1.0
 	maxExpiry = 30.0
-	deadline = 360 // Kerbin days are 6h so x4
+	deadline = 90
 	cancellable = true
 	declinable = true
 	autoAccept = false

--- a/GameData/RP-0/Contracts/Landing Contracts/CallistoLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/CallistoLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Callisto
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 13140 // 9 years - enough to use gravity assists
+	deadline = 3285 // 9 years - enough to use gravity assists
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/DeimosLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/DeimosLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Deimos
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/EnceladusLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/EnceladusLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Enceladus
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 14600 // 10 years - enough to use gravity assists
+	deadline = 3650 // 10 years - enough to use gravity assists
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/EuropaLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/EuropaLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Europa
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 13140 // 9 years - enough to use gravity assists
+	deadline = 3285 // 9 years - enough to use gravity assists
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/GanymedeLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/GanymedeLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Ganymede
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 13140 // 9 years - enough to use gravity assists
+	deadline = 3285 // 9 years - enough to use gravity assists
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/IoLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/IoLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Io
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 13140 // 9 years - enough to use gravity assists
+	deadline = 3285 // 9 years - enough to use gravity assists
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/MarsLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/MarsLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Mars
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/MercuryLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/MercuryLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Mercury
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 13140 // 9 years - enough to use gravity assists
+	deadline = 3285 // 9 years - enough to use gravity assists
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/MimasLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/MimasLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Mimas
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 14600 // 10 years - enough to use gravity assists
+	deadline = 3650 // 10 years - enough to use gravity assists
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/MoonLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/MoonLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Moon
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 	prestige = Significant
 	
 	rewardReputation = 50.0

--- a/GameData/RP-0/Contracts/Landing Contracts/PhobosLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/PhobosLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Phobos
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/TitanLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/TitanLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Titan
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 14600 // 10 years - enough to use gravity assists
+	deadline = 3650 // 10 years - enough to use gravity assists
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/TritonLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/TritonLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Triton
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 26280 // 18 years
+	deadline = 6570 // 18 years
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Landing Contracts/VenusLandingContract.cfg
+++ b/GameData/RP-0/Contracts/Landing Contracts/VenusLandingContract.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	targetBody = Venus
 	maxCompletions = 1
 	maxSimultaneous = 1
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 	prestige = Exceptional
 	
 	rewardReputation = 100.0

--- a/GameData/RP-0/Contracts/Milestones/Docking.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Docking.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	
 	agent = Federation Aeronautique Internationale
 	
-	deadline = 1460 // 1 year
+	deadline = 365 // 1 year
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1

--- a/GameData/RP-0/Contracts/Milestones/EVA.cfg
+++ b/GameData/RP-0/Contracts/Milestones/EVA.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	
 	agent = Federation Aeronautique Internationale
 	
-	deadline = 1460 // 1 year
+	deadline = 365 // 1 year
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1

--- a/GameData/RP-0/Contracts/Milestones/FirstCrewedSupersonic.cfg
+++ b/GameData/RP-0/Contracts/Milestones/FirstCrewedSupersonic.cfg
@@ -15,7 +15,7 @@ CONTRACT_TYPE
 	maxExpiry = 0
     maxCompletions = 1
     maxSimultaneous = 1
-	deadline = 4384 // Kerbin days are 6h so x4
+	deadline = 1095 // 3 years
 	cancellable = false
 	autoAccept = false
 	

--- a/GameData/RP-0/Contracts/Milestones/GEO.cfg
+++ b/GameData/RP-0/Contracts/Milestones/GEO.cfg
@@ -11,7 +11,7 @@ CONTRACT_TYPE
 	
 	completedMessage = Congratulations! Ground tracking confirms a period of approximately 23 hours, 59 minutes, and 4.1 seconds.
 	
-	deadline = 2920 // Kerbin days are 6h so x4
+	deadline = 730 // 2 years
 	minExpiry = 1
 	maxExpiry = 30
 	maxSimultaneous = 1

--- a/GameData/RP-0/Contracts/Milestones/HumanMarsFlyby.cfg
+++ b/GameData/RP-0/Contracts/Milestones/HumanMarsFlyby.cfg
@@ -10,7 +10,7 @@ CONTRACT_TYPE
 	synopsis = Send a human being into martian space and return safely.
 	
 	completedMessage = Crew alive and well after the mission--congratulations! The interviews will go on for months!
-	deadline = 7300 // 5 years
+	deadline = 1825 // 5 years
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1

--- a/GameData/RP-0/Contracts/Milestones/HumanMoonFlyby.cfg
+++ b/GameData/RP-0/Contracts/Milestones/HumanMoonFlyby.cfg
@@ -11,7 +11,7 @@ CONTRACT_TYPE
 	
 	completedMessage = Crew alive and well after the mission--congratulations! The interviews will go on for months!
 
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1

--- a/GameData/RP-0/Contracts/Milestones/HumanMoonLanding.cfg
+++ b/GameData/RP-0/Contracts/Milestones/HumanMoonLanding.cfg
@@ -20,7 +20,7 @@ CONTRACT_TYPE
 	autoAccept = false
 	prestige = Exceptional
 	
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 	
 	targetBody = Moon
 	

--- a/GameData/RP-0/Contracts/Milestones/HumanOrbit.cfg
+++ b/GameData/RP-0/Contracts/Milestones/HumanOrbit.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	
 	agent = Federation Aeronautique Internationale
 	
-	deadline = 4384 // Kerbin days are 6h so x4
+	deadline = 1095 // 3 years
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1

--- a/GameData/RP-0/Contracts/Milestones/HumanVenusFlyby.cfg
+++ b/GameData/RP-0/Contracts/Milestones/HumanVenusFlyby.cfg
@@ -10,7 +10,7 @@ CONTRACT_TYPE
 	synopsis = Send a human being into cytherean space and return safely.
 	
 	completedMessage = Crew alive and well after the mission--congratulations! The interviews will go on for months!
-	deadline = 7300 // 5 years
+	deadline = 1825 // 5 years
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1

--- a/GameData/RP-0/Contracts/Milestones/KarmanLineCrewed.cfg
+++ b/GameData/RP-0/Contracts/Milestones/KarmanLineCrewed.cfg
@@ -15,7 +15,7 @@ CONTRACT_TYPE
 	
     targetBody = HomeWorld()
 	
-    deadline = 4384 // Kerbin days are 6h so x4
+    deadline = 1095 // 3 years
 	minExpiry = 0
 	maxExpiry = 0
     maxCompletions = 1

--- a/GameData/RP-0/Contracts/Milestones/MoonFlyBy.cfg
+++ b/GameData/RP-0/Contracts/Milestones/MoonFlyBy.cfg
@@ -15,7 +15,7 @@ CONTRACT_TYPE
 	maxExpiry = 7
 	maxCompletions = 2 // We'll pay this much for only the first two flybies
 	maxSimultaneous = 1
-	deadline = 1460 // Kerbin days are 6h so x4
+	deadline = 365 // 1 year
 	cancellable = true // should it be false? Dunno.
 	declinable = true
 	autoAccept = false

--- a/GameData/RP-0/Contracts/Milestones/MoonImpact.cfg
+++ b/GameData/RP-0/Contracts/Milestones/MoonImpact.cfg
@@ -15,7 +15,7 @@ CONTRACT_TYPE
 	maxExpiry = 7
 	maxCompletions = 3 // Up to three impacts
 	maxSimultaneous = 1
-	deadline = 1460 // Kerbin days are 6h so x4
+	deadline = 365 // 1 year
 	cancellable = true // should it be false? Dunno.
 	declinable = true
 	autoAccept = false

--- a/GameData/RP-0/Contracts/Milestones/MoonOrbit.cfg
+++ b/GameData/RP-0/Contracts/Milestones/MoonOrbit.cfg
@@ -15,7 +15,7 @@ CONTRACT_TYPE
 	maxExpiry = 7
 	maxCompletions = 2 // a few is ok
 	maxSimultaneous = 1
-	deadline = 1460 // Kerbin days are 6h so x4
+	deadline = 365 // 1 year
 	cancellable = true // should it be false? Dunno.
 	declinable = true
 	autoAccept = false

--- a/GameData/RP-0/Contracts/Milestones/Reentry.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Reentry.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	maxExpiry = 7
 	maxCompletions = 3 // so it's not a fluke
 	maxSimultaneous = 1
-	deadline = 1460 // Kerbin days are 6h so x4
+	deadline = 365 // 1 year
 	cancellable = true
 	declinable = true
 	autoAccept = false

--- a/GameData/RP-0/Contracts/Milestones/Satellite.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Satellite.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	
 	agent = Federation Aeronautique Internationale
     
-	deadline = 2920 // Kerbin days are 6h so x4
+	deadline = 730 // 2 years
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1

--- a/GameData/RP-0/Contracts/Milestones/Station.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Station.cfg
@@ -19,7 +19,7 @@ CONTRACT_TYPE
 	declinable = false
 	autoAccept = false
 	
-	deadline = 2920 // 2 years
+	deadline = 730 // 2 years
 
 	prestige = Significant
 	

--- a/GameData/RP-0/Contracts/SCANSat.cfg
+++ b/GameData/RP-0/Contracts/SCANSat.cfg
@@ -7,7 +7,7 @@
 {
 	%maxSimultaneous = 5
 	
-	@deadline = 1460 * @/targetBody1.Multiplier() // 1 year * mult
+	@deadline = 365 * @/targetBody1.Multiplier() // 1 year * mult
 	
 	@advanceFunds = Random(1000, 3000.0) + 5000.0 * @/targetBody1.Multiplier()
 	@rewardFunds = @advanceFunds
@@ -32,7 +32,7 @@
 {
 	%maxSimultaneous = 5
 	
-	@deadline = 1460 * @/targetBody3.Multiplier() // 1 year * mult
+	@deadline = 365 * @/targetBody3.Multiplier() // 1 year * mult
 	
 	@advanceFunds = Random(5000, 10000.0) + 10000.0 * @/targetBody3.Multiplier()
 	@rewardFunds = @advanceFunds
@@ -57,7 +57,7 @@
 {
 	%maxSimultaneous = 5
 	
-	@deadline = 1460 * @/targetBody2.Multiplier() // 1 year * mult
+	@deadline = 365 * @/targetBody2.Multiplier() // 1 year * mult
 	
 	@advanceFunds = Random(5000, 10000.0) + 10000.0 * @/targetBody2.Multiplier()
 	@rewardFunds = @advanceFunds

--- a/GameData/RP-0/Contracts/Sounding Rocket Contracts/SoundingHigh.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rocket Contracts/SoundingHigh.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	
 	minExpiry = 1.0
 	maxExpiry = 30.0
-	deadline = 360 // Kerbin days are 6h so x4
+	deadline = 90
 	cancellable = true
 	declinable = true
 	autoAccept = false

--- a/GameData/RP-0/Contracts/Sounding Rocket Contracts/SoundingLow.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rocket Contracts/SoundingLow.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	
 	minExpiry = 1.0
 	maxExpiry = 30.0
-	deadline = 360 // Kerbin days are 6h so x4
+	deadline = 90
 	cancellable = true
 	declinable = true
 	autoAccept = false

--- a/GameData/RP-0/Contracts/Sounding Rocket Contracts/SoundingMed.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rocket Contracts/SoundingMed.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	
 	minExpiry = 1.0
 	maxExpiry = 30.0
-	deadline = 360 // Kerbin days are 6h so x4
+	deadline = 90
 	cancellable = true
 	declinable = true
 	autoAccept = false

--- a/GameData/RP-0/Contracts/StockContracts.cfg
+++ b/GameData/RP-0/Contracts/StockContracts.cfg
@@ -318,7 +318,7 @@
 		{
 			@MinimumExpireDays = 1
 			@MaximumExpireDays = 7
-			@DeadlineDays = 1460 // really, it should depend on how far away the target is...90 days is enough for Earth space, but 20 years for out-system... Note, Kerbal days, so this is 1 year.
+			@DeadlineDays = 365 // really, it should depend on how far away the target is...90 days is enough for Earth space, but 20 years for out-system... 
 		}
 		@Funds
 		{

--- a/GameData/RP-0/Contracts/X-Planes/CrewedFlight.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedFlight.cfg
@@ -15,7 +15,7 @@ CONTRACT_TYPE
 
 	minExpiry = 1.0
 	maxExpiry = 30.0
-	deadline = 360 // Kerbin days are 6h so x4
+	deadline = 90
 	cancellable = true
 	declinable = true
 	autoAccept = false

--- a/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmo.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmo.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	
 	minExpiry = 1.0
 	maxExpiry = 30.0
-	deadline = 360 // Kerbin days are 6h so x4
+	deadline = 90
 	cancellable = true
 	declinable = true
 	autoAccept = false

--- a/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoLate.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoLate.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 	
 	minExpiry = 1.0
 	maxExpiry = 30.0
-	deadline = 360 // Kerbin days are 6h so x4
+	deadline = 90
 	cancellable = true
 	declinable = true
 	autoAccept = false

--- a/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
@@ -13,7 +13,7 @@ CONTRACT_TYPE
 
 	minExpiry = 1.0
 	maxExpiry = 30.0
-	deadline = 360 // Kerbin days are 6h so x4
+	deadline = 90
 	cancellable = true
 	declinable = true
 	autoAccept = false


### PR DESCRIPTION
Deadlines appear to now be passed directly from CC to KSP and KSP appears to properly use Earth days when in Earth mode, so adjusted all contract deadlines to be in Earth days.

Earth.