### PR TITLE
Flyby Contracts for the gas giant moons

### DIFF
--- a/GameData/RP-0/Contracts/Fly-by Contracts/CallistoFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/CallistoFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Callisto Flyby
-	description = Design and successfully launch a probe on a flyby of Callisto with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Callisto with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Callisto closer than 20000km and transmit science.
+	synopsis = Fly by Callisto closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 95.0
 	rewardFunds = 48000.0
 	failureFunds = 70000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{
@@ -55,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Callisto
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Fly-by Contracts/CallistoFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/CallistoFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyCallisto
+	
+	group = Fly-ByContracts
+	
+	title = Callisto Flyby
+	description = Design and successfully launch a probe on a flyby of Callisto with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Callisto closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Callisto
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 1825 // 5 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 48000.0
+	rewardReputation = 95.0
+	rewardFunds = 48000.0
+	failureFunds = 70000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybyJupiter
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Callisto and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Callisto
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Callisto
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/DioneFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/DioneFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyDione
+	
+	group = Fly-ByContracts
+	
+	title = Dione Flyby
+	description = Design and successfully launch a probe on a flyby of Dione with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Dione closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Dione
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 3650 // 10 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 55000.0
+	rewardReputation = 105.0
+	rewardFunds = 55000.0
+	failureFunds = 80000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybySaturn
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Dione and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Dione
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Dione
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/DioneFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/DioneFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Dione Flyby
-	description = Design and successfully launch a probe on a flyby of Dione with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Dione with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Dione closer than 20000km and transmit science.
+	synopsis = Fly by Dione closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 105.0
 	rewardFunds = 55000.0
 	failureFunds = 80000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{
@@ -55,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Dione
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Fly-by Contracts/EnceladusFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/EnceladusFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Enceladus Flyby
-	description = Design and successfully launch a probe on a flyby of Enceladus with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Enceladus with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Enceladus closer than 20000km and transmit science.
+	synopsis = Fly by Enceladus closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 105.0
 	rewardFunds = 55000.0
 	failureFunds = 80000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{

--- a/GameData/RP-0/Contracts/Fly-by Contracts/EnceladusFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/EnceladusFlyByContract.cfg
@@ -53,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Enceladus
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Fly-by Contracts/EnceladusFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/EnceladusFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyEnceladus
+	
+	group = Fly-ByContracts
+	
+	title = Enceladus Flyby
+	description = Design and successfully launch a probe on a flyby of Enceladus with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Enceladus closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Enceladus
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 3650 // 10 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 55000.0
+	rewardReputation = 105.0
+	rewardFunds = 55000.0
+	failureFunds = 80000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybySaturn
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Enceladus and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Enceladus
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Enceladus
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/EuropaFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/EuropaFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Europa Flyby
-	description = Design and successfully launch a probe on a flyby of Europa with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Europa with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Europa closer than 20000km and transmit science.
+	synopsis = Fly by Europa closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 95.0
 	rewardFunds = 48000.0
 	failureFunds = 70000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{
@@ -55,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Europa
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Fly-by Contracts/EuropaFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/EuropaFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyEuropa
+	
+	group = Fly-ByContracts
+	
+	title = Europa Flyby
+	description = Design and successfully launch a probe on a flyby of Europa with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Europa closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Europa
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 1825 // 5 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 48000.0
+	rewardReputation = 95.0
+	rewardFunds = 48000.0
+	failureFunds = 70000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybyJupiter
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Europa and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Europa
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Europa
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/GanymedeFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/GanymedeFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Ganymede Flyby
-	description = Design and successfully launch a probe on a flyby of Ganymede with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Ganymede with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Ganymede closer than 20000km and transmit science.
+	synopsis = Fly by Ganymede closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 95.0
 	rewardFunds = 48000.0
 	failureFunds = 70000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{
@@ -55,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Ganymede
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Fly-by Contracts/GanymedeFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/GanymedeFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyGanymede
+	
+	group = Fly-ByContracts
+	
+	title = Ganymede Flyby
+	description = Design and successfully launch a probe on a flyby of Ganymede with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Ganymede closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Ganymede
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 1825 // 5 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 48000.0
+	rewardReputation = 95.0
+	rewardFunds = 48000.0
+	failureFunds = 70000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybyJupiter
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Ganymede and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Ganymede
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Ganymede
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/IapetusFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/IapetusFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyIapetus
+	
+	group = Fly-ByContracts
+	
+	title = Iapetus Flyby
+	description = Design and successfully launch a probe on a flyby of Iapetus with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Iapetus closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Iapetus
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 3650 // 10 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 55000.0
+	rewardReputation = 105.0
+	rewardFunds = 55000.0
+	failureFunds = 80000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybySaturn
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Iapetus and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Iapetus
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Iapetus
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/IapetusFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/IapetusFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Iapetus Flyby
-	description = Design and successfully launch a probe on a flyby of Iapetus with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Iapetus with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Iapetus closer than 20000km and transmit science.
+	synopsis = Fly by Iapetus closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 105.0
 	rewardFunds = 55000.0
 	failureFunds = 80000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{
@@ -55,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Iapetus
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Fly-by Contracts/IoFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/IoFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyIo
+	
+	group = Fly-ByContracts
+	
+	title = Io Flyby
+	description = Design and successfully launch a probe on a flyby of Io with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Io closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Io
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 1825 // 5 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 48000.0
+	rewardReputation = 95.0
+	rewardFunds = 48000.0
+	failureFunds = 70000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybyJupiter
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Io and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Io
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Io
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/IoFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/IoFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Io Flyby
-	description = Design and successfully launch a probe on a flyby of Io with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Io with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Io closer than 20000km and transmit science.
+	synopsis = Fly by Io closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 95.0
 	rewardFunds = 48000.0
 	failureFunds = 70000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{
@@ -55,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Io
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Fly-by Contracts/MimasFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/MimasFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyMimas
+	
+	group = Fly-ByContracts
+	
+	title = Mimas Flyby
+	description = Design and successfully launch a probe on a flyby of Mimas with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Mimas closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Mimas
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 3650 // 10 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 55000.0
+	rewardReputation = 105.0
+	rewardFunds = 55000.0
+	failureFunds = 80000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybySaturn
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Mimas and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Mimas
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Mimas
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/MimasFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/MimasFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Mimas Flyby
-	description = Design and successfully launch a probe on a flyby of Mimas with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Mimas with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Mimas closer than 20000km and transmit science.
+	synopsis = Fly by Mimas closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 105.0
 	rewardFunds = 55000.0
 	failureFunds = 80000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{
@@ -55,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Mimas
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Fly-by Contracts/RheaFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/RheaFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Rhea Flyby
-	description = Design and successfully launch a probe on a flyby of Rhea with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Rhea with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Rhea closer than 20000km and transmit science.
+	synopsis = Fly by Rhea closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 105.0
 	rewardFunds = 55000.0
 	failureFunds = 80000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{
@@ -55,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Rhea
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Fly-by Contracts/RheaFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/RheaFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyRhea
+	
+	group = Fly-ByContracts
+	
+	title = Rhea Flyby
+	description = Design and successfully launch a probe on a flyby of Rhea with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Rhea closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Rhea
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 3650 // 10 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 55000.0
+	rewardReputation = 105.0
+	rewardFunds = 55000.0
+	failureFunds = 80000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybySaturn
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Rhea and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Rhea
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Rhea
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/TethysFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/TethysFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Tethys Flyby
-	description = Design and successfully launch a probe on a flyby of Tethys with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Tethys with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Tethys closer than 20000km and transmit science.
+	synopsis = Fly by Tethys closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 105.0
 	rewardFunds = 55000.0
 	failureFunds = 80000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{
@@ -55,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Tethys
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Fly-by Contracts/TethysFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/TethysFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyTethys
+	
+	group = Fly-ByContracts
+	
+	title = Tethys Flyby
+	description = Design and successfully launch a probe on a flyby of Tethys with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Tethys closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Tethys
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 3650 // 10 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 55000.0
+	rewardReputation = 105.0
+	rewardFunds = 55000.0
+	failureFunds = 80000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybySaturn
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Tethys and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Tethys
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Tethys
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/TitanFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/TitanFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyTitan
+	
+	group = Fly-ByContracts
+	
+	title = Titan Flyby
+	description = Design and successfully launch a probe on a flyby of Titan with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Titan closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Titan
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 3650 // 10 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 55000.0
+	rewardReputation = 105.0
+	rewardFunds = 55000.0
+	failureFunds = 80000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybySaturn
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Titan and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Titan
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Titan
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/TitanFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/TitanFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Titan Flyby
-	description = Design and successfully launch a probe on a flyby of Titan with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Titan with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Titan closer than 20000km and transmit science.
+	synopsis = Fly by Titan closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 105.0
 	rewardFunds = 55000.0
 	failureFunds = 80000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{
@@ -55,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Titan
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Fly-by Contracts/TritonFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/TritonFlyByContract.cfg
@@ -1,0 +1,74 @@
+CONTRACT_TYPE
+{
+	name = flybyTriton
+	
+	group = Fly-ByContracts
+	
+	title = Triton Flyby
+	description = Design and successfully launch a probe on a flyby of Triton with a closest approach of 20000km or closer, then record observations and transmit.
+	
+	synopsis = Fly by Triton closer than 20000km and transmit science.
+	
+	completedMessage = Congratulations on the flyby! The data are coming in now.
+	
+	minExpiry = 1
+	maxExpiry = 30
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	targetBody = Triton
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 3650 // 10 years
+	prestige = Significant
+	
+	// rewards
+	advanceFunds = 65000.0
+	rewardReputation = 105.0
+	rewardFunds = 65000.0
+	failureFunds = 90000.0
+	
+	weight = 10.0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybyNeptune
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = Perform a flyby of Triton and receive data.
+		define = venusFlybyCraft
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+		}
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			targetBody = Triton
+			maxAltitude = 20000000
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = CollectScience
+			type = CollectScience
+			targetBody = Triton
+			recoveryMethod = RecoverOrTransmit
+		}
+	}
+}
+
+
+
+
+

--- a/GameData/RP-0/Contracts/Fly-by Contracts/TritonFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/TritonFlyByContract.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Fly-ByContracts
 	
 	title = Triton Flyby
-	description = Design and successfully launch a probe on a flyby of Triton with a closest approach of 20000km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Triton with a closest approach of 2000km or closer, then record observations and transmit.
 	
-	synopsis = Fly by Triton closer than 20000km and transmit science.
+	synopsis = Fly by Triton closer than 2000km and transmit science.
 	
 	completedMessage = Congratulations on the flyby! The data are coming in now.
 	
@@ -27,8 +27,6 @@ CONTRACT_TYPE
 	rewardReputation = 105.0
 	rewardFunds = 65000.0
 	failureFunds = 90000.0
-	
-	weight = 10.0
 	
 	REQUIREMENT
 	{
@@ -55,7 +53,7 @@ CONTRACT_TYPE
 			name = ReachState
 			type = ReachState
 			targetBody = Triton
-			maxAltitude = 20000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
 		}
 		PARAMETER


### PR DESCRIPTION
Creates Fly-by contracts for the gas giant moons. 
- Rewards (loosely) based on the difference between Mars and Phobos fly-bys
- Minimum distance kept the same 20Mm, given all flyby missions (except the moon) have this
- Deadline is the same as the one for parent body flyby
- Requirement is parent body flyby
