### PR TITLE
More CrewScience Labs

### DIFF
--- a/GameData/RP-0/Science/CrewScience/CrewLabAdder.cfg
+++ b/GameData/RP-0/Science/CrewScience/CrewLabAdder.cfg
@@ -68,7 +68,7 @@ RESOURCE_DEFINITION
 //**********************************************************************************
 // 	SECOND GEN CAPSULES
 //**********************************************************************************
-@PART[FASAGeminiPod2|FASAGeminiPod2White|K2Pod|Voskhod_Crew_A|RO-Mk1CrewModule|RO-Mk1CockpitInline]:FOR[RP-0]
+@PART[FASAGeminiPod2|FASAGeminiPod2White|K2Pod|Voskhod_Crew_A|RO-Mk1CrewModule|RO-Mk1CockpitInline|RO-Mk1Cockpit]:FOR[RP-0]
 {	
 	MODULE
 	{

--- a/GameData/RP-0/Science/CrewScience/CrewLabAdder.cfg
+++ b/GameData/RP-0/Science/CrewScience/CrewLabAdder.cfg
@@ -23,7 +23,7 @@ RESOURCE_DEFINITION
 //**********************************************************************************
 // 	BASIC CAPSULES
 //**********************************************************************************
-@PART[orbitaiespod|moduldesspod|FASAMercuryPod|mk1pod|IronVostok_Crew_A]:FOR[RP-0]
+@PART[orbitaiespod|moduldesspod|FASAMercuryPod|mk1pod|IronVostok_Crew_A|Mark2Cockpit|Mark1Cockpit|KerbCan]:FOR[RP-0]
 {	
 	MODULE
 	{
@@ -68,7 +68,7 @@ RESOURCE_DEFINITION
 //**********************************************************************************
 // 	SECOND GEN CAPSULES
 //**********************************************************************************
-@PART[FASAGeminiPod2|FASAGeminiPod2White|K2Pod|Voskhod_Crew_A]:FOR[RP-0]
+@PART[FASAGeminiPod2|FASAGeminiPod2White|K2Pod|Voskhod_Crew_A|RO-Mk1CrewModule|RO-Mk1CockpitInline]:FOR[RP-0]
 {	
 	MODULE
 	{
@@ -96,7 +96,7 @@ RESOURCE_DEFINITION
 //**********************************************************************************
 // 	MATURE CAPSULES
 //**********************************************************************************
-@PART[FASAGeminiBigG|FASAGeminiBigGWhite|SSTU-SC-A-OM|bluedog_Apollo_Block2_Capsule|FASAApollo_CM|SSTU-SC-B-CM|Mark1-2Pod|rn_lok_bo|t_af_bo|SSTU-SC-B-CMX|rn_astp_bo|bluedog_Apollo_Block3_Capsule|MK2VApod|rn_va_capsule|SOYUZ_orbitalSegment|mk3-9pod|SSTU-SC-C-CM|SSTU-SC-C-CMX|XOrionPodXbb31|XOrionPodX|inlineCmdPod|CST-100?capsule]:FOR[RP-0]
+@PART[FASAGeminiBigG|FASAGeminiBigGWhite|SSTU-SC-A-OM|bluedog_Apollo_Block2_Capsule|FASAApollo_CM|SSTU-SC-B-CM|Mark1-2Pod|rn_lok_bo|t_af_bo|SSTU-SC-B-CMX|rn_astp_bo|bluedog_Apollo_Block3_Capsule|MK2VApod|rn_va_capsule|SOYUZ_orbitalSegment|mk3-9pod|SSTU-SC-C-CM|SSTU-SC-C-CMX|XOrionPodXbb31|XOrionPodX|inlineCmdPod|CST-100?capsule|MK1CrewCabin|mk2Cockpit_Standard|mk2Cockpit_Inline|mk2CrewCabin|mk3Cockpit_Shuttle]:FOR[RP-0]
 {	
 	MODULE
 	{


### PR DESCRIPTION
Equips more parts with the WBIConvertibleMPL part module. Requires https://github.com/KSP-RO/RP-0/pull/881 or it won't work.

I've used the incredibly scientific method of assigning them according to crew capacity: 1 - basic, 2 - 2ndGen, 3+ mature