### PR TITLE
Don't remove Ablator from crew pods.  They're likely to need it.

### DIFF
--- a/GameData/RP-0/Science/CrewScience/CrewLabAdder.cfg
+++ b/GameData/RP-0/Science/CrewScience/CrewLabAdder.cfg
@@ -61,7 +61,7 @@ RESOURCE_DEFINITION
 
 		opsViewTitle = Basic Capsule Configuration
 
-		resourcesToKeep = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater;LithiumHydroxide
+		resourcesToKeep = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater;LithiumHydroxide;Ablator
 	}
 }
 
@@ -89,7 +89,7 @@ RESOURCE_DEFINITION
 
 		opsViewTitle = Second Generation Capsule Configuration
 
-		resourcesToKeep = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater;LithiumHydroxide
+		resourcesToKeep = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater;LithiumHydroxide;Ablator
 	}
 }
 
@@ -117,6 +117,6 @@ RESOURCE_DEFINITION
 
 		opsViewTitle = Mature Capsule Configuration
 
-		resourcesToKeep = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater;LithiumHydroxide
+		resourcesToKeep = ElectricCharge;Food;Oxygen;Water;CarbonDioxide;Waste;WasteWater;LithiumHydroxide;Ablator
 	}
 }


### PR DESCRIPTION
I also noticed HTP was being removed from the FASA Mercury pod, but the list
of possible RCS propellants is quite long; there must be a better way to fix
this than just listing them all.  (It'd surely be simpler to list all the
resources to _remove_...)