### PR TITLE
moving FRE viking engine back

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -1210,13 +1210,6 @@ generalRocketry: # TL1 Late 1950s/1960 tech, first real orbital LVs. Atlas, R-7,
     TLV_Engine_A: *RD107
     Alto_Engine_A: *VostokUpper
     Alto_Engine_B: *R7Vernier
-    
-    FREVIKINGEARLY: #Viking 2/2B
-        cost: 550 #Ariane 1-1 first stage: $14.5M
-        entryCost: 15000 #was too high compared to other engines (gameplay feedback)
-    FREVIKINGUPPER: #Viking 4/4B
-        cost: 1000
-        entryCost: 20000
         
     # RD-107 & RD-108 From SSTU
     SSTU-SC-ENG-RD-108A: *RD108
@@ -1815,10 +1808,13 @@ advRocketry:
     #RaiderNick - Soyuz
     rn_r7_vernier_blok_i_s_fg:
         cost: 20 # 6kN
-    
-    FREVIKINGLOWER: #Viking 5C/6
-        cost: 380 #$10M for Ariane 4L stage, 4 engines
-        entryCost: 35000
+
+    FREVIKINGEARLY: #Viking 2/2B
+        cost: 550 #Ariane 1-1 first stage: $14.5M
+        entryCost: 15000 #was too high compared to other engines (gameplay feedback)
+    FREVIKINGUPPER: #Viking 4/4B
+        cost: 1000
+        entryCost: 20000
         
      # SSTU
     SSTU-SC-ENG-RD-0110: *RD-0110
@@ -2556,6 +2552,10 @@ heavyRocketry: #TL3 Mid-late 60s tech. F-1, H-1 uprated, etc.
     SSTU-SC-ENG-AJ10-137: *ApolloSPS
     SSTU-SC-ENG-F1: *F-1
     SSTU-AJ10-CustomAdvanced: *AJ10adv
+    
+    FREVIKINGLOWER: #Viking 5C/6
+    cost: 380 #$10M for Ariane 4L stage, 4 engines
+    entryCost: 35000
 
 hydroloxTL3:
 

--- a/tree.yml
+++ b/tree.yml
@@ -2554,8 +2554,8 @@ heavyRocketry: #TL3 Mid-late 60s tech. F-1, H-1 uprated, etc.
     SSTU-AJ10-CustomAdvanced: *AJ10adv
     
     FREVIKINGLOWER: #Viking 5C/6
-    cost: 380 #$10M for Ariane 4L stage, 4 engines
-    entryCost: 35000
+        cost: 380 #$10M for Ariane 4L stage, 4 engines
+        entryCost: 35000
 
 hydroloxTL3:
 


### PR DESCRIPTION
As said on the Reddit page, one node back for each engine. The next FRE update will fix engine configs pricing/placing conflicts (requested by @NathanKell )
it conflicts now, I probably left a tab somewhere.