### PR TITLE
Create README.md

### DIFF
--- a/GameData/RP-0/Contracts/README.md
+++ b/GameData/RP-0/Contracts/README.md
@@ -1,0 +1,2 @@
+// New Commercial Satellite contracts for various orbits and planets with user selectable payload quantities (orbits and payloads affect rewards).
+//  cmlSat contracts for several earth orbits, inner planets, and each outerplanet system (ex: Jupiter and its moons)


### PR DESCRIPTION
New Commercial Satellite (cmlSat) contracts:

GOALS:

-the player to be able to control the desired contract payload.  This way if they only have a small payload capacity they can set the contracts to utilize a low quantity, and if they build a heavy launcher then they can also set the contracts up to a high quantity (and rewards are tied to this).

-wanted something that is also useful for playing out of launch sites away from equator (ie so that you could prioritize molniya or tundra for example, since GEO may not be practical from high latitudes until much later). 

Overview of these new contracts:
-player can set (increase/decrease) desired payload quantities for all future generated commercial satellite contracts.  Does not change existing (accepted) contracts
 
-Each cmlSat contract offering has its own unlocks; Example molniya requires first molniya sat to be complete, MEO requiring a LEO completion, other planets require their respective first orbit.  There are also requirements shared - comTestSat has been completed 3 times.

- Rewards are tied to orbits and the payload quantity.  They start at a lower base value and are scaled a bit stronger on payload quantity than the existing 'advComSat' contract because larger payloads necessitate larger rockets which in turn have longer build times as well.  (Launching a payload that is 800% as large should have more incentive than the current 50% reward increase).

- Earth orbits of:  LEO, MEO, HEO, Molniya, Tundra, Synchronous, Stationary. 

- Other Random orbits around:  Inners (rand between Mercury, Venus, Mars, Ceres), Each outer System inclusive of moons (ie Jupiter, Saturn, and the respective moons) - with weighted choice chance to favor choosing the main planet over moon)
