### PR TITLE
Add stability tech level early controllable core

### DIFF
--- a/GameData/RP-0/ProceduralAvionics.cfg
+++ b/GameData/RP-0/ProceduralAvionics.cfg
@@ -179,7 +179,18 @@
 		AVIONICSCONFIG
 		{
 			name = probeCore
-
+			
+			TECHLIMIT # Early controllable core
+			{
+				name = stability
+				tonnageToMassRatio = 3.072
+				costPerControlledTon = 4998
+				enabledProceduralW = 250
+				disabledProceduralW = 5
+				standardAvionicsDensity = 1.24
+				SASServiceLevel = 1
+				hasScienceContainer = true
+			}
 			TECHLIMIT # Ranger Block I Core
 			{
 				name = basicScience


### PR DESCRIPTION
Given  #649, I doubled the baseline volume of this procedural. It still is super dense compared to Ranger I. I wonder if the volume for the ranger core was calculated including the metal structural parts below the core.