### PR TITLE
fix minPeA after completion

### DIFF
--- a/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
@@ -209,7 +209,7 @@ CONTRACT_TYPE
 		{
 			name = Orbit
 			type = Orbit
-			minPeA = 400000
+			minPeA = 250000
 			maxApA = 2000000
 			targetBody = HomeWorld()
 			title = Keep the station in a stable orbit with a Perigee greater than 250 km and an Apogee less than 2,000 km


### PR DESCRIPTION
in the current version, minPeA=400km, after the first crew departed, even though the text says 250k. I think that's a typo and set it to 250k.