### PR TITLE
Add HG-3

### DIFF
--- a/tree.yml
+++ b/tree.yml
@@ -3486,6 +3486,12 @@ hydroloxTL4:
         cost: 9000 # J-2 is 8500
     RLA_mp_large_spike: *J2T 
     NP_lfe_125m_AerospikeEngine: *J2T
+    
+    SXTLT80: &HG-3
+        cost: 3175
+        entryCost: 127000
+    SHIP_HG_3_SL: *HG-3
+    SHIP_HG_3_VAC: *HG-3
         
 precisionPropulsion:
     FRERD843: #RD-843, late and tiny rocket engine used on Vega


### PR DESCRIPTION
Using a 27% price increase estimate for the cost of the the HG-3 over the J-2, directly extrapolating from the thrust increase. This is just a placeholder in the extreme, and if @pap1723 is already working on something like this or something then this can just get closed. But I at least wanted to get the ball rolling. I figured that since T5 is where the RS-25 first pops up, and T3 is the home of the J-2, T4 worked well enough as a place for this engine. That being said, I could be doing this wrong, as this is my first RP-0 pull request, so feel free to call me out on stupid mistakes.