### PR TITLE
Show three decimal places for tooling dimensions

### DIFF
--- a/Source/Tooling/ModuleToolingDiamLen.cs
+++ b/Source/Tooling/ModuleToolingDiamLen.cs
@@ -15,9 +15,9 @@ namespace RP0
             float d, l;
             GetDimensions(out d, out l);
             if (l != 0f)
-                return d.ToString("F2") + "m x " + l.ToString("F2") + "m";
+                return d.ToString("F3") + "m x " + l.ToString("F3") + "m";
             else
-                return d.ToString("F2") + "m";
+                return d.ToString("F3") + "m";
         }
 
         public override float GetToolingCost()

--- a/Source/Tooling/ToolingGUI.cs
+++ b/Source/Tooling/ToolingGUI.cs
@@ -126,9 +126,9 @@ namespace RP0
         {
             GUILayout.BeginHorizontal();
             try {
-                GUILayout.Label(diameter.ToString("F2") + "m", HighLogic.Skin.label, GUILayout.Width(80));
+                GUILayout.Label(diameter.ToString("F3") + "m", HighLogic.Skin.label, GUILayout.Width(80));
                 GUILayout.Label("×", HighLogic.Skin.label);
-                GUILayout.Label(length.ToString("F2") + "m", rightLabel, GUILayout.Width(80));
+                GUILayout.Label(length.ToString("F3") + "m", rightLabel, GUILayout.Width(80));
             } finally {
                 GUILayout.EndHorizontal();
             }


### PR DESCRIPTION
Proc parts sliders allow editing with precision of up to three decimal
places, so three decimal places should be shown when displaying sizes of
tooled/untooled parts