### PR TITLE
Add HG-3 Configs to Tree

### DIFF
--- a/GameData/RP-0/Tree/TREE-Engine_Configs.cfg
+++ b/GameData/RP-0/Tree/TREE-Engine_Configs.cfg
@@ -1650,3 +1650,13 @@
         { %techRequired = advancedNuclearPropulsion }
     }
 }
+@PART[*]:HAS[#engineType[HG-3]:FOR[xxxRP0]
+{
+    @MODULE[ModuleEngineConfigs]
+    {
+        @CONFIG[HG-3]
+        { %techRequired = hydrolox1976 }
+        @CONFIG[HG-3-SL]
+        { %techRequired = hydrolox1976 }
+     }
+}


### PR DESCRIPTION
Adds tech tree support for the HG-3 configurations on SXT parts, and on future parts the HG-3 configurations are added to.