### PR TITLE
Add flyby contracts for Ceres and Vesta

### DIFF
--- a/GameData/RP-0/Contracts/Flyby Contracts/Ceres Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Ceres Flyby.cfg
@@ -1,0 +1,90 @@
+CONTRACT_TYPE
+{
+	name = flybyCeres
+	title = Ceres Flyby
+	group = Flybys
+	agent = Federation Aeronautique Internationale
+
+	description = Design and successfully launch a probe on a flyby of Ceres with a closest approach of 20,000 km or closer, then record observations and transmit.
+
+	synopsis = Flyby Ceres closer than 20,000 km and transmit science
+
+	completedMessage = Congratulations on the flyby! The data is coming in now.
+
+	sortKey = 824
+
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 1440  // 4 years
+
+	targetBody = Ceres
+
+
+
+	prestige = Significant   // 1.25x
+	advanceFunds = 10000
+	rewardScience = 0
+	rewardReputation = 20
+	rewardFunds = 40000
+	failureReputation = 30
+	failureFunds = 15000
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybyMars
+		title = Complete @contractType Contract
+	}
+
+	// ************ PARAMETERS ************
+
+	PARAMETER
+	{
+		name = VesselGroup
+		type = VesselParameterGroup
+		title = Flyby Ceres
+		define = FlybyCeres
+	
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+			title = Uncrewed
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = FlybyPlanet
+			type = ReachState
+			maxAltitude = 20000000
+			disableOnStateChange = true
+			title = Flyby Ceres within 20,000 km
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = CollectSpaceScience
+			type = CollectScience
+			recoveryMethod = Transmit
+			title = Transmit Science Data from Space near @targetBody
+			hideChildren = true
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Flyby Contracts/Vesta Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Vesta Flyby.cfg
@@ -1,0 +1,90 @@
+CONTRACT_TYPE
+{
+	name = flybyVesta
+	title = Vesta Flyby
+	group = Flybys
+	agent = Federation Aeronautique Internationale
+
+	description = Design and successfully launch a probe on a flyby of Vesta with a closest approach of 20,000 km or closer, then record observations and transmit.
+
+	synopsis = Flyby Vesta closer than 20,000 km and transmit science
+
+	completedMessage = Congratulations on the flyby! The data is coming in now.
+
+	sortKey = 823
+
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 1440  // 4 years
+
+	targetBody = Vesta
+
+
+
+	prestige = Significant   // 1.25x
+	advanceFunds = 10000
+	rewardScience = 0
+	rewardReputation = 20
+	rewardFunds = 40000
+	failureReputation = 30
+	failureFunds = 15000
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = flybyMars
+		title = Complete @contractType Contract
+	}
+
+	// ************ PARAMETERS ************
+
+	PARAMETER
+	{
+		name = VesselGroup
+		type = VesselParameterGroup
+		title = Flyby Vesta
+		define = FlybyVesta
+	
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+			title = Uncrewed
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = FlybyPlanet
+			type = ReachState
+			maxAltitude = 20000000
+			disableOnStateChange = true
+			title = Flyby Vesta within 20,000 km
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = CollectSpaceScience
+			type = CollectScience
+			recoveryMethod = Transmit
+			title = Transmit Science Data from Space near @targetBody
+			hideChildren = true
+		}
+	}
+}


### PR DESCRIPTION
* Based on data from Mars and Jupiter flybys
* 4-year deadline
* Same requirement as Jupiter flyby
* Same altitude (20 Mm) as Mars flyby
