### PR TITLE
Update TestFlightRnD.cfg

### DIFF
--- a/GameData/RP-0/TestFlightRnD.cfg
+++ b/GameData/RP-0/TestFlightRnD.cfg
@@ -38,24 +38,22 @@ TFRNDSETTINGS
 }
 
 //  ==================================================
-//  After pass: fix up RnD and first delete the settings from RO.
+//  After pass: fix up RnD but overwrite the settings from RO.
 //  ==================================================
 
 @PART[*]:HAS[@MODULE[TestFlightCore],#entryCost[*]]:AFTER[zTestFlight]
 {
 	@MODULE[TestFlightCore],*
 	{
-		!rndCost = DEL
-		!rndRate = DEL
 		%rndMaxData = 2500
-		rndCost = #$../cost$
+		%rndCost = #$../cost$
 		@rndCost *= 0.00100
 		@rndCost += 0.15
 		
 		tmp = #$../cost$
 		@tmp *= 20
 		@tmp != 0.25
-		rndRate = 6
+		%rndRate = 6
 		@rndRate /= #$tmp$
 		!tmp = DEL
 	}

--- a/GameData/RP-0/TestFlightRnD.cfg
+++ b/GameData/RP-0/TestFlightRnD.cfg
@@ -1,5 +1,5 @@
 //  ==================================================
-//  Set the global TF RnD settings.
+//  Set the global TF RnD settings. For now these settings are ignored by Testflight.
 //  ==================================================
 
 TFRNDSETTINGS
@@ -38,14 +38,16 @@ TFRNDSETTINGS
 }
 
 //  ==================================================
-//  After pass: fix up RnD.
+//  After pass: fix up RnD and first delete the settings from RO.
 //  ==================================================
 
 @PART[*]:HAS[@MODULE[TestFlightCore],#entryCost[*]]:AFTER[zTestFlight]
 {
 	@MODULE[TestFlightCore],*
 	{
-		rndMaxData = 2500
+		!rndCost = DEL
+		!rndRate = DEL
+		%rndMaxData = 2500
 		rndCost = #$../cost$
 		@rndCost *= 0.00100
 		@rndCost += 0.15


### PR DESCRIPTION
TFRNDSETTING are not accepted by TF and we work with the standards from TF

We need to overwrite rndCost and rndRate from RO. TF take the last numbers and without overwriting we end up in editing the number from RO and set rndCost = cost and rndRate = 6