### PR TITLE
Fix completion bug Issue #764

### DIFF
--- a/GameData/RP-0/Contracts/Orbits/Venus Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Venus Orbit.cfg
@@ -75,6 +75,7 @@ CONTRACT_TYPE
 			name = EnterOrbit
 			type = Orbit
 			situation = ORBITING
+			minApA = 0
 			maxPeA = @targetBody.Radius() * 2
 			disableOnStateChange = true
 			title = Orbit Venus with a maximum Periapsis of @/orbitKM km
@@ -84,7 +85,7 @@ CONTRACT_TYPE
 				name = Duration
 				type = Duration
 
-				duration = 2m
+				duration = 10s
 
 				preWaitText = Check for Stable Orbit
 				waitingText = Checking for Stable Orbit


### PR DESCRIPTION
The contract was being satisfied by a fly-by instead of an orbit. Changing the min Apoapsis value to be 0 means that hyperbolic orbits no longer satisfy the contract.