### PR TITLE
Fix avionics tech for FASA Centaur parts

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -502,7 +502,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 1000.0
-		techRequired = flightControl
+		techRequired = improvedFlightControl
 	}
 }
 
@@ -514,7 +514,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 40.0
-		techRequired = flightControl
+		techRequired = improvedFlightControl
 	}
 }
 // Centaur D-1T
@@ -524,7 +524,7 @@
 	{
 		name = ModuleAvionics
 		massLimit = 40.0
-		techRequired = flightControl
+		techRequired = improvedFlightControl
 	}
 }
 // Centaur D2


### PR DESCRIPTION
The node `flightControl` no longer exists. I've placed the avionics on the same node that unlocks the Centaur's RCS thrusters.