### PR TITLE
Why do I need <3 empty seats?

### DIFF
--- a/GameData/RP-0/Contracts/Space Stations/Power Module Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Power Module Station.cfg
@@ -53,7 +53,7 @@ CONTRACT_TYPE
 		requiredValue = true
 		hidden = true
 		uniquenessCheck = GROUP_ACTIVE
-		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station && v.EmptyCrewSpace()<3 && v.FreeDockingPorts()>0).SelectUnique()
+		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station &&  v.FreeDockingPorts()>0).SelectUnique()
 		title = Must have a station with less than 3 empty seats
 	}
 	DATA

--- a/GameData/RP-0/Contracts/Space Stations/Power Module Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Power Module Station.cfg
@@ -54,7 +54,7 @@ CONTRACT_TYPE
 		hidden = true
 		uniquenessCheck = GROUP_ACTIVE
 		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station &&  v.FreeDockingPorts()>0).SelectUnique()
-		title = Must have a station with less than 3 empty seats
+		title = Must have a station 
 	}
 	DATA
 	{


### PR DESCRIPTION
Warning: when I had this locally, this contract somehow seems to have blocked the New Crew Station contract to appear. Do you have an idea why? 