### PR TITLE
CKAN homepage pointing at Forums

### DIFF
--- a/RP-0.version.in
+++ b/RP-0.version.in
@@ -5,6 +5,7 @@
     "NAME"     : "Realistic Progression Zero",
     "URL"      : "https://raw.githubusercontent.com/KSP-RO/RP-0/master/GameData/RP-0/RP-0.version",
     "DOWNLOAD" : "https://github.com/KSP-RO/RP-0/releases",
+    "HOMEPAGE"  : "http://forum.kerbalspaceprogram.com/index.php?/topic/162117-122-realistic-progression-zero-rp-0-lightweight-realismoverhaul-career-v054-june-15/",
     "GITHUB" : {
         "USERNAME"          : "KSP-RO",
         "REPOSITORY"        : "RP-0",


### PR DESCRIPTION
using https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md as a guide, added line 8 to this version file, confusion exists with NetKan file.
See issue #704