### PR TITLE
Fixes to procedural avionics

### DIFF
--- a/GameData/RP-0/Tree/ProceduralAvionics.cfg
+++ b/GameData/RP-0/Tree/ProceduralAvionics.cfg
@@ -130,7 +130,7 @@
 			TECHLIMIT # TL2 - Satellite era
 			{
 				name = basicAvionics
-				unlockCost = 15000
+				unlockCost = 24000
 				tonnageToMassRatio = 120.154
 				costPerControlledTon = 2.147
 				enabledProceduralW = 320
@@ -141,7 +141,7 @@
 			TECHLIMIT # TL3 - Human and Interplanetary probes
 			{
 				name = improvedAvionics
-				unlockCost = 30000
+				unlockCost = 54000
 				tonnageToMassRatio = 270.347
 				costPerControlledTon = 0.8416
 				enabledProceduralW = 12.8
@@ -152,7 +152,7 @@
 			TECHLIMIT # TL4 - Advanced Capsules
 			{
 				name = matureAvionics
-				unlockCost = 45000
+				unlockCost = 99000
 				tonnageToMassRatio = 608.281
 				costPerControlledTon = 0.3291
 				enabledProceduralW = 5.12
@@ -163,7 +163,7 @@
 			TECHLIMIT # TL5 - Lunar Era
 			{
 				name = largeScaleAvionics
-				unlockCost = 60000
+				unlockCost = 159000
 				tonnageToMassRatio = 1368.63
 				costPerControlledTon = 0.1283
 				enabledProceduralW = 2.048
@@ -174,7 +174,7 @@
 			TECHLIMIT # TL6 - Space Station Era
 			{
 				name = advancedAvionics
-				unlockCost = 75000
+				unlockCost = 234000
 				tonnageToMassRatio = 3079.4
 				costPerControlledTon = 0.0498
 				enabledProceduralW = 0.8192
@@ -185,7 +185,7 @@
 			TECHLIMIT # TL7 - Long Term Habitation
 			{
 				name = longTermAvionics
-				unlockCost = 90000
+				unlockCost = 324000
 				tonnageToMassRatio = 6928.7
 				costPerControlledTon = 0.02
 				enabledProceduralW = 0.32768
@@ -196,7 +196,7 @@
 			TECHLIMIT # TL8 - Commercial Era
 			{
 				name = modernAvionics
-				unlockCost = 105000
+				unlockCost = 429000
 				tonnageToMassRatio = 15590
 				costPerControlledTon = 0.007
 				enabledProceduralW = 0.131072
@@ -224,7 +224,7 @@
 			TECHLIMIT # TL2 - Human and Interplanetary probes
 			{
 				name = interplanetaryProbes
-				unlockCost = 9000
+				unlockCost = 15000
 				tonnageToMassRatio = 145.161
 				costPerControlledTon = 5.667
 				enabledProceduralW = 30
@@ -237,7 +237,7 @@
 			TECHLIMIT # TL3 - Advanced Capsules
 			{
 				name = matureAvionics
-				unlockCost = 12000
+				unlockCost = 27000
 				tonnageToMassRatio = 290.3
 				costPerControlledTon = 3.75
 				enabledProceduralW = 18
@@ -250,7 +250,7 @@
 			TECHLIMIT # TL4 - Lunar Era
 			{
 				name = largeScaleAvionics
-				unlockCost = 15000
+				unlockCost = 42000
 				tonnageToMassRatio = 580.65
 				costPerControlledTon = 2.38
 				enabledProceduralW = 10.8
@@ -263,7 +263,7 @@
 			TECHLIMIT # TL5 - Space Station Era
 			{
 				name = advancedAvionics
-				unlockCost = 18000
+				unlockCost = 60000
 				tonnageToMassRatio = 1161.3
 				costPerControlledTon = 1.47
 				enabledProceduralW = 6.48
@@ -276,7 +276,7 @@
 			TECHLIMIT # TL6 - Long Term Habitation
 			{
 				name = longTermAvionics
-				unlockCost = 21000
+				unlockCost = 81000
 				tonnageToMassRatio = 2322
 				costPerControlledTon = 0.886
 				enabledProceduralW = 3.889
@@ -289,7 +289,7 @@
 			TECHLIMIT # TL7 - Commercial Era
 			{
 				name = modernAvionics
-				unlockCost = 24000
+				unlockCost = 105000
 				tonnageToMassRatio = 4645
 				costPerControlledTon = 0.527
 				enabledProceduralW = 2.33
@@ -317,7 +317,7 @@
 			TECHLIMIT # TL2 - Human and Interplanetary
 			{
 				name = interplanetaryProbes
-				unlockCost = 35000
+				unlockCost = 65000
 				tonnageToMassRatio = 12
 				costPerControlledTon = 2922.5
 				enabledProceduralW = 100
@@ -329,7 +329,7 @@
 			TECHLIMIT # TL3 - Advanced Capsules
 			{
 				name = matureAvionics
-				unlockCost = 40000
+				unlockCost = 105000
 				tonnageToMassRatio = 18
 				costPerControlledTon = 2348.3
 				enabledProceduralW = 53
@@ -341,7 +341,7 @@
 			TECHLIMIT # TL4 - Lunar Era
 			{
 				name = largeScaleAvionics
-				unlockCost = 45000
+				unlockCost = 150000
 				tonnageToMassRatio = 24
 				costPerControlledTon = 2121.25
 				enabledProceduralW = 32
@@ -353,7 +353,7 @@
 			TECHLIMIT # TL5 - Space Station Era
 			{
 				name = advancedAvionics
-				unlockCost = 50000
+				unlockCost = 200000
 				tonnageToMassRatio = 30
 				costPerControlledTon = 2042
 				enabledProceduralW = 20.48
@@ -365,7 +365,7 @@
 			TECHLIMIT # TL6 - Long Term Habitation
 			{
 				name = longTermAvionics
-				unlockCost = 55000
+				unlockCost = 255000
 				tonnageToMassRatio = 36
 				costPerControlledTon = 2021
 				enabledProceduralW = 13
@@ -377,7 +377,7 @@
 			TECHLIMIT # TL7 - Commercial Era
 			{
 				name = modernAvionics
-				unlockCost = 60000
+				unlockCost = 315000
 				tonnageToMassRatio = 42
 				costPerControlledTon = 2000
 				enabledProceduralW = 9.3

--- a/GameData/RP-0/Tree/ProceduralAvionics.cfg
+++ b/GameData/RP-0/Tree/ProceduralAvionics.cfg
@@ -306,8 +306,8 @@
 			{
 				name = basicAvionics
 				unlockCost = 30000
-				tonnageToMassRatio = 6
-				costPerControlledTon = 4845
+				tonnageToMassRatio = 4
+				costPerControlledTon = 4850
 				enabledProceduralW = 250
 				disabledProceduralW = 5
 				standardAvionicsDensity = 0.25
@@ -318,8 +318,8 @@
 			{
 				name = interplanetaryProbes
 				unlockCost = 65000
-				tonnageToMassRatio = 12
-				costPerControlledTon = 2922.5
+				tonnageToMassRatio = 5
+				costPerControlledTon = 3000
 				enabledProceduralW = 100
 				disabledProceduralW = 2
 				standardAvionicsDensity = 0.25
@@ -330,8 +330,8 @@
 			{
 				name = matureAvionics
 				unlockCost = 105000
-				tonnageToMassRatio = 18
-				costPerControlledTon = 2348.3
+				tonnageToMassRatio = 6.5
+				costPerControlledTon = 2300
 				enabledProceduralW = 53
 				disabledProceduralW = 1
 				standardAvionicsDensity = 0.25
@@ -342,8 +342,8 @@
 			{
 				name = largeScaleAvionics
 				unlockCost = 150000
-				tonnageToMassRatio = 24
-				costPerControlledTon = 2121.25
+				tonnageToMassRatio = 8.5
+				costPerControlledTon = 2000
 				enabledProceduralW = 32
 				disabledProceduralW = 0.5
 				standardAvionicsDensity = 0.25
@@ -354,8 +354,8 @@
 			{
 				name = advancedAvionics
 				unlockCost = 200000
-				tonnageToMassRatio = 30
-				costPerControlledTon = 2042
+				tonnageToMassRatio = 12
+				costPerControlledTon = 1750
 				enabledProceduralW = 20.48
 				disabledProceduralW = 0.3
 				standardAvionicsDensity = 0.25
@@ -366,8 +366,8 @@
 			{
 				name = longTermAvionics
 				unlockCost = 255000
-				tonnageToMassRatio = 36
-				costPerControlledTon = 2021
+				tonnageToMassRatio = 15
+				costPerControlledTon = 1500
 				enabledProceduralW = 13
 				disabledProceduralW = 0.18
 				standardAvionicsDensity = 0.25
@@ -378,8 +378,8 @@
 			{
 				name = modernAvionics
 				unlockCost = 315000
-				tonnageToMassRatio = 42
-				costPerControlledTon = 2000
+				tonnageToMassRatio = 18.5
+				costPerControlledTon = 1200
 				enabledProceduralW = 9.3
 				disabledProceduralW = 0.1
 				standardAvionicsDensity = 0.25


### PR DESCRIPTION
When costs were defined, I thought they were directly applied, but the costs of previous TLs are discounted from the values in the configs. Fixed that to have total cost in each TL.