### PR TITLE
Avionic Changes

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -12,7 +12,8 @@
 // *** Non-control probe cores
 // Disable attitude control on non-control parts. FIXME Add to this patch
 // all probes which should not have independent attitude control.
-@PART[SXTSputnik|FASAExplorerProbe|RP0probeSounding0-3m|RP0probeVanguardXray|explorer_6|pioneer_0_1_2|pioneer_3_4|grab-1|tiros-1|transit2a|vanguard-1|vanguard-2|vanguard-3|taerobee_control]:FOR[RP-0]
+// Moved Pioneer 5 here as it is a spin stablized probe and did not have indenpendant attitude control - https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1960-001A
+@PART[SXTSputnik|FASAExplorerProbe|RP0probeSounding0-3m|RP0probeVanguardXray|explorer_6|pioneer_0_1_2|pioneer_3_4|pioneer_5|grab-1|tiros-1|transit2a|vanguard-1|vanguard-2|vanguard-3|taerobee_control|sputnik1|sputnik2|sputnik3|luna2]:FOR[RP-0]
 {
 	MODULE
 	{
@@ -194,6 +195,44 @@
 	{
 		name = ModuleAvionics
 		massLimit = 6.0
+	}
+}
+
+// ** Sovient Probes, Probes with individual attitude control get
+// Basing values on the ~2x control allowed for US probes.
+@PART[molniya1]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 3.0
+	}
+}
+
+@PART[luna3]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 0.5
+	}
+}
+
+@PART[luna9_als|luna_als]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 2.0
+	}
+}
+
+@PART[polyot]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 1.5
 	}
 }
 


### PR DESCRIPTION
Added most RN Soviet Probes (all sputniks, molinya1, polyot, and lunas
2-10) and removed avionics from Pioneer 5