### PR TITLE
SSTU MUS Tanks

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -675,3 +675,60 @@
 		massLimit = 150.0	// Just a guess but since the TRS was supposed to reposition Skylab, I figured it should be set high
 	}
 }
+@PART[SSTU-SC-TANK-MUS-*]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 5.0
+		TechRequired = earlyAvionics
+	}
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 5.0	// should add up to 10t
+		techRequired = basicAvionics
+	}
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 10.0	// should add up to 20
+		techRequired = stability
+	}
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 20.0	// should add up to 40t
+		techRequired = flightControl
+	}
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 60.0	// should add up to 100t
+		techRequired = advFlightControl
+	}
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 150.0	// should add up to 250t
+		techRequired = specializedControl
+	}
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 250.0	// should add up to 500t
+		techRequired = avionicsTL5
+	}
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 250.0	// should add up to 750t
+		techRequired = avionicsTL6
+	}
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 250.0	// should add up to 1000t
+		techRequired = avionicsTL7
+	}
+}


### PR DESCRIPTION
Right now, if you use one of the SSTU MUS tanks, you have unlimited avionics control.  Difficulty is, these tanks are procedural so the larger the tank, the more avionics you'd need for it.  What I've done here isn't pretty since the parts will now display 9 separate avionics modules, but in VAB/SPH and in flight, they do combine correctly.  So if, for example,  you have Flight Control, the MUS tanks can handle up to 40t for avionics purposes.  This doesn't have anything to do with the actual size of the part you create, but it does allow these tanks to function better throughout the course of a career game.  If there is a cleaner way to setup something like this, that would be a better option, but this at least works.