### PR TITLE
fix perl shebang line

### DIFF
--- a/bin/makeversion
+++ b/bin/makeversion
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 use 5.010;
 use strict;
 use warnings;

--- a/bin/yml2mm
+++ b/bin/yml2mm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use 5.010;
 use strict;
 use warnings;


### PR DESCRIPTION
use `/usr/bin/env perl` to look it up in the PATH instead of
the hardcoded /usr/bin/perl (typically the first perl in the user's
PATH is going to be preferred).

the -w flag causes issues when used with env but both of these
scripts declare `use warnings` so that flag is redundant and
removed from the shebang.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>