### PR TITLE
Removed the NewVessel requirement from the flyby contracts

### DIFF
--- a/GameData/RP-0/Contracts/Fly-by Contracts/CallistoFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/CallistoFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Callisto

--- a/GameData/RP-0/Contracts/Fly-by Contracts/DeimosFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/DeimosFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Deimos

--- a/GameData/RP-0/Contracts/Fly-by Contracts/DioneFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/DioneFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Dione

--- a/GameData/RP-0/Contracts/Fly-by Contracts/EnceladusFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/EnceladusFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Enceladus

--- a/GameData/RP-0/Contracts/Fly-by Contracts/EuropaFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/EuropaFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Europa

--- a/GameData/RP-0/Contracts/Fly-by Contracts/GanymedeFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/GanymedeFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Ganymede

--- a/GameData/RP-0/Contracts/Fly-by Contracts/IapetusFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/IapetusFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Iapetus

--- a/GameData/RP-0/Contracts/Fly-by Contracts/IoFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/IoFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Io

--- a/GameData/RP-0/Contracts/Fly-by Contracts/JupiterFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/JupiterFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Jupiter

--- a/GameData/RP-0/Contracts/Fly-by Contracts/MarsFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/MarsFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Mars

--- a/GameData/RP-0/Contracts/Fly-by Contracts/MercuryFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/MercuryFlyByContract.cfg
@@ -43,12 +43,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Mercury

--- a/GameData/RP-0/Contracts/Fly-by Contracts/MimasFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/MimasFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Mimas

--- a/GameData/RP-0/Contracts/Fly-by Contracts/NeptuneFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/NeptuneFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Neptune

--- a/GameData/RP-0/Contracts/Fly-by Contracts/PhobosFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/PhobosFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Phobos

--- a/GameData/RP-0/Contracts/Fly-by Contracts/PlutoFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/PlutoFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Pluto

--- a/GameData/RP-0/Contracts/Fly-by Contracts/RheaFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/RheaFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Rhea

--- a/GameData/RP-0/Contracts/Fly-by Contracts/SaturnFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/SaturnFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Saturn

--- a/GameData/RP-0/Contracts/Fly-by Contracts/TethysFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/TethysFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Tethys

--- a/GameData/RP-0/Contracts/Fly-by Contracts/TitanFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/TitanFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Titan

--- a/GameData/RP-0/Contracts/Fly-by Contracts/TritonFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/TritonFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Triton

--- a/GameData/RP-0/Contracts/Fly-by Contracts/UranusFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/UranusFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Uranus

--- a/GameData/RP-0/Contracts/Fly-by Contracts/VenusFlyByContract.cfg
+++ b/GameData/RP-0/Contracts/Fly-by Contracts/VenusFlyByContract.cfg
@@ -44,12 +44,6 @@ CONTRACT_TYPE
 		
 		PARAMETER
 		{
-			name = NewVessel
-			type = NewVessel
-		}
-	
-		PARAMETER
-		{
 			name = ReachState
 			type = ReachState
 			targetBody = Venus


### PR DESCRIPTION
@stratochief66 @NathanKell see any problems with this?  By doing this, I could setup a Jupiter flyby, and then if I see that I could also swing by Saturn, I could accept that contract later and use my Jupiter probe.