### PR TITLE
Entry Cost configs

### DIFF
--- a/GameData/RP-0/Tree/EntryCostModifiers.cfg
+++ b/GameData/RP-0/Tree/EntryCostModifiers.cfg
@@ -40,6 +40,62 @@ ENTRYCOSTMODS
 		}
 	}
 	
+	//AJ10 Early
+	PART
+	{
+		name = SXTAJ10
+		entryCostMultipliers
+		{
+			SSTU-AJ10-CustomEarly = 0
+			rn-aj10-37 = 0
+		}
+	}
+	PART
+	{
+		name = SSTU-AJ10-CustomEarly
+		entryCostMultipliers
+		{
+			SXTAJ10 = 0
+			rn-aj10-37 = 0
+		}
+	}
+	PART
+	{
+		name = rn-aj10-37
+		entryCostMultipliers
+		{
+			SSTU-AJ10-CustomEarly = 0
+			SXTAJ10 = 0
+		}
+	}
+	
+	//Vanguad X405
+	PART
+	{
+		name = rn-x405
+		entryCostSubtractors
+		{
+			SXTX405 = 12000
+		}
+	}
+	PART
+	{
+		name = rn-x405-vernier
+		entryCostSubtractors
+		{
+			SXTX405 = 1000
+		}
+	}
+	PART
+	{
+		name = SXTX405
+		entryCostSubtractors
+		{
+			rn-x405 = 12000
+			rn-x405-vernier = 1000
+		}
+	}
+	
 	// TIER 2
 	PART
 	{
@@ -61,12 +117,53 @@ ENTRYCOSTMODS
 		}
 	}
 	
+	//AJ10 Mid
 	PART
 	{
 		name = SXTAJ10Mid
+		maxSubtraction = 3000
 		entryCostSubtractors
 		{
 			SXTAJ10 = 3000
+			SSTU-AJ10-CustomEarly = 3000
+			rn-aj10-37 = 3000
+		}
+		entryCostMultipliers
+		{
+			SSTU-AJ10-CustomMid = 0
+			rn-aj10-104 = 0
+		}
+	}
+	PART
+	{
+		name = SSTU-AJ10-CustomMid
+		maxSubtraction = 3000
+		entryCostSubtractors
+		{
+			SXTAJ10 = 3000
+			SSTU-AJ10-CustomEarly = 3000
+			rn-aj10-37 = 3000
+		}
+		entryCostMultipliers
+		{
+			SXTAJ10Mid = 0
+			rn-aj10-104 = 0
+		}
+	}
+	PART
+	{
+		name = rn-aj10-104
+		maxSubtraction = 3000
+		entryCostSubtractors
+		{
+			SXTAJ10 = 3000
+			SSTU-AJ10-CustomEarly = 3000
+			rn-aj10-37 = 3000
+		}
+		entryCostMultipliers
+		{
+			SSTU-AJ10-CustomMid = 0
+			SXTAJ10Mid = 0
 		}
 	}
 	

--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -16445,7 +16445,7 @@
 {
     %TechRequired = orbitalRocketry1958
     %cost = 25
-    %entryCost = 500
+    %entryCost = 1000
     RP0conf = true
 }
 @PART[Vega_Stage3]:FOR[xxxRP0]


### PR DESCRIPTION
Added entry cost mosifiers for AJ10 early and mid and the Vanguard X405.
Also chnage the entry cost for the RN X405 Vernier so that the total
entry cost for the RN Vanguard X405 matches the SXT composite