### PR TITLE
Add science core to everything without avionics or crew control

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -9,11 +9,8 @@
 
 
 
-// *** Non-control probe cores
-// Disable attitude control on non-control parts. FIXME Add to this patch
-// all probes which should not have independent attitude control.
-// Moved Pioneer 5 here as it is a spin stablized probe and did not have indenpendant attitude control - https://nssdc.gsfc.nasa.gov/nmc/spacecraftDisplay.do?id=1960-001A
-@PART[SXTSputnik|FASAExplorerProbe|RP0probeSounding0-3m|RP0probeVanguardXray|explorer_6|pioneer_0_1_2|pioneer_3_4|pioneer_5|grab-1|tiros-1|transit2a|vanguard-1|vanguard-2|vanguard-3|taerobee_control|sputnik1|sputnik2|sputnik3|luna2]:FOR[RP-0]
+// Disable attitude control on non-control parts.
+@PART[*]:HAS[@MODULE[ModuleCommand]:HAS[~minimumCrew[>0]],!MODULE[ModuleAvionics],!MODULE[ModuleProceduralAvionics],!MODULE[ModuleScienceCore]]:FOR[RP-0]
 {
 	MODULE
 	{

--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -10,7 +10,7 @@
 
 
 // Disable attitude control on non-control parts.
-@PART[*]:HAS[@MODULE[ModuleCommand]:HAS[~minimumCrew[>0]],!MODULE[ModuleAvionics],!MODULE[ModuleProceduralAvionics],!MODULE[ModuleScienceCore]]:FOR[RP-0]
+@PART[*]:HAS[@MODULE[ModuleCommand]:HAS[~minimumCrew[>0]],!MODULE[ModuleAvionics],!MODULE[ModuleProceduralAvionics],!MODULE[ModuleScienceCore]]:AFTER[RP-0]
 {
 	MODULE
 	{


### PR DESCRIPTION
This eliminates the need to explicitly enumerate all probe cores that
need to have science cores added.