### PR TITLE
Update the RP-0 part categorizer

### DIFF
--- a/GameData/RP-0/NonRP0.cfg
+++ b/GameData/RP-0/NonRP0.cfg
@@ -1,117 +1,78 @@
 //  ==================================================
-//  Remove the RP-0 tag from parts that are not placed
-//  correctly in the tech tree.
+//  RP-0 generic stuff.
+
+//  *   Move the parts to the appropriate categories if FilterExtensions is installed.
+//  *   Hide all parts that are not compatible with RP-0 (either WIP or NON).
+//  *   Tag all WIP or NON RP-0 parts appropriately.
 //  ==================================================
 
-@PART[*]:HAS[#TechRequired[ORPHANS]]:FINAL
+@PART[*]:HAS[~RP0conf[],#RSSROConfig[*rue]]:FOR[zzzRP-0]
 {
-    !RP0conf = DEL
-}
-
-//  ==================================================
-//  Remove WIP and NON RP-0 parts from the rest and
-//  place them to their own categories.
-//  ==================================================
-
-@PART[*]:HAS[#RP0conf[false]]:NEEDS[FilterExtensions,!NoNonRP0]:FINAL
-{
-    %category = 10
-}
-
-@PART[*]:HAS[~RP0conf[]]:NEEDS[FilterExtensions,!NoNonRP0]:FINAL
-{
-    %category = 11
-}
-
-//  ==================================================
-//  Part title changes. Now includes NoNonRP0 checks
-//  ==================================================
-
-@PART[*]:HAS[~RP0conf[],#RSSROConfig[true]]:FINAL
-{
+	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
+	@category:NEEDS[FilterExtensions,!NoNonRP0] = 99
+	@category:NEEDS[!FilterExtensions,NoNonRP0] = -1
 	@title ^=:^:non RP-0 - :
 	@description ^=:$: (PART NOT SUPPORTED BY RP-0):
-	@category:NEEDS[NoNonRP0] = -1
-	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
 }
-@PART[*]:HAS[~RP0conf[],#RSSROConfig[True]]:FINAL
+
+@PART[*]:HAS[~RP0conf[],~RSSROConfig[]]:FOR[zzzRP-0]
 {
-	@title ^=:^:non RP-0 - :
-	@description ^=:$: (PART NOT SUPPORTED BY RP-0):
-	@category:NEEDS[NoNonRP0] = -1
 	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
-}
-@PART[*]:HAS[~RP0conf[],~RSSROConfig[]]:FINAL
-{
+	@category:NEEDS[FilterExtensions,!NoNonRP0] = 97
+	@category:NEEDS[!FilterExtensions,NoNonRP0] = -1
 	@title ^=:non RO:non RP-0:
 	@description ^=:BY RO:BY RP-0 OR RO:
-	@category:NEEDS[NoNonRP0] = -1
-	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
-}
-@PART[*]:HAS[~RP0conf[],#RSSROConfig[false]]:FINAL
-{
-	@title ^=:WIP RO:non RP-0:
-	@description ^=:PART IN PROGRESS, MAY NOT WORK:PART NOT SUPPORTED BY RP-0, RO IN PROGRESS:
-	@category:NEEDS[NoNonRP0] = -1
-	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
-}
-@PART[*]:HAS[~RP0conf[],#RSSROConfig[False]]:FINAL
-{
-	@title ^=:WIP RO:non RP-0:
-	@description ^=:PART IN PROGRESS, MAY NOT WORK:PART NOT SUPPORTED BY RP-0, RO IN PROGRESS:
-	@category:NEEDS[NoNonRP0] = -1
-	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
 }
 
-@PART[*]:HAS[#RP0conf[false],#RSSROConfig[true]]:FINAL
+@PART[*]:HAS[~RP0conf[],#RSSROConfig[*alse]]:FOR[zzzRP-0]
 {
+	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
+	@category:NEEDS[FilterExtensions,!NoNonRP0] = 96
+	@category:NEEDS[!FilterExtensions,NoNonRP0] = -1
+	@title ^=:WIP RO:non RP-0:
+	@description ^=:PART IN PROGRESS, MAY NOT WORK:PART NOT SUPPORTED BY RP-0, RO IN PROGRESS:
+}
+
+@PART[*]:HAS[#RP0conf[*alse],#RSSROConfig[*rue]]:FOR[zzzRP-0]
+{
+	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
+	@category:NEEDS[FilterExtensions,!NoNonRP0] = 98
+	@category:NEEDS[!FilterExtensions,NoNonRP0] = -1
 	@title ^=:^:RP-0 nocost - :
 	@description ^=:$: (PART NOT COSTED BY RP-0 BUT IN CORRECT NODE):
-	@category:NEEDS[NoNonRP0] = -1
-	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
 }
-@PART[*]:HAS[#RP0conf[false],#RSSROConfig[True]]:FINAL
+
+@PART[*]:HAS[#RP0conf[*alse],#RSSROConfig[*alse]]:FOR[zzzRP-0]
 {
-	@title ^=:^:RP-0 nocost - :
-	@description ^=:$: (PART NOT COSTED BY RP-0 BUT IN CORRECT NODE):
-	@category:NEEDS[NoNonRP0] = -1
 	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
-}
-@PART[*]:HAS[#RP0conf[false],#RSSROConfig[false]]:FINAL
-{
+	@category:NEEDS[FilterExtensions,!NoNonRP0] = 96
+	@category:NEEDS[!FilterExtensions,NoNonRP0] = -1
 	@title ^=:WIP RO:WIP RO nocost:
 	@description ^=:PART IN PROGRESS, MAY NOT WORK:PART IN PROGRESS, COSTS AND STATS WRONG:
-	@category:NEEDS[NoNonRP0] = -1
-	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
 }
-@PART[*]:HAS[#RP0conf[false],#RSSROConfig[False]]:FINAL
+
+@PART[*]:HAS[#RP0conf[*alse],~RSSROConfig[]]:FOR[zzzRP-0]
 {
-	@title ^=:WIP RO:WIP RO nocost:
-	@description ^=:PART IN PROGRESS, MAY NOT WORK:PART IN PROGRESS, COSTS AND STATS WRONG:
-	@category:NEEDS[NoNonRP0] = -1
 	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
-}
-@PART[*]:HAS[#RP0conf[false],~RSSROConfig[]]:FINAL
-{
+	@category:NEEDS[FilterExtensions,!NoNonRP0] = 97
+	@category:NEEDS[!FilterExtensions,NoNonRP0] = -1
 	@title ^=:non RO:non RO/nocost:
 	@description ^=:BY RO:BY RO, RP-0 PLACED BUT COST WRONG:
-	@category:NEEDS[NoNonRP0] = -1
-	@TechRequired:NEEDS[NoNonRP0] = ORPHANS
 }
-@PART[*]:HAS[#RP0conf[true],~RSSROConfig[]]:FINAL
+
+@PART[*]:HAS[#RP0conf[*rue],~RSSROConfig[]]:FOR[zzzRP-0]
 {
+	@category:NEEDS[FilterExtensions,!NoNonRP0] = 97
+	@category:NEEDS[!FilterExtensions,NoNonRP0] = -1
 	@title ^=:non RO:non RO (RP-0 yes):
 	@description ^=:BY RO:BY RO BUT PLACED AND COSTED BY RP-0:
 }
 
-//////////////////////////////////////
-// Hide parts
+//  ==================================================
+//  Cleanup.
+//  ==================================================
 
-// Ven's Stock Parts Revamp (VSR)
--PART[MicroEngineB]:FOR[RP-0]
+@PART[*]:HAS[#RP0conf[*]]:FOR[zzzTagCleanup]
 {
-}
-
--PART[engineSkipperButtless]:FOR[RP-0]
-{
+	!RP0conf = NULL
 }


### PR DESCRIPTION
Change log:

* Merge the Filter Extensions and the "NoNonRP0" folder patchers to a single one.
* Make the RP-0 tag insensitive to capitalization ("true" and "True" are exactly the same).
* Change the MM pass that the patches are applied (FINAL is bad for redistributed mods).
* Remove some part patches that referred to two VSR engines (the "engineSkipperButtless" does not exist and the "MicroEngineB" is already taken care of by RO).
* Add a tag cleanup pass.