### PR TITLE
Crew Science requirements

### DIFF
--- a/GameData/RP-0/Science/CrewScience/Experiments/BasicCapsuleExperiments.cfg
+++ b/GameData/RP-0/Science/CrewScience/Experiments/BasicCapsuleExperiments.cfg
@@ -16,7 +16,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = Very little is known about how liquids behave in a microgravity environment. Various tests are needed to analyze the liquids to properly design fluid storage tanks in the future. <b>NOTE: Experiment takes 2 hours of Crew Observations to complete</b>
     mass = 0.004
-    techRequired = basicCapsules
+    techRequired = start
     cost = 0
     tags = basicCapsule
     minCrew = 1
@@ -40,7 +40,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = Maneuvering in space will be very important if we want to continue our exploration. We need the crew member to see how the spacecraft reacts and maneuvers with yaw, pitch and roll controls. <b>This experiment can be completed twice. NOTE: Experiment takes 1 hour of Crew Observations to complete</b>
     mass = 0.001
-    techRequired = basicCapsules
+    techRequired = earlyFlightControl
     cost = 0
     tags = basicCapsule
     minCrew = 1
@@ -64,7 +64,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = This experiment is designed to test how well humans can track objects in space. A multicolor, mylar balloon, about the size of a beach ball, will be extended on a tether for the crew member to track. <b>This experiment can be completed twice. NOTE: Experiment takes 2 hours of Crew Observations to complete</b>
     mass = 0.003
-    techRequired = basicCapsules
+    techRequired = start
     cost = 0
     tags = basicCapsule
     minCrew = 1
@@ -88,7 +88,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = By using a hand-held camera, our crew can take images of locations on Earth that our scientists are intersted in. These images can be of much higher quality than our current satellite technology can accomplish. <b>This experiment can be completed four times. NOTE: Experiment takes 1 hour of Crew Observations to complete</b>
     mass = 0.005
-    techRequired = basicCapsules
+    techRequired = start
     cost = 0
     tags = basicCapsule
     minCrew = 1

--- a/GameData/RP-0/Science/CrewScience/Experiments/MatureCapsuleExperiments.cfg
+++ b/GameData/RP-0/Science/CrewScience/Experiments/MatureCapsuleExperiments.cfg
@@ -16,7 +16,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = To broadcast live television while in route to the Moon.<b>This experiment can be completed once. NOTE: This experiment takes 2 hours and you must be higher than 50,000 km.</b>
     mass = 0.01
-    techRequired = matureCapsules
+    techRequired = lunarRangeComms
     cost = 0
     tags = matureCapsule
     minCrew = 3
@@ -41,7 +41,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = To investigate determination of spacecraft attitude in yaw and pitch from measurement of ion flow variations. The recording of ion sensor outputs during pitch and yaw maneuvers will be compared with data obtained from the inertial guidance system and the horizon scanner. Results of the comparison and the astronaut evaluation will form the basis for further development of simple, lightweight orbital attitude determination systems.<b>This experiment can be completed once. NOTE: This experiment takes 48 hours.</b>
     mass = 0
-    techRequired = matureCapsules
+    techRequired = electronicsHuman
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -65,7 +65,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = To test the usefulness and performance of a low-light-level television system as a supplement to unaided vision in observing surface features primarily when such features are in darkness and spacecraft pilots are not dark-adapted.<b>This experiment can be completed once. NOTE: This experiment takes 12 hours.</b>
     mass = 0.01
-    techRequired = matureCapsules
+    techRequired = electronicsHuman
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -89,7 +89,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = Crew photgraphs of land and ocean areas for geologic, geographic, and oceanographic study for evaluation of various film types<b>This experiment can be completed 3 times. NOTE: This experiment takes 12 hours.</b>
     mass = 0.008
-    techRequired = matureCapsules
+    techRequired = start
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -113,7 +113,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = Crew photographs of global and local weather systems for use by scientists in improving techniques of interpretation of orbital altitude weather photographs.<b>This experiment can be completed 3 times. NOTE: This experiment takes 12 hours.</b>
     mass = 0.008
-    techRequired = matureCapsules
+    techRequired = start
     cost = 0
     tags = secondGenCapsule
     minCrew = 2

--- a/GameData/RP-0/Science/CrewScience/Experiments/SecondGenExperiments.cfg
+++ b/GameData/RP-0/Science/CrewScience/Experiments/SecondGenExperiments.cfg
@@ -14,9 +14,9 @@ EXPERIMENT_DEFINITION
     requireAtmosphere = False
     situationMask = 16
     biomeMask = 0
-    description = It will be necessary for our future spacecraft to be able to change their oribts in order to rendezvous and dock. This experiment will test the Orbital Maneuvering system to better understand what is required and possible.<b>This experiment can be completed twice. NOTE: This experiment takes 2 hours.</b>
+    description = It will be necessary for our future spacecraft to be able to change their orbits in order to rendezvous and dock. This experiment will test the Orbital Maneuvering system to better understand what is required and possible.<b>This experiment can be completed twice. NOTE: This experiment takes 2 hours.</b>
     mass = 0
-    techRequired = secondGenCapsules
+    techRequired = earlyFlightControl
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -40,7 +40,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = The visual ability of the astronauts in the detection and recognition of objects on the Earth's surface will be tested.<b> This experiment can be completed three times. NOTE: This experiment takes 2 hours.</b>
     mass = 0.002
-    techRequired = secondGenCapsules
+    techRequired = start
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -62,9 +62,9 @@ EXPERIMENT_DEFINITION
     requireAtmosphere = False
     situationMask = 16
     biomeMask = 0
