### PR TITLE
Adding avionics to SSTU, coatl

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -48,7 +48,7 @@
 	}
 }
 
-@PART[HL_Aero_Cockpit|B9_Cockpit_MK5|mk3Cockpit_Shuttle|STSOrbiter|CSSCrewCompartment]:FOR[RP-0]
+@PART[HL_Aero_Cockpit|B9_Cockpit_MK5|mk3Cockpit_Shuttle|STSOrbiter|CSSCrewCompartment|SSTU-SC-C-CM|SSTU-SC-C-CMX|SSTU_LanderCore_LC5-POD]:FOR[RP-0]
 {
 	MODULE
 	{
@@ -58,7 +58,7 @@
 }
 
 // FIXME do this for anything else Apollo sized
-@PART[FASAApollo_CM|Mark1-2Pod|mk2Cockpit_Standard|mk2Cockpit_Inline|B9_Body_Mk2_Cockpit|B9_Body_Mk2_Cockpit_Intake|B9_Cockpit_M27|B9_Cockpit_MK2|B9_Cockpit_S3|B9_Cockpit_S2|FASAGeminiBigG|FASAGeminiBigGWhite|XOrionPodX|XOrionPodXbb31|LazTekDragonV2|MK2VApod|GuidanceStart4m]:FOR[RP-0]
+@PART[FASAApollo_CM|Mark1-2Pod|mk2Cockpit_Standard|mk2Cockpit_Inline|B9_Body_Mk2_Cockpit|B9_Body_Mk2_Cockpit_Intake|B9_Cockpit_M27|B9_Cockpit_MK2|B9_Cockpit_S3|B9_Cockpit_S2|FASAGeminiBigG|FASAGeminiBigGWhite|XOrionPodX|XOrionPodXbb31|LazTekDragonV2|MK2VApod|GuidanceStart4m|SSTU-SC-B-CM|SSTU-SC-B-CMX|SSTU-SC-A-DM|SSTU_LanderCore_LC3-POD]:FOR[RP-0]
 {
 	MODULE
 	{
@@ -68,7 +68,7 @@
 }
 
 // FIXME do this for other landers
-@PART[FASALM_AscentStage|mk2LanderCabin|MEMLander|SXTLander|bahaMk2LightningCockpit|rn_lk_lander|RO-Mk1Cockpit|RO-Mk1CockpitInline]:FOR[RP-0]
+@PART[FASALM_AscentStage|mk2LanderCabin|MEMLander|SXTLander|bahaMk2LightningCockpit|rn_lk_lander|RO-Mk1Cockpit|RO-Mk1CockpitInline|SSTU-SC-C-SM|SSTU-SC-B-SM|SSTU-SC-A-SM|SSTU-LC2-POD]:FOR[RP-0]
 {
 	MODULE
 	{
@@ -835,5 +835,31 @@
 	{
 		toggleable = true
 		disabledkW = 0.01
+	}
+}
+@PART[ca_vor_core]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 12.0
+	}
+}
+
+@PART[ca_fom_lander]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 2.0
+	}
+}
+
+@PART[ca_linkor]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 12.0
 	}
 }


### PR DESCRIPTION
placed SSTU command pods in their respective avionics class.
Added avionics to SSTU service modules (20 t, same class as small pods), delete this if you consider it inappropriate.
Added avionics to a couple Coatl aerospace parts for the Venera mission.