### PR TITLE
Fix placement of Atlas LV-3A

### DIFF
--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -7773,6 +7773,14 @@
     RP0conf = true
     @description ^=:$: <b><color=green>From FASA mod</color></b>
 }
+@PART[FASAMercuryAtlasLFTLong]:FOR[xxxRP0]
+{
+    %TechRequired = materialsScienceHuman
+    %cost = 400
+    %entryCost = 8000
+    RP0conf = true
+    @description ^=:$: <b><color=green>From FASA mod</color></b>
+}
 @PART[ca_RM03]:FOR[xxxRP0]
 {
     %TechRequired = improvedFlightControl
@@ -9456,14 +9464,6 @@
     %entryCost = 10000
     RP0conf = false
     @description ^=:$: <b><color=green>From Bluedog DB mod</color></b>
-}
-@PART[FASAMercuryAtlasLFTLong]:FOR[xxxRP0]
-{
-    %TechRequired = materialsScienceAdvCapsules
-    %cost = 400
-    %entryCost = 8000
-    RP0conf = true
-    @description ^=:$: <b><color=green>From FASA mod</color></b>
 }
 @PART[FASAAtlasSLV3A]:FOR[xxxRP0]
 {


### PR DESCRIPTION
The part for AtlasLFTLong is described as the SLV-3 which I believe is
why this was placed in the wrong node. While SLV-3 didn't fly until '64,
the tank is identical to that used on LV-3A which flew the agena in '60.
Without this, there is no Atlas tank that can be used with the Agena on
the node where the Agena is unlocked. It certainly flew before LV3-C
which is on this node as well.