### PR TITLE
Place RCS Tech Level 2 into earlyDocking node

### DIFF
--- a/GameData/RP-0/Tree/RFTechLevels.cfg
+++ b/GameData/RP-0/Tree/RFTechLevels.cfg
@@ -141,7 +141,7 @@ PARTUPGRADE
 {
 	name = RFTech-rcs-tltech2
 	partIcon = RCSBlock
-	techRequired = improvedFlightControl
+	techRequired = earlyDocking
 	entryCost = 0
 	cost = 0	
 	title = RCS Technology Upgrade Level 2


### PR DESCRIPTION
soundnfury noticed that RCS `TLTECH2` in `RFSETTINGS` was placed into
the `earlyDocking` node, but the `PARTUPGRADE` was placed into the
`improvedFlightControl` node. Pap said that the correct value is
whatever `TLTECH` was.