-    description = To study the deasibility and operational value of start occulting measurements in the development of a simple, accurate, and self-contained navigational capability by measuring the time starts dip behind an established horizon.<b>This experiment can be completed twice. NOTE: This experiment takes 24 hours.</b>
+    description = To study the deasibility and operational value of start occulting measurements in the development of a simple, accurate, and self-contained navigational capability by measuring the time stars dip behind an established horizon.<b>This experiment can be completed twice. NOTE: This experiment takes 24 hours.</b>
     mass = 0.008
-    techRequired = secondGenCapsules
+    techRequired = earlyFlightControl
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -88,7 +88,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = To determine man's ability to perform work tasks in pressurized suit under zero gravity.<b>This experiment can be completed twice. NOTE: This experiment takes 24 hours.</b>
     mass = 0
-    techRequired = secondGenCapsules
+    techRequired = materialsScienceHuman
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -112,7 +112,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = This experiment is designed to explore the possibility of the existence of a graviational field effect on cells exposed to microgravity situations. These irregularites would be easier to explore in simple cell systems.<b> This experiment can be completed once. NOTE: This experiment takes 3 hours.</b>
     mass = 0.001
-    techRequired = secondGenCapsules
+    techRequired = materialsScienceHuman
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -136,7 +136,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = The objective is to examine the biological effects of radiation. The experiment will test the possibility that weightlessness interacts with radiation to produce unpredicted effects greater than the sum of their individual effects.<b> This experiment can be completed twice. NOTE: This experiment takes 48 hours.</b>
     mass = 0
-    techRequired = secondGenCapsules
+    techRequired = start
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -160,7 +160,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = The objectives of this experiment are to assess the crew's state of alertness, levels of conciousness, and depth of sleep during flight.<b>This experiment can be completed twice. NOTE: This experiment takes 72 hours.</b>
     mass = 0
-    techRequired = secondGenCapsules
+    techRequired = start
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -184,7 +184,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = Our scientists have come up with a fancy way of packaging food for consumption in space. We need the crew to evaluate how the trip to space has affected this packaging and the quality of the food.<b> This experiment can be completed once. NOTE: This experiment takes 1 hour.</b>
     mass = 0.001
-    techRequired = secondGenCapsules
+    techRequired = start
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -206,9 +206,9 @@ EXPERIMENT_DEFINITION
     requireAtmosphere = False
     situationMask = 16
     biomeMask = 0
-    description = The astronauts will use a bungee cord to assess theircapacity to do physical work under space flight conditions.<b> This experiment can be completed twice. NOTE: This experiment takes 1 hour.</b>
+    description = The astronauts will use a bungee cord to assess their capacity to do physical work under space flight conditions.<b> This experiment can be completed twice. NOTE: This experiment takes 1 hour.</b>
     mass = 0.003
-    techRequired = secondGenCapsules
+    techRequired = start
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -232,7 +232,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = Study the capability of crew to provide a reliable method of navigation without input from the ground utilizing a space stedimeter and a sextant.<b>This experiment can be completed twice. NOTE: This experiment takes 12 hours.</b>
     mass = 0.005
-    techRequired = secondGenCapsules
+    techRequired = start
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -256,7 +256,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = To obtain photographs of zodiacal light, airglow layer, and other dim light phenomena, including day sky brightness from orbital altitude.<b>This experiment can be completed twice. NOTE: This experiment takes 12 hours.</b>
     mass = 0.008
-    techRequired = secondGenCapsules
+    techRequired = start
     cost = 0
     tags = secondGenCapsule
     minCrew = 2
@@ -280,7 +280,7 @@ EXPERIMENT_DEFINITION
     biomeMask = 0
     description = To obtain information on communication systems operating through the ionosphere.<b>This experiment can be completed twice. NOTE: This experiment takes 12 hours.</b>
     mass = 0.005
-    techRequired = secondGenCapsules
+    techRequired = lunarRangeComms
     cost = 0
     tags = secondGenCapsule
     minCrew = 2

--- a/GameData/RP-0/Science/CrewScience/LabConfigs.cfg
+++ b/GameData/RP-0/Science/CrewScience/LabConfigs.cfg
@@ -9,7 +9,7 @@ RP0-LAB-TEMPLATE
 	author = Angel-125, Pap
 	shortName = BasicCapsule
 	title = Basic Capsule
-	techRequired = basicCapsules
+	techRequired = start
 	mass = 0.0
 	requiredResource = Equipment
 	requiredAmount = 1
@@ -123,7 +123,7 @@ RP0-LAB-TEMPLATE
 	author = Angel-125, Pap
 	shortName = 2ndGenCapsule
 	title = Second Generation Capsule
-	techRequired = secondGenCapsules
+	techRequired = start
 	mass = 0.0
 	requiredResource = Equipment
 	requiredAmount = 1
@@ -254,7 +254,7 @@ RP0-LAB-TEMPLATE
 	author = Angel-125, Pap
 	shortName = MatureCapsule
 	title = Mature Capsule
-	techRequired = matureCapsules
+	techRequired = start
 	mass = 0.0
 	requiredResource = Equipment
 	requiredAmount = 1


### PR DESCRIPTION
There's several entry requirements for crew science:
- Part has to be configured with a "Lab" module. These come in three classes which are mostly proxies for size.
- Each class of lab module has a techlevel requirement.
- individual experiments each require a particular class of lab AND have a tech requirement.

This PR removes the second requirement by moving all Labs to be at the "start" node (you still need to get a sufficiently large module into orbit to do the experiments, and three small ones don't stack)

Further, I attempted to put a reasonable tech requirement on the experiments.

