### PR TITLE
Fix Mercury Flyby Contract

### DIFF
--- a/GameData/RP-0/Contracts/Fly-by Contracts/MercuryFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/MercuryFlyByContract.cfg
@@ -23,27 +23,16 @@ CONTRACT_TYPE
 	prestige = Exceptional
 	
 	// rewards
-	advanceFunds = 30000.0
-	rewardReputation = 80.0
-	rewardFunds = 30000.0
-	failureFunds = 45000.0
+	advanceFunds = 50000.0
+	rewardReputation = 100.0
+	rewardFunds = 50000.0
+	failureFunds = 75000.0
 	
 	REQUIREMENT
 	{
-		name = contractOrTech
-		type = Any
-		REQUIREMENT
-		{
-			name = CompleteContract
-			type = CompleteContract
-			contractType = flybyVenus
-		}
-		REQUIREMENT
-		{
-			name = ReqCapsules
-			type = CanResearchTech
-			tech = miniaturization
-		}
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybyVenus
 	}
 	PARAMETER
 	{


### PR DESCRIPTION
Fixed the requirements as they weren't preventing the contract from being available prior to Venus (or even lunar) flyby completion.

Also increased rewards because small bodies next to huge Sun's are far harder than say Venus.  I set rewards equal to Saturn, but should probably be more inline with Uranus or Neptune.