### PR TITLE
Created PARTUPGRADES for the RF Fuel Tank Types

### DIFF
--- a/GameData/RP-0/ResourceTechs.cfg
+++ b/GameData/RP-0/ResourceTechs.cfg
@@ -52,3 +52,94 @@
 {
 	%techRequired = survivability
 }
+
+PARTUPGRADE
+{
+	name = RF-cryogenic-tank-unlock
+	partIcon = fuelTank3-2
+	techRequired = advConstruction
+	entryCost = 0
+	cost = 0	
+	title = Cryogenic Tank Type Unlock
+	basicInfo = You can now choose the tank type Cryogenic
+	manufacturer = Generic
+	description = You can now choose the tank type Cryogenic
+}
+
+PARTUPGRADE
+{
+	name = RF-balloon-cryogenic-tank-unlock
+	partIcon = fuelTank3-2
+	techRequired = advConstruction
+	entryCost = 0
+	cost = 0	
+	title = Balloon Cryogenic Tank Type Unlock
+	basicInfo = You can now choose the tank type Balloon Cryogenic
+	manufacturer = Generic
+	description = You can now choose the tank type Balloon Cryogenic
+}
+
+PARTUPGRADE
+{
+	name = RF-default-tank-unlock
+	partIcon = fuelTank_long
+	techRequired = engineering101
+	entryCost = 0
+	cost = 0	
+	title = Default Tank Type Unlock
+	basicInfo = You can now choose the tank type Default
+	manufacturer = Generic
+	description = You can now choose the tank type Default
+}
+
+PARTUPGRADE
+{
+	name = RF-service-module-tank-unlock
+	partIcon = Size3MediumTank
+	techRequired = basicConstruction
+	entryCost = 0
+	cost = 0	
+	title = Service Module Tank Type Unlock
+	basicInfo = You can now choose the tank type Service Module
+	manufacturer = Generic
+	description = You can now choose the tank type Service Module
+}
+
+PARTUPGRADE
+{
+	name = RF-balloon-tank-unlock
+	partIcon = Size3LargeTank
+	techRequired = basicConstruction
+	entryCost = 0
+	cost = 0	
+	title = Balloon Tank Type Unlock
+	basicInfo = You can now choose the tank type Balloon
+	manufacturer = Generic
+	description = You can now choose the tank type Balloon
+}
+
+PARTUPGRADE
+{
+	name = RF-electric-propulsion-tank-unlock
+	partIcon = xenonTank
+	techRequired = electronics
+	entryCost = 0
+	cost = 0	
+	title = Electric Propulsion Tank Type Unlock
+	basicInfo = You can now choose the tank type Electric Propulsion
+	manufacturer = Generic
+	description = You can now choose the tank type Electric Propulsion
+}
+
+PARTUPGRADE
+{
+	name = RF-life-support-tank-unlock
+	partIcon = miniFuelTank
+	techRequired = survivability
+	entryCost = 0
+	cost = 0	
+	title = Life Support Tank Type Unlock
+	basicInfo = You can now choose the tank type Life Support
+	manufacturer = Generic
+	description = You can now choose the tank type Life Support
+}


### PR DESCRIPTION
In reference to #523 I decided to create very simple PARTUPGRADES to show up in the Tech Tree for each of the different types of fuel tanks made available by RealFuels.

I have used stock Icons so that they will work on any install and given them no costs to unlock (because they don't actually do anything, they are just informative).

Here they are in action:
http://imgur.com/a/6yfvB