### PR TITLE
Reduce cost of H-1 family (issue #490)

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -1863,7 +1863,7 @@ advRocketry:
 
     # Saturn I/IB H-1 engine.
     FASAApolloLFEH1: &H1
-        cost: 1050
+        cost: 750
         entryCost: 53750 # 33750 + 20,000 from LR79
     KW2mengineMaverickV: *H1
     RO-H1-RS27: *H1


### PR DESCRIPTION
Price 750, comparable to the cheapest LR79 (S-3D) configs, since it's
largely a simplification of that engine.  H-1B pushes up to 1050 to pay
for additional reliability / man-rating, then RS-27 are cheaper again
(at 800, 825) because they're mature tech and are the inexpensive option.

No actual sources for these numbers.