### PR TITLE
Fix for altitude record overwrite issue

### DIFF
--- a/GameData/RP-0/Contracts/Records/AltRecord.cfg
+++ b/GameData/RP-0/Contracts/Records/AltRecord.cfg
@@ -97,17 +97,6 @@ CONTRACT_TYPE
             RP0_SoundingAltitudeIndex = RP0_SoundingAltitudeIndex + 1
         }
     }
-	
-	BEHAVIOUR
-    {
-        name = SetMaxSoundingDifficulty
-        type = Expression
-
-        CONTRACT_COMPLETED_SUCCESS
-        {
-            RP0_SoundingDifficulty = @/newMaxSoundingDifficulty
-        }
-    }
 		
 	BEHAVIOUR
     {


### PR DESCRIPTION
Can't fix this correctly because CC is weird, so now altitude records won't update the sounding difficulty if they beat your current - but at least it won't write an old cached value back to the difficulty and overwrite progress.