### PR TITLE
Atlas only depends on basicAvionics

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -449,7 +449,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 125.0
-		techRequired = flightControl
+		techRequired = basicAvionics
 	}
 }
 // Atlas F-mod (appears identical to E/F)
@@ -459,6 +459,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 130.0
+		techRequired = basicAvionics
 	}
 }
 // Atlas H
@@ -468,7 +469,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 160.0
-		techRequired = avionicsTL5
+		techRequired = basicAvionics
 	}
 }
 // Atlas II
@@ -478,7 +479,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 180.0
-		techRequired = avionicsTL6
+		techRequired = basicAvionics
 	}
 }
 // Atlas SLV-3 (Appears to be Atlas E/F)
@@ -488,7 +489,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 125.0
-		techRequired = stability
+		techRequired = basicAvionics
 	}
 }
 // Atlas SLV-3A (used as booster for Agena D / GATV)
@@ -498,7 +499,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 150.0
-		techRequired = advFlightControl
+		techRequired = basicAvionics
 	}
 }
 
@@ -509,7 +510,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 130.0
-		techRequired = flightControl
+		techRequired = basicAvionics
 	}
 }
 
@@ -520,7 +521,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 150.0
-		techRequired = advFlightControl
+		techRequired = basicAvionics
 	}
 }
 


### PR DESCRIPTION
Unlocking Basic Avionics will enable the integrated avionics on all Atlas tanks.