### PR TITLE
Allow distinct proc avionics parts to have different tech levels

### DIFF
--- a/Source/Avionics/ModuleProceduralAvionics.cs
+++ b/Source/Avionics/ModuleProceduralAvionics.cs
@@ -79,7 +79,7 @@ namespace RP0.ProceduralAvionics
 
 		public ProceduralAvionicsTechNode CurrentProceduralAvionicsTechNode {
 			get {
-				if (avionicsTechLevel != null && CurrentProceduralAvionicsConfig.TechNodes.ContainsKey(avionicsTechLevel))
+				if (CurrentProceduralAvionicsConfig != null && avionicsTechLevel != null && CurrentProceduralAvionicsConfig.TechNodes.ContainsKey(avionicsTechLevel))
 				{
 					return CurrentProceduralAvionicsConfig.TechNodes[avionicsTechLevel];
 				}

--- a/Source/Avionics/ModuleProceduralAvionics.cs
+++ b/Source/Avionics/ModuleProceduralAvionics.cs
@@ -79,8 +79,9 @@ namespace RP0.ProceduralAvionics
 
 		public ProceduralAvionicsTechNode CurrentProceduralAvionicsTechNode {
 			get {
-				if (CurrentProceduralAvionicsConfig != null) {
-					return CurrentProceduralAvionicsConfig.CurrentTechNode;
+				if (avionicsTechLevel != null && CurrentProceduralAvionicsConfig.TechNodes.ContainsKey(avionicsTechLevel))
+				{
+					return CurrentProceduralAvionicsConfig.TechNodes[avionicsTechLevel];
 				}
 				return null;
 			}
@@ -309,7 +310,6 @@ namespace RP0.ProceduralAvionics
 			currentProceduralAvionicsConfig =
 				ProceduralAvionicsTechManager.GetProceduralAvionicsConfig(avionicsConfigName);
 			Log("Setting tech node to ", avionicsTechLevel);
-			currentProceduralAvionicsConfig.currentTechNodeName = avionicsTechLevel;
 			oldAvionicsConfigName = avionicsConfigName;
 			SetMinVolume(true);
 		}
@@ -696,7 +696,6 @@ namespace RP0.ProceduralAvionics
 						Log("Configuration window changed, updating part window");
 						UpdateConfigSliders();
 						avionicsTechLevel = techNode.name;
-						currentlyDisplayedConfigs.currentTechNodeName = techNode.name;
 						currentProceduralAvionicsConfig = currentlyDisplayedConfigs;
 						avionicsConfigName = guiAvionicsConfigName;
 						AvionicsConfigChanged();

--- a/Source/Avionics/ProceduralAvionicsConfig.cs
+++ b/Source/Avionics/ProceduralAvionicsConfig.cs
@@ -11,19 +11,6 @@ namespace RP0.ProceduralAvionics
 		[Persistent]
 		public string name;
 
-		public string currentTechNodeName; 
-
-		public ProceduralAvionicsTechNode CurrentTechNode
-		{
-			get
-			{
-				if (currentTechNodeName != null && TechNodes.ContainsKey(currentTechNodeName)) {
-					return TechNodes[currentTechNodeName];
-				}
-				return null;
-			}
-		}	
-
 		public byte[] techNodesSerialized;
 
 		private Dictionary<String, ProceduralAvionicsTechNode> techNodes;


### PR DESCRIPTION
Prior to this PR, distinct proc avionics parts that had the same
config (i.e. "booster", "upper stage", or "probe") were forced to have
the same tech level, since the tech level was set per-config, instead of
per-part (or per-PartModule, in this case).