### PR TITLE
Fix config node unlocks for RN's R-7 engines.

### DIFF
--- a/GameData/RP-0/Tree/TREE-Engine_Configs.cfg
+++ b/GameData/RP-0/Tree/TREE-Engine_Configs.cfg
@@ -974,6 +974,34 @@
         { %techRequired = orbitalRocketry1972 }
     }
 }
+@PART[rn_r7_bvgd_engine]:FOR[xxxRP0]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG[RD-107-8D74]
+        { %techRequired = orbitalRocketry1956 }
+        @CONFIG[RD-107-8D74PS]
+        { %techRequired = orbitalRocketry1956 }
+        @CONFIG[RD-107-8D76]
+        { %techRequired = orbitalRocketry1958 }
+        @CONFIG[RD-107-8D74-1958]
+        { %techRequired = orbitalRocketry1958 }
+        @CONFIG[RD-107-8D74K]
+        { %techRequired = orbitalRocketry1960 }
+        @CONFIG[RD-107-8D74-1959]
+        { %techRequired = orbitalRocketry1960 }
+        @CONFIG[RD-107-8D728]
+        { %techRequired = orbitalRocketry1964 }
+        @CONFIG[RD-107-11D511]
+        { %techRequired = orbitalRocketry1972 }
+        @CONFIG[RD-107-11D511P]
+        { %techRequired = orbitalRocketry1972 }
+        @CONFIG[RD-107A-14D22]
+        { %techRequired = orbitalRocketry1998 }
+        @CONFIG[RD-107A-14D22KhZ]
+        { %techRequired = orbitalRocketry1998 }
+    }
+}
 @PART[*]:HAS[#engineType[RD108-118]]:FOR[xxxRP0]
 {
     @MODULE[ModuleEngineConfigs]
@@ -990,6 +1018,34 @@
         { %techRequired = orbitalRocketry1964 }
         @CONFIG[RD-118_11D512]
         { %techRequired = orbitalRocketry1972 }
+    }
+}
+@PART[rn_r7_blok_a_engine]:FOR[xxxRP0]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG[RD-108-8D75]
+        { %techRequired = orbitalRocketry1956 }
+        @CONFIG[RD-108-8D75PS]
+        { %techRequired = orbitalRocketry1956 }
+        @CONFIG[RD-108-8D77]
+        { %techRequired = orbitalRocketry1958 }
+        @CONFIG[RD-108-8D75-1958]
+        { %techRequired = orbitalRocketry1958 }
+        @CONFIG[RD-108-8D75K]
+        { %techRequired = orbitalRocketry1960 }
+        @CONFIG[RD-108-8D75-1959]
+        { %techRequired = orbitalRocketry1960 }
+        @CONFIG[RD-108-8D727]
+        { %techRequired = orbitalRocketry1964 }
+        @CONFIG[RD-108-11D512]
+        { %techRequired = orbitalRocketry1972 }
+        @CONFIG[RD-108-11D512P]
+        { %techRequired = orbitalRocketry1972 }
+        @CONFIG[RD-108A-14D21]
+        { %techRequired = orbitalRocketry1998 }
+        @CONFIG[RD-108A-14D21KhZ]
+        { %techRequired = orbitalRocketry1998 }
     }
 }
 @PART[*]:HAS[#engineType[RD120]]:FOR[xxxRP0]


### PR DESCRIPTION
This doesn't work yet, but I'm not sure what else could be going wrong.