### PR TITLE
Add contracts for Navigational Satellites

### DIFF
--- a/GameData/RP-0/Contracts/Early Satellites/First Nav Sat.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/First Nav Sat.cfg
@@ -1,0 +1,100 @@
+CONTRACT_TYPE
+{
+	name = FirstNavSat
+	title = First Navigational Satellite  // Based on Transit 1 through 4
+	group = EarlySatellites
+	agent = Federation Aeronautique Internationale
+
+	description = Through measuring the Doppler shift of radio signals transmitted from a satellite in a known orbit, it is possible for a receiver on the ground to establish their location, which would have many applications both civilian and military.  To test the principle and develop receiver equipment, it is necessary to have a test navigational satellite in orbit.  Be sure to include solar panels and/or an RTG to generate power.  Historically, the first experiments in satellite navigation were made with Transit 1B (119kg, Thor-Ablestar).
+
+	synopsis = Launch the first navigation satellite
+
+	completedMessage = Congratulations!  The satellite is in orbit and we have already begun to receive Doppler curves.
+
+	sortKey = 410
+
+	cancellable = false
+	declinable = false
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 365  // 1 year
+
+	targetBody = HomeWorld()
+
+
+	// ************ REWARDS ************
+	prestige = Trivial       // 1.0x
+	advanceFunds = 5000
+	rewardScience = 0
+	rewardReputation = 5
+	rewardFunds = 10000
+	failureReputation = 2
+	failureFunds = 5000
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = FirstSolarSat
+		title = Complete @contractType Contract
+	}
+
+	PARAMETER
+	{
+		name = FirstNavSat
+		type = VesselParameterGroup
+		title = First Navigational Satellite
+		define = FirstNavSat
+
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+			title = Uncrewed
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = HasNavSatPayload
+			type = HasResource
+			resource = NavSatPayload
+			minQuantity = 100
+			title = Have a NavSatPayload of at least @minQuantity units on the craft
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minInclination = 45
+			minPeA = 300000
+			disableOnStateChange = true
+			title = Achieve Orbit with a minimum inclination of 45 degrees and a minimum Perigee of 300 km
+
+			PARAMETER
+			{
+				name = Duration
+				type = Duration
+
+				duration = 2m
+
+				preWaitText = Check for Stable Orbit
+				waitingText = Checking for Stable Orbit
+				completionText = Stable Orbit: Confirmed
+			}
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Groups.cfg
+++ b/GameData/RP-0/Contracts/Groups.cfg
@@ -78,6 +78,14 @@ CONTRACT_GROUP
     }
 	CONTRACT_GROUP
     {
+        name = NavSats
+        displayName = Navigational Satellite Contracts
+        minVersion = 1.22.2
+		sortKey = 55
+		agent = Satellites
+    }
+	CONTRACT_GROUP
+    {
         name = HumanMilestones
         displayName = Human Milestones
         minVersion = 1.22.2

--- a/GameData/RP-0/Contracts/Nav Sats/Early Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Early Nav Sats.cfg
@@ -1,0 +1,110 @@
+CONTRACT_TYPE
+{
+	name = EarlyNavSats
+	title = Early Navigation Satellite  // Representative of Transit 4 and 5 series
+	group = NavSats
+
+
+	description = Our engineers are once again requesting a new navigational satellite test article.  Please place one into the proper orbit around Earth.  This contract can be completed up to 4 times.
+
+	synopsis = Launch a navigational satellite into the proper orbit
+
+	completedMessage = Success!  We are getting more Doppler curves to refine our navigation algorithms.
+
+	sortKey = 550
+
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 4
+	maxSimultaneous = 1
+	deadline = 365  // 1 year
+
+	targetBody = HomeWorld()
+
+
+	prestige = Trivial       // 1.0x
+	advanceFunds = 10000
+	rewardScience = 0
+	rewardReputation = 10
+	rewardFunds = 5000
+	failureReputation = 10
+	failureFunds = 20000
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = FirstNavSat
+		title = Complete @contractType Contract
+	}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = OperationalNavSats
+		title = Has not Completed @contractType Contract
+		invertRequirement = true
+	}
+
+	// ************ PARAMETERS ************
+
+	PARAMETER
+	{
+		name = EarlyNavSat
+		type = VesselParameterGroup
+		title = Early Navigational Satellite
+
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+			title = Uncrewed
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = HasNavSatPayload
+			type = HasResource
+			resource = NavSatPayload
+			minQuantity = 60
+			title = Have a NavSatPayload of at least @minQuantity units on the craft
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = 800000
+			maxApA = 1000000
+			minInclination = 64.0
+			maxInclination = 70.0
+			disableOnStateChange = true
+			title = Achieve an orbit within the stated parameters
+
+			PARAMETER
+			{
+				name = Duration
+				type = Duration
+
+				duration = 2m
+
+				preWaitText = Check for Stable Orbit
+				waitingText = Checking for Stable Orbit
+				completionText = Stable Orbit: Confirmed
+			}
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Nav Sats/GLONASS Network.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/GLONASS Network.cfg
@@ -2,7 +2,7 @@ CONTRACT_TYPE
 {
 	name = GLONASSnetwork
 	title = GLONASS Network
-	group = AdvSatellites
+	group = NavSats
 	agent = GLONASS
 	
 	description = Using satellites positioned in specific orbits and locations, we can create a system that will provide geolocation and navigation all over Earth. Anywhere on Earth that has line of sight to 4 or more GLONASS satellites will be able to get their precise location.\n\nThis is not a contract to be undertaken lightly. It requires you to launch 24 satellites into 3 different and specific orbits, and to complete it all within six years. Each satellite is required to be able to communicate with all other satellites (only requires one omni-directional antenna) as well as the ground stations. The payout is definitely worth it, but the penalty for failure may bankrupt your space program.\n\n<b><color=white>NOTE: You can only select this contract or the GPS Network contract.</color></b>
@@ -11,7 +11,7 @@ CONTRACT_TYPE
 	
 	completedMessage = Congratulations! With the GLONASS Network fully operational, we now have access to pinpoint location information around the world. What could we possibly use this technology for?
 	
-	sortKey = 904
+	sortKey = 554
 	
 	cancellable = true
 	declinable = true
@@ -41,6 +41,14 @@ CONTRACT_TYPE
 		type = CompleteContract
 		contractType = GeoComSatNetwork
 		title = Complete @contractType Contract
+	}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = SecondGenNavSats
+		title = Complete All @contractType Contracts
+		minCount = 3
 	}
 	REQUIREMENT
 	{

--- a/GameData/RP-0/Contracts/Nav Sats/GPS Network.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/GPS Network.cfg
@@ -2,7 +2,7 @@ CONTRACT_TYPE
 {
 	name = GPSnetwork
 	title = GPS Network
-	group = AdvSatellites
+	group = NavSats
 	agent = GPS
 	
 	description = Using satellites positioned in specific orbits and locations, we can create a system that will provide geolocation and navigation all over Earth. Anywhere on Earth that has line of sight to 4 or more GPS satellites will be able to get their precise location.\n\nThis is not a contract to be undertaken lightly. It requires you to launch 24 satellites into 6 different and specific orbits, and to complete it all within five years. Each satellite is required to be able to communicate with all other satellites (only requires one omni-directional antenna) as well as the ground stations. The payout is definitely worth it, but the penalty for failure may bankrupt your space program.\n\n<b><color=white>NOTE: You can only select this contract or the GLONASS Network contract.</color></b>
@@ -11,7 +11,7 @@ CONTRACT_TYPE
 	
 	completedMessage = Congratulations! With the GPS Network fully operational, we now have access to pinpoint location information around the world. What could we possibly use this technology for?
 	
-	sortKey = 903
+	sortKey = 553
 	
 	cancellable = true
 	declinable = true
@@ -41,6 +41,14 @@ CONTRACT_TYPE
 		type = CompleteContract
 		contractType = GeoComSatNetwork
 		title = Complete @contractType Contract
+	}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = SecondGenNavSats
+		title = Complete All @contractType Contracts
+		minCount = 3
 	}
 	REQUIREMENT
 	{

--- a/GameData/RP-0/Contracts/Nav Sats/Operational Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Operational Nav Sats.cfg
@@ -1,0 +1,266 @@
+CONTRACT_TYPE
+{
+	name = OperationalNavSats
+	title = Operational Navigation System // based on Transit Oscar
+	group = NavSats
+
+
+	description = Our development of Doppler satellite navigation equipment is now complete and we are ready to launch the operational five-satellite constellation into polar orbit.
+
+	synopsis = Launch a constellation of 5 Navigational Satellites
+
+	completedMessage = Congratulations!  All the satellites are operational and giving good fixes.
+
+	sortKey = 551
+
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 1095  // 3 years
+
+	targetBody = HomeWorld()
+
+
+	// ************ REWARDS ************
+	prestige = Significant   // 1.25x
+	advanceFunds = 20000
+	rewardScience = 0
+	rewardReputation = 30
+	rewardFunds = 64000
+
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = EarlyNavSats
+		title = Complete All @contractType Contracts
+		minCount = 4
+	}
+
+	PARAMETER
+	{
+		name = NavSat1
+		type = VesselParameterGroup
+
+		define = NavSat I
+		disableOnStateChange = false
+
+		PARAMETER
+		{
+			name = IsNotVessel
+			type = IsNotVessel
+
+			vessel = NavSat II
+		}
+
+		PARAMETER
+		{
+			name = IsNotVessel
+			type = IsNotVessel
+
+			vessel = NavSat III
+		}
+
+		PARAMETER
+		{
+			name = IsNotVessel
+			type = IsNotVessel
+
+			vessel = NavSat IV
+		}
+
+		PARAMETER
+		{
+			name = IsNotVessel
+			type = IsNotVessel
+
+			vessel = NavSat V
+		}
+
+		PARAMETER
+		{
+			name = HasNavSatPayload
+			type = HasResource
+			resource = NavSatPayload
+			minQuantity = 120
+			title = Have a NavSatPayload of at least 120 units on the craft
+		}
+
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+
+			minPeA = 1020000
+			maxApA = 1080000
+			minInclination = 88.0
+		}
+	}
+
+	PARAMETER
+	{
+		name = NavSat2
+		type = VesselParameterGroup
+
+		define = NavSat II
+		disableOnStateChange = false
+
+		PARAMETER
+		{
+			name = IsNotVessel
+			type = IsNotVessel
+
+			vessel = NavSat III
+		}
+
+		PARAMETER
+		{
+			name = IsNotVessel
+			type = IsNotVessel
+
+			vessel = NavSat IV
+		}
+
+		PARAMETER
+		{
+			name = IsNotVessel
+			type = IsNotVessel
+
+			vessel = NavSat V
+		}
+
+		PARAMETER
+		{
+			name = HasNavSatPayload
+			type = HasResource
+			resource = NavSatPayload
+			minQuantity = 120
+			title = Have a NavSatPayload of at least 120 units on the craft
+		}
+
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+
+			minPeA = 1020000
+			maxApA = 1080000
+			minInclination = 88.0
+		}
+	}
+
+	PARAMETER
+	{
+		name = NavSat3
+		type = VesselParameterGroup
+
+		define = NavSat III
+		disableOnStateChange = false
+
+		PARAMETER
+		{
+			name = IsNotVessel
+			type = IsNotVessel
+
+			vessel = NavSat IV
+		}
+
+		PARAMETER
+		{
+			name = IsNotVessel
+			type = IsNotVessel
+
+			vessel = NavSat V
+		}
+
+		PARAMETER
+		{
+			name = HasNavSatPayload
+			type = HasResource
+			resource = NavSatPayload
+			minQuantity = 120
+			title = Have a NavSatPayload of at least 120 units on the craft
+		}
+
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+
+			minPeA = 1020000
+			maxApA = 1080000
+			minInclination = 88.0
+		}
+	}
+
+	PARAMETER
+	{
+		name = NavSat4
+		type = VesselParameterGroup
+
+		define = NavSat IV
+		disableOnStateChange = false
+
+		PARAMETER
+		{
+			name = IsNotVessel
+			type = IsNotVessel
+
+			vessel = NavSat V
+		}
+
+		PARAMETER
+		{
+			name = HasNavSatPayload
+			type = HasResource
+			resource = NavSatPayload
+			minQuantity = 120
+			title = Have a NavSatPayload of at least 120 units on the craft
+		}
+
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+
+			minPeA = 1020000
+			maxApA = 1080000
+			minInclination = 88.0
+		}
+	}
+
+	PARAMETER
+	{
+		name = NavSat5
+		type = VesselParameterGroup
+
+		define = NavSat V
+		disableOnStateChange = false
+
+		PARAMETER
+		{
+			name = HasNavSatPayload
+			type = HasResource
+			resource = NavSatPayload
+			minQuantity = 120
+			title = Have a NavSatPayload of at least 120 units on the craft
+		}
+
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+
+			minPeA = 1020000
+			maxApA = 1080000
+			minInclination = 88.0
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
@@ -1,0 +1,102 @@
+CONTRACT_TYPE
+{
+	name = SecondGenNavSats
+	title = Second-Generation Navigation Satellite  // Timing-based GPS precursors such as Timation (later NTS)
+	group = NavSats
+
+
+	description = A more accurate technique for satellite navigation is to use Time-Difference Of Arrival of pulsed radio signals.  Please place a new test navigational satellite into the proper orbit around Earth.  This contract can be completed up to 3 times.  Note that these TDOA satellites use ComSatPayload rather than NavSatPayload.
+
+	synopsis = Launch a navigational satellite into the proper orbit
+
+	completedMessage = Success!  The accuracy is so good we found errors in existing geodetic surveys.
+
+	sortKey = 552
+
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 3
+	maxSimultaneous = 1
+	deadline = 365  // 1 year
+
+	targetBody = HomeWorld()
+
+
+	prestige = Trivial       // 1.0x
+	advanceFunds = 12000
+	rewardScience = 0
+	rewardReputation = 10
+	rewardFunds = 16000 + @SecondGenNavSat/HasComSatPayload/minQuantity * 2
+	failureReputation = 10
+	failureFunds = 25000
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = EarlyNavSats
+		title = Complete @contractType Contract at least once
+	}
+
+	// ************ PARAMETERS ************
+
+	PARAMETER
+	{
+		name = SecondGenNavSat
+		type = VesselParameterGroup
+		title = Early Navigational Satellite
+
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+			title = Uncrewed
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = HasComSatPayload
+			type = HasResource
+			resource = ComSatPayload
+			minQuantity = Round(Random(200,250),1)
+			title = Have a ComSatPayload of at least @minQuantity units on the craft
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = 875000
+			maxApA = 925000
+			minInclination = 68.0
+			maxInclination = 72.0
+			disableOnStateChange = true
+			title = Achieve an orbit within the stated parameters
+
+			PARAMETER
+			{
+				name = Duration
+				type = Duration
+
+				duration = 2m
+
+				preWaitText = Check for Stable Orbit
+				waitingText = Checking for Stable Orbit
+				completionText = Stable Orbit: Confirmed
+			}
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/RP0_Contract_Resources.cfg
+++ b/GameData/RP-0/Contracts/RP0_Contract_Resources.cfg
@@ -34,6 +34,18 @@ RESOURCE_DEFINITION
 	volume = 1
 }
 
+RESOURCE_DEFINITION
+{
+	name = NavSatPayload
+	density = 0.00012
+	unitCost = 0.1
+	flowMode = NO_FLOW
+	transfer = NONE
+	isTweakable = true
+	isVisible = true
+	volume = 1
+}
+
 
 
 @TANK_DEFINITION[Fuselage|ServiceModule]:FOR[RP-0]:NEEDS[RealFuels]
@@ -57,6 +69,14 @@ RESOURCE_DEFINITION
 	TANK
 	{
 		name = WeatherSatPayload
+		utilization = 1
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+	}
+	TANK
+	{
+		name = NavSatPayload
 		utilization = 1
 		fillable = True
 		amount = 0.0


### PR DESCRIPTION
The first generation use a new payload type, NavSatPayload, which is of much
 lower density than the other payloads (this is to match the mass and volume
 of the early Transit series of satellites).
The second generation (timing-based) use ComSatPayload, thus minimising the
 changes needed to the GPS and GLONASS contracts which are now moved into
 the navsats group.

Why add these contracts?  To add a bit more variety when grinding satellite
 launches, mainly.