### PR TITLE
Replace the Geiger Counter in FASA's Agena probe

### DIFF
--- a/GameData/RP-0/Science/PartExperimentAdder.cfg
+++ b/GameData/RP-0/Science/PartExperimentAdder.cfg
@@ -140,7 +140,7 @@
 }
 
 // Add Geiger counter
-@PART[RP0probeVanguardXray|dmUSPresTemp|FASAProbeGeigerCounter|FASAExplorerProbe|sputnik3]:FOR[RP-0]
+@PART[RP0probeVanguardXray|dmUSPresTemp|FASAProbeGeigerCounter|FASAExplorerProbe|FASAAgenaProbe|sputnik3]:FOR[RP-0]
 {
 	MODULE
 	{
@@ -173,7 +173,7 @@
 // The FASA Geiger Counter is no more. It now gives the player the GeigerMuller Tube
 // experiment
 
-@PART[FASAProbeGeigerCounter|FASAExplorerProbe]:FOR[RP-0]
+@PART[FASAProbeGeigerCounter|FASAExplorerProbe|FASAAgenaProbe]:FOR[RP-0]
 {
     !MODULE[ModuleScienceExperiment]:HAS[#experimentID[GeigerCounter]]
     {


### PR DESCRIPTION
The Agena satellite bus provided by FASA has a geiger counter, but it is not being replaced by RP-0 with its version.