### PR TITLE
reduce Crazy rewards for flight duration

### DIFF
--- a/GameData/RP-0/Contracts/Human Records/CrewedDurationRecord.cfg
+++ b/GameData/RP-0/Contracts/Human Records/CrewedDurationRecord.cfg
@@ -19,13 +19,15 @@ CONTRACT_TYPE
     prestige = Trivial
 
     targetBody = HomeWorld()
+// - Not sure whether this should be limited to the homeworld. A trip to the moon should be at least equally rewarding. 
+// But I dont know how to change that - glilienthal.
 
     // Can only have one active
     maxSimultaneous = 1
 
     // Contract rewards
-    rewardFunds = 20000.0 + @crewedTargetDurationNum * 20000
-    rewardReputation = 30.0 + @crewedTargetDurationNum * 2
+    rewardFunds = 20000.0 + @crewedTargetDurationRew * 20000
+    rewardReputation = 30.0 + @crewedTargetDurationRew * 2
 
     DATA
     {
@@ -37,9 +39,17 @@ CONTRACT_TYPE
     DATA
     {
         type = List<float>
-
         crewedDurationsNum = [ 1, 2, 3, 7, 14, 30, 60, 90, 180, 365 ]
     }
+
+    DATA
+	// Rewards	
+    {
+        type = List<float>
+        crewedDurationsRew = [ 1, 2, 3, 5,  7, 10, 15, 20,  20,  20 ]
+	// beyond a certain point Rewards don't really go up. 	
+    }
+
 
     // Break this into two steps to work around ContractConfigurator#260
     DATA
@@ -62,6 +72,14 @@ CONTRACT_TYPE
 
         crewedTargetDurationNum = @crewedDurationsNum.ElementAt(@crewedDurationIndex)
     }
+
+    DATA
+    {
+        type = float
+
+        crewedTargetDurationRew = @crewedDurationsRew.ElementAt(@crewedDurationIndex)
+    }
+
     PARAMETER
     {
         name = VesselGroup


### PR DESCRIPTION
The current rewards for flight duration are dominating all my contract rewards. 180days gives me 7,200,000 funds.  A year would double that.  (In my settings a moon landing is significantly less than that.) 

Considering that long-time spaceflights are not a  difficult thing in gameplay, I think this should be changed to an approach that is less than linear. 