### PR TITLE
ProcTankSpaceplane: added tooling

### DIFF
--- a/GameData/RP-0/Parts/RFProcTanks.cfg
+++ b/GameData/RP-0/Parts/RFProcTanks.cfg
@@ -423,8 +423,40 @@
 	}
 }
 
+@PART[RO-ProcTankSpaceplane]:FOR[RP-0]
+{
+	@MODULE[ProceduralPart]
+	{
+                !TECHLIMIT,* {}
+                %TECHLIMIT
+                {
+                        name = start
+                        diameterMin = 0.01
+                        diameterMax = Infinity
+                        lengthMin = 0.01
+                        lengthMax = Infinity
+                        volumeMin = 0.001
+                        volumeMax = Infinity
+                }
+	}
+        @MODULE[ModuleFuelTanks]
+        {
+                %maxUtilization = 92
+                %utilization = 92
+        }
+	MODULE
+	{
+		name = ModuleToolingPTank
+		toolingType = TankShielded
+		untooledMultiplier = 0.25
+		finalToolingCostMultiplier = 1.375 // more than balloon, less than SM
+	}
+
+}
+
 @PART[proceduralTankRealFuels]:FOR[zzzRP-0]
 {
 	%category = -1
 	%techRequired = ORPHANS
 }
+


### PR DESCRIPTION
Problem: 
Shielded Proctank was not part of the general RP-1 overhaul and still uses the old system of unlocking sizes by techlevel (no tooling). Also has 100% utilization.

Solution:
Retrofitted tooling and applied a max utilization.