### PR TITLE
Add science cores to some Bluedog probe cores

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -13,7 +13,7 @@
 // Disable attitude control on non-control parts. FIXME Add to this patch
 // all probes which should not have independent attitude control.
 // Moved Pioneer 5 here as it is a spin stablized probe and did not have indenpendant attitude control - https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1960-001A
-@PART[SXTSputnik|FASAExplorerProbe|RP0probeSounding0-3m|RP0probeVanguardXray|explorer_6|pioneer_0_1_2|pioneer_3_4|pioneer_5|grab-1|tiros-1|transit2a|vanguard-1|vanguard-2|vanguard-3|taerobee_control|sputnik1|sputnik2|sputnik3|luna2]:FOR[RP-0]
+@PART[SXTSputnik|FASAExplorerProbe|RP0probeSounding0-3m|RP0probeVanguardXray|explorer_6|pioneer_0_1_2|pioneer_3_4|pioneer_5|grab-1|tiros-1|transit2a|vanguard-1|vanguard-2|vanguard-3|taerobee_control|sputnik1|sputnik2|sputnik3|luna2|bluedog_Pioneer4|bluedog_Explorer1|bluedog_Pioneer1|bluedog_explorer7probe]:FOR[RP-0]
 {
 	MODULE
 	{


### PR DESCRIPTION
There were some other cores that didn't have science cores nor something saying how much vessel mass the avionics support. I wasn't sure whether these should have avionics added:

  - Ranger Block 1 Core (bluedog_rangerCore)
  - Galileo Atmospheric Probe (galileo_aprobe)
  - Alouette Core (SXTAlouetteI)
  - Surveyor Core (ca.landv.core)
  - Mariner 1/2 Probe (rn_mariner1_2)
  - Tons of others