### PR TITLE
Fix NewCrewStations.cfg

### DIFF
--- a/GameData/RP-0/Contracts/Space Stations/New Crew Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/New Crew Station.cfg
@@ -53,8 +53,8 @@ CONTRACT_TYPE
 		requiredValue = true
 		hidden = true
 		uniquenessCheck = GROUP_ACTIVE
-		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station && v.EmptyCrewSpace()<3 && v.FreeDockingPorts()>0).SelectUnique()
-		title = Must have a station with less than 3 empty seats
+		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station && v.CrewCount()==0 && v.FreeDockingPorts()>0).SelectUnique()
+		title = Must have a station with no crew on board
 	}
 	DATA
 	{


### PR DESCRIPTION
As I read this, the point of this contract is to send crew to an empty station.  But the current requirement is set to only allow the contract to occur when there are less than 3 vacant seats available.  Meaning if a station can support 5 crew and you have 3 on the station, the contract would become available because "EmptyCrewSpace()" would return a result of 2.  By using "v.CrewCount()==0" we should only allow the contract to occur when a station has no crew on board, regardless of how many available seats there may be.