### PR TITLE
Adjusting contracts

### DIFF
--- a/GameData/RP-0/Contracts/Human Contracts/Suborbital Crewed.cfg
+++ b/GameData/RP-0/Contracts/Human Contracts/Suborbital Crewed.cfg
@@ -53,6 +53,19 @@ CONTRACT_TYPE
 		title = Has not compeleted @contractType Contract
 		invertRequirement = true
 	}
+	REQUIREMENT
+	{
+		name = CompleteCrewedSuborbital
+		type = CompleteContract
+
+		contractType = CrewedSuborbital
+
+		minCount = 0
+
+		//complete before we can attempt again.
+		cooldownDuration = 4d
+	}
+		
 	
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingAltitude.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingAltitude.cfg
@@ -35,21 +35,9 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = float
-		soundingMaxAlt = $RP0_SoundingMaxAltitudeKM
+		soundingMaxAlt = ($RP0_SoundingMaxAltitudeKM,100)
 	}
 	
-	DATA
-	{
-		type = float
-		soundingDifficulty = $RP0_SoundingDifficulty 
-	}
-	
-	DATA
-	{
-		type = float
-		maxDifficulty = @soundingDifficulty > (60 * @targetAltitudeKM) ? @soundingDifficulty : (60 * @targetAltitudeKM )
-	
-	}
 	
 	DATA
 	{

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingDifficult.cfg
@@ -34,13 +34,13 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = float
-		soundingDifficulty = $RP0_SoundingDifficulty 
+		soundingDifficulty = Max($RP0_SoundingDifficulty, 6000) 
 	}
 	
 	DATA
 	{
 		type = float
-		soundingMaxAlt = $RP0_SoundingMaxAltitudeKM
+		soundingMaxAlt = Max($RP0_SoundingMaxAltitudeKM, 100)
 	}
 	
 	DATA
@@ -198,7 +198,7 @@ CONTRACT_TYPE
 
 			minCount = 0
 
-			complete before we can attempt again.
+			//complete before we can attempt again.
 			cooldownDuration = 4d
 		}
 		
@@ -211,7 +211,7 @@ CONTRACT_TYPE
 
 			minCount = 0
 
-			complete before we can attempt again.
+			//complete before we can attempt again.
 			cooldownDuration = 4d
 		}
 		
@@ -224,7 +224,7 @@ CONTRACT_TYPE
 
 			minCount = 0
 
-			complete before we can attempt again.
+			//complete before we can attempt again.
 			cooldownDuration = 4d
 		}
 				
@@ -237,7 +237,7 @@ CONTRACT_TYPE
 
 			minCount = 0
 
-			complete before we can attempt again.
+			//complete before we can attempt again.
 			cooldownDuration = 4d
 		}
 		

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingEasy.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingEasy.cfg
@@ -34,13 +34,13 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = float
-		soundingDifficulty = $RP0_SoundingDifficulty 
+		soundingDifficulty = Max($RP0_SoundingDifficulty,6000) 
 	}
 	
 	DATA
 	{
 		type = float
-		soundingMaxAlt = $RP0_SoundingMaxAltitudeKM
+		soundingMaxAlt = Max(100,$RP0_SoundingMaxAltitudeKM)
 	}
 	
 	DATA

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingIntermediate.cfg
@@ -34,13 +34,13 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = float
-		soundingDifficulty = $RP0_SoundingDifficulty 
+		soundingDifficulty = Max($RP0_SoundingDifficulty,6000) 
 	}
 	
 	DATA
 	{
 		type = float
-		soundingMaxAlt = $RP0_SoundingMaxAltitudeKM
+		soundingMaxAlt = Max($RP0_SoundingMaxAltitudeKM,100)
 	}
 	
 	DATA

--- a/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmo.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmo.cfg
@@ -55,6 +55,20 @@ CONTRACT_TYPE
 		contractType = BreakSoundBarrier
 		title = Complete @contractType Contract
 	}
+	
+	REQUIREMENT
+	{
+		name = CompleteCrewedReachSpace
+		type = CompleteContract
+
+		contractType = CrewedReachSpace
+
+		minCount = 0
+
+		//complete before we can attempt again.
+		cooldownDuration = 4d
+	}
+		
 
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoLate.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoLate.cfg
@@ -49,6 +49,20 @@ CONTRACT_TYPE
 		type = CompleteContract
 		contractType = BreakSoundBarrier
 	}
+	
+	REQUIREMENT
+	{
+		name = CompleteCrewedSpaceLate
+		type = CompleteContract
+
+		contractType = CrewedSpaceLate
+
+		minCount = 0
+
+		//complete before we can attempt again.
+		cooldownDuration = 4d
+	}
+		
 
 	PARAMETER
 	{


### PR DESCRIPTION
Adding cooldowns to x-planes high, high late, and crewed suborbital, setting reasonable minimums to sounding rockets just as a safety net for players who don't start the game off with the new ones