### PR TITLE
SSTU Tanks and procedural decouplers

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -1458,6 +1458,10 @@ survivability: # 3-Axis Stability and early probes ##
     Heatshield-5M:
         entryCost: 30000
         cost: 1700
+    
+    #SSTU Procedural Heat Shield
+    SSTU-SC-GEN-MHS:
+        cost: 0
 
     # Heatshield decoupler
     decoupler_ftr_small:

--- a/tree.yml
+++ b/tree.yml
@@ -3594,7 +3594,7 @@ avionicsTL7:
 avionicsTL7:
     ParaDockingPort: # Let's assume it's NDS
         cost: 3500 # somewhat higher than for Apollo docking port
-    dockingPort2: &NASADockingSystem
+    dockingPort2: &NASADockingDevice
         cost: 3500
     dockingPortLateral: # same, lateral shielded.
         cost: 4000
@@ -3607,7 +3607,7 @@ avionicsTL7:
     FASADeltaAv4:
         cost: 1200
         entryCost: 30000
-    SSTU-SC-GEN-DP-1P: *NASADockingSystem
+    SSTU-SC-GEN-DP-1P: *NASADockingDevice
 
 #FIXME HERE BE DRAGONS (below this point)
 advExploration:

--- a/tree.yml
+++ b/tree.yml
@@ -151,7 +151,9 @@ start: #TL-1 early tech. Sounding rockets, basic structural pieces and wings. La
     SSTU-SC-TANK-MFT-B:
         cost: 100
     SSTU-SC-GEN-PDC: #still 5 times more expensive than PP decoupler
+        cost: 0
     SSTU-SC-GEN-RBDC:
+        cost: 0
 
     # Nose Cones
 

--- a/tree.yml
+++ b/tree.yml
@@ -154,6 +154,10 @@ start: #TL-1 early tech. Sounding rockets, basic structural pieces and wings. La
         cost: 0
     SSTU-SC-GEN-RBDC:
         cost: 0
+    SSTU-SC-GEN-FR-N:
+       cost: 0
+    SSTU-SC-GEN-FR-W:
+       cost: 0
 
     # Nose Cones
 
@@ -896,22 +900,28 @@ engineering101:
     tankMER6:
     tank1300cl:
     
-    #SSTU (tanks)
+    #SSTU tanks
     SSTU-SC-TANK-MFT-D:
         entryCost: 1000
         cost: 100
-    SSTU-SC-TANK-MFT-R:
-        entryCost: 300 #small radial modular tank
-        cost: 50 #designed for smaller size = should be aligned for smaller volume with PP
+    SSTU-SC-TANK-MFT-R: #small radial tank
+        entryCost: 300
+        cost: 50 
     SSTU-SC-TANK-MFT-L: #Lander tanks
         entryCost: 500
-        cost: 75 #Ballon tanks, designed for smaller volumes
-    SSTU-SC-TANK-MUS-CB:
+        cost: 75
+    SSTU-SC-TANK-MUS-CB: #less structures
         entryCost: 800
-        cost: 90 #less structures
-    SSTU-SC-TANK-MUS-ST:
+        cost: 90 
+    SSTU-SC-TANK-MUS-ST: #less structures
         entryCost: 800
-        cost: 90 #less structures
+        cost: 90 
+    SSTU-SC-GEN-IPA-N:
+        cost: 0
+    SSTU-SC-GEN-IPA-W:
+        cost: 0
+    SSTU-SC-GEN-ISDC:
+        cost: 0
         
     #AIES decouplers - they have similar sizes, about 1,25 - 2,5m
     decoupvector:
@@ -2743,6 +2753,8 @@ advFlightControl:
     FASALM_RCS: &ApolloLMRCS
         entryCost: 10500
         cost: 300
+    #SSTU Apollo Docking 
+    SSTU-SC-GEN-DP-0P: *ApolloDockingDevice
 
     # Avionics
     GuidanceLate1m: # Later 1m guidance
@@ -3579,9 +3591,10 @@ exoticFuelStorage: #TL7 solids
         cost: 2500 # based on the costs above
 
 avionicsTL7:
+avionicsTL7:
     ParaDockingPort: # Let's assume it's NDS
         cost: 3500 # somewhat higher than for Apollo docking port
-    dockingPort2: # NASA Docking System
+    dockingPort2: &NASADockingSystem
         cost: 3500
     dockingPortLateral: # same, lateral shielded.
         cost: 4000
@@ -3594,6 +3607,7 @@ avionicsTL7:
     FASADeltaAv4:
         cost: 1200
         entryCost: 30000
+    SSTU-SC-GEN-DP-1P: *NASADockingSystem
 
 #FIXME HERE BE DRAGONS (below this point)
 advExploration:

--- a/tree.yml
+++ b/tree.yml
@@ -144,6 +144,14 @@ start: #TL-1 early tech. Sounding rockets, basic structural pieces and wings. La
         cost: 0.1
     proceduralStackDecoupler:
         cost: 0.1
+        
+    #SSTU Procedural stuff
+	SSTU-SC-TANK-MFT-A: #not excalty the same curve as PP, but roughly accurate for medium sized tanks (using the "4" tank model)
+		cost: 100
+	SSTU-SC-TANK-MFT-B:
+		cost: 100
+	SSTU-SC-GEN-PDC: #still 5 times more expensive than PP decoupler
+	SSTU-SC-GEN-RBDC:
 
     # Nose Cones
 
@@ -886,6 +894,23 @@ engineering101:
     tankMER6:
     tank1300cl:
     
+    #SSTU tanks
+	SSTU-SC-TANK-MFT-D:
+		entryCost: 1000
+		cost: 100
+	SSTU-SC-TANK-MFT-R:
+		entryCost: 300 #small radial modular tank
+		cost: 50 #designed for smaller size = should be aligned for smaller volume with PP
+	SSTU-SC-TANK-MFT-L: #Lander tanks
+		entryCost: 500
+		cost: 75 #Ballon tanks, designed for smaller volumes
+	SSTU-SC-TANK-MUS-CB:
+		entryCost: 800
+		cost: 90 #less structures
+	SSTU-SC-TANK-MUS-ST:
+		entryCost: 800
+		cost: 90 #less structures
+		
     #AIES decouplers - they have similar sizes, about 1,25 - 2,5m
     decoupvector:
     decouplersv05:

--- a/tree.yml
+++ b/tree.yml
@@ -910,7 +910,7 @@ engineering101:
     SSTU-SC-TANK-MUS-ST:
         entryCost: 800
         cost: 90 #less structures
-		
+        
     #AIES decouplers - they have similar sizes, about 1,25 - 2,5m
     decoupvector:
     decouplersv05:

--- a/tree.yml
+++ b/tree.yml
@@ -146,12 +146,12 @@ start: #TL-1 early tech. Sounding rockets, basic structural pieces and wings. La
         cost: 0.1
         
     #SSTU Procedural stuff
-	SSTU-SC-TANK-MFT-A: #not excalty the same curve as PP, but roughly accurate for medium sized tanks (using the "4" tank model)
-		cost: 100
-	SSTU-SC-TANK-MFT-B:
-		cost: 100
-	SSTU-SC-GEN-PDC: #still 5 times more expensive than PP decoupler
-	SSTU-SC-GEN-RBDC:
+    SSTU-SC-TANK-MFT-A: #not excalty the same curve as PP, but roughly accurate for medium sized tanks (around 20*5m)
+        cost: 100
+    SSTU-SC-TANK-MFT-B:
+        cost: 100
+    SSTU-SC-GEN-PDC: #still 5 times more expensive than PP decoupler
+    SSTU-SC-GEN-RBDC:
 
     # Nose Cones
 
@@ -894,22 +894,22 @@ engineering101:
     tankMER6:
     tank1300cl:
     
-    #SSTU tanks
-	SSTU-SC-TANK-MFT-D:
-		entryCost: 1000
-		cost: 100
-	SSTU-SC-TANK-MFT-R:
-		entryCost: 300 #small radial modular tank
-		cost: 50 #designed for smaller size = should be aligned for smaller volume with PP
-	SSTU-SC-TANK-MFT-L: #Lander tanks
-		entryCost: 500
-		cost: 75 #Ballon tanks, designed for smaller volumes
-	SSTU-SC-TANK-MUS-CB:
-		entryCost: 800
-		cost: 90 #less structures
-	SSTU-SC-TANK-MUS-ST:
-		entryCost: 800
-		cost: 90 #less structures
+    #SSTU (tanks)
+    SSTU-SC-TANK-MFT-D:
+        entryCost: 1000
+        cost: 100
+    SSTU-SC-TANK-MFT-R:
+        entryCost: 300 #small radial modular tank
+        cost: 50 #designed for smaller size = should be aligned for smaller volume with PP
+    SSTU-SC-TANK-MFT-L: #Lander tanks
+        entryCost: 500
+        cost: 75 #Ballon tanks, designed for smaller volumes
+    SSTU-SC-TANK-MUS-CB:
+        entryCost: 800
+        cost: 90 #less structures
+    SSTU-SC-TANK-MUS-ST:
+        entryCost: 800
+        cost: 90 #less structures
 		
     #AIES decouplers - they have similar sizes, about 1,25 - 2,5m
     decoupvector:


### PR DESCRIPTION
The tanks pricing should be fine with medium-sized tanks (aligned with PP); indeed, SSTU does not use the same pricing system and a flat and wide tanks will be less expensive than a long and thin one, for the same volume.

Decouplers are just here not to appear in the "non-RP0" section; I do not have a way to change their price (radial one is less expensive, stack one is more expensive).