### PR TITLE
Add Avionics to RN Soviet Spacecraft / Salyut / Skylab

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -30,7 +30,7 @@
 	}
 }
 // Vostok/Voskhod
-@PART[Voskhod_Crew_A|IronVostok_Crew_A]:FOR[RP-0]
+@PART[Voskhod_Crew_A|IronVostok_Crew_A|rn_vostok_sc]:FOR[RP-0]
 {
 	MODULE
 	{
@@ -38,6 +38,16 @@
 		massLimit = 6.0
 	}
 }
+// RN Voskhod is heavier than 6t
+@PART[rn_voskhod_sc]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 10.0
+	}
+}
+
 @PART[FASABigGeminiRetroModule]
 {
 	//yes, you can do this without a ModuleCommand
@@ -45,6 +55,26 @@
 	{
 		name = ModuleAvionics
 		massLimit = 50.0
+	}
+}
+
+//RN Soyuz/Progress/Zond
+@PART[ok_sa|tg_sa|rn_zond_sa]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 20.0
+	}
+}
+
+//RN Soyuz LOK
+@PART[rn_lok_sa]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 30.0
 	}
 }
 
@@ -58,7 +88,7 @@
 }
 
 // FIXME do this for anything else Apollo sized
-@PART[FASAApollo_CM|Mark1-2Pod|mk2Cockpit_Standard|mk2Cockpit_Inline|B9_Body_Mk2_Cockpit|B9_Body_Mk2_Cockpit_Intake|B9_Cockpit_M27|B9_Cockpit_MK2|B9_Cockpit_S3|B9_Cockpit_S2|FASAGeminiBigG|FASAGeminiBigGWhite|XOrionPodX|XOrionPodXbb31|LazTekDragonV2|MK2VApod|GuidanceStart4m|SSTU-SC-B-CM|SSTU-SC-B-CMX|SSTU-SC-A-DM|SSTU_LanderCore_LC3-POD]:FOR[RP-0]
+@PART[FASAApollo_CM|Mark1-2Pod|mk2Cockpit_Standard|mk2Cockpit_Inline|B9_Body_Mk2_Cockpit|B9_Body_Mk2_Cockpit_Intake|B9_Cockpit_M27|B9_Cockpit_MK2|B9_Cockpit_S3|B9_Cockpit_S2|FASAGeminiBigG|FASAGeminiBigGWhite|XOrionPodX|XOrionPodXbb31|LazTekDragonV2|MK2VApod|rn_va_capsule|GuidanceStart4m|SSTU-SC-B-CM|SSTU-SC-B-CMX|SSTU-SC-A-DM|SSTU_LanderCore_LC3-POD]:FOR[RP-0]
 {
 	MODULE
 	{
@@ -82,6 +112,26 @@
 	{
 		name = ModuleAvionics
 		massLimit = 20.0
+	}
+}
+
+//RN Salyut1-4,6,7 Almaz3-5
+@PART[salyut1-4|salyut6|salyut7|almaz3-5]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 40.0
+	}
+}
+
+//RN Skylab
+@PART[skylab]:FOR[RP-0]
+{
+	MODULE
+	{
+		name = ModuleAvionics
+		massLimit = 150.0
 	}
 }
 


### PR DESCRIPTION
I added avionics to some RaiderNick parts, including:
Vostok, Voskhod, Soyuz, Zond, Progress, Salyut1-4/6/7, Almaz3-5, Skylab and the VA capsule.

These numbers are mostly made up to go in line with other command pods.

This is my first ever PR so please let me know if i did something wrong.
