### PR TITLE
Use GUILayout for proc avionics config window

### DIFF
--- a/Source/Avionics/ModuleProceduralAvionics.cs
+++ b/Source/Avionics/ModuleProceduralAvionics.cs
@@ -636,7 +636,7 @@ namespace RP0.ProceduralAvionics
 		public void OnGUI()
 		{
 			if (showGUI) {
-				windowRect = GUI.Window(GetInstanceID(), windowRect, WindowFunction, "Configure Procedural Avionics");
+				windowRect = GUILayout.Window(GetInstanceID(), windowRect, WindowFunction, "Configure Procedural Avionics");
 			}
 		}
 


### PR DESCRIPTION
Prior to this, the window would not resize when selecting different tech
levels. This could result in buttons and text being rendered below the
bottom of the window, especially when lots of tech levels are present
(e.g. Sandbox).