### PR TITLE
Fix Surface Base Contracts

### DIFF
--- a/GameData/RP-0/Contracts/Surface Outposts/MarsOutpost.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MarsOutpost.cfg
@@ -2,7 +2,7 @@ CONTRACT_TYPE
 {
 	name = MarsSurfaceOutpost
 	title = Martian Surface Outpost
-	group = SurfaceOutposts
+	group = SurfaceBases
 	agent = Base Construction
 
 	description = Design, build, launch, and land a surface outpost on Mars. Keep it crewed for a month.

--- a/GameData/RP-0/Contracts/Surface Outposts/MarsOutpostWithLab.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MarsOutpostWithLab.cfg
@@ -2,7 +2,7 @@ CONTRACT_TYPE
 {
 	name = MarsSurfaceOutpostLab
 	title = Expanded Martian Surface Outpost
-	group = SurfaceOutposts
+	group = SurfaceBases
 	agent = Base Construction
 
 	description = Design, build, launch, and land a large surface outpost on Mars. It needs to have a science lab and room for 10 kerbals, with 4 onboard.

--- a/GameData/RP-0/Contracts/Surface Outposts/MoonOutpost.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MoonOutpost.cfg
@@ -2,7 +2,7 @@ CONTRACT_TYPE
 {
 	name = MoonSurfaceOutpost
 	title = Lunar Surface Outpost
-	group = SurfaceOutposts
+	group = SurfaceBases
 	agent = Base Construction
 
 	description = Design, build, launch, and land a surface outpost on the moon. Keep it crewed for a month.

--- a/GameData/RP-0/Contracts/Surface Outposts/MoonOutpostWithLab.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MoonOutpostWithLab.cfg
@@ -2,7 +2,7 @@ CONTRACT_TYPE
 {
 	name = MoonSurfaceOutpostLab
 	title = Expanded Lunar Surface Outpost
-	group = SurfaceOutposts
+	group = SurfaceBases
 	agent = Base Construction
 
 	description = Design, build, launch, and land a large surface outpost on the Moon. It needs to have a science lab and room for 10 kerbals, with 4 onboard.


### PR DESCRIPTION
The group name was not matching the group definition by RP-0. They were not showing in the RP-0 group and were red. Now they are appearing correctly.
![screenshot663](https://user-images.githubusercontent.com/34808675/45782915-f8b68080-bc6c-11e8-8ab0-23ae6cbae768.png)
