### PR TITLE
Fixed missing RN soyuz entries for crew training

### DIFF
--- a/GameData/RP-0/CrewTrainingTimes.cfg
+++ b/GameData/RP-0/CrewTrainingTimes.cfg
@@ -109,6 +109,7 @@ TRAININGTIMES
 	Voskhod = 200, Vostok										// 500
 		Voskhod-Crew-A = Voskhod
 		rn-voskhod-sc = Voskhod
+		rn-voskhod-airlock = Voskhod
 	Voskhod-Mission = 60
 		
 	// Soyuz
@@ -116,6 +117,9 @@ TRAININGTIMES
 		SSTU-SC-A-DM = Soyuz
 		SSTU-SC-A-OM = Soyuz
 		rn-zond-sa = Soyuz
+		ok-sa = Soyuz
+		ok-bo-fem = Soyuz
+		ok-bo-male = Soyuz
 		rn-lok-sa = Soyuz
 		rn-lok-bo = Soyuz
 		t-bo = Soyuz


### PR DESCRIPTION
Fixed missing RN soyuz entries for 7K-OK Descent and Orbital (Male, Female)  modules for the Soyuz training, plus the Voskhod Airlock for the Voskhod training.

Added:
ok-sa = Soyuz
ok-bo-fem = Soyuz
ok-bo-male = Soyuz
rn-voskhod-airlock = Voskhod