### PR TITLE
Added settings for disabling crew training and retirement features

### DIFF
--- a/Source/Crew/FSGUI.cs
+++ b/Source/Crew/FSGUI.cs
@@ -109,9 +109,13 @@ namespace RP0.Crew
                 GUILayout.Label(course, GUILayout.Width(96));
                 GUILayout.Label(complete, GUILayout.Width(80));
                 if (CrewHandler.Instance.kerbalRetireTimes.ContainsKey(student.name))
-                    retires = KSPUtil.PrintDate(CrewHandler.Instance.kerbalRetireTimes[student.name], false);
+                {
+                    retires = CrewHandler.Instance.retirementEnabled ? KSPUtil.PrintDate(CrewHandler.Instance.kerbalRetireTimes[student.name], false) : "(n/a)";
+                }
                 else
+                {
                     retires = "(unknown)";
+                }
                 GUILayout.Label(retires, GUILayout.Width(80));
                 if (currentCourse != null) {
                     if (currentCourse.seatMin > 1) {
@@ -213,7 +217,7 @@ namespace RP0.Crew
             GUILayout.BeginHorizontal();
             try {
                 GUILayout.Label(String.Format("{0} {1:D}", selectedNaut.trait, selectedNaut.experienceLevel.ToString()));
-                if (CrewHandler.Instance.kerbalRetireTimes.ContainsKey(selectedNaut.name)) {
+                if (CrewHandler.Instance.retirementEnabled && CrewHandler.Instance.kerbalRetireTimes.ContainsKey(selectedNaut.name)) {
                     GUILayout.Space(8);
                     GUILayout.Label(String.Format("Retires NET {0}", KSPUtil.PrintDate(CrewHandler.Instance.kerbalRetireTimes[selectedNaut.name], false)),
                                     rightLabel);

--- a/Source/DifficultyPresets.cs
+++ b/Source/DifficultyPresets.cs
@@ -33,4 +33,37 @@ namespace RP0
             Debug.Log("[RP-0]: Reset difficulty presets.");
         }
     }
+
+    public class RP0Settings : GameParameters.CustomParameterNode
+    {
+        public override string Title { get { return "General Settings"; } }
+        public override GameParameters.GameMode GameMode { get { return GameParameters.GameMode.CAREER; } }
+        public override string Section { get { return "RP-0"; } }
+        public override string DisplaySection { get { return "RP-0"; } }
+        public override int SectionOrder { get { return 1; } }
+        public override bool HasPresets { get { return true; } }
+
+        [GameParameters.CustomParameterUI("Crews require training")]
+        public bool IsTrainingEnabled = true;
+
+        [GameParameters.CustomParameterUI("Enable crew retirement", toolTip = "Re-enabling this option can cause some of the older crewmembers to instantly retire.")]
+        public bool IsRetirementEnabled = true;
+
+        public override void SetDifficultyPreset(GameParameters.Preset preset)
+        {
+            switch (preset)
+            {
+                case GameParameters.Preset.Easy:
+                    IsTrainingEnabled = false;
+                    IsRetirementEnabled = false;
+                    break;
+                case GameParameters.Preset.Normal:
+                case GameParameters.Preset.Moderate:
+                case GameParameters.Preset.Hard:
+                    IsTrainingEnabled = true;
+                    IsRetirementEnabled = true;
+                    break;
+            }
+        }
+    }
 }

--- a/Source/KCTBinderModule.cs
+++ b/Source/KCTBinderModule.cs
@@ -34,7 +34,9 @@ namespace RP0
             if (pcm == null)
                 return false;
 
-            if (EntryCostStorage.GetCost(partName) == 1)
+            bool requireTraining = HighLogic.CurrentGame.Parameters.CustomParams<RP0Settings>().IsTrainingEnabled;
+
+            if (!requireTraining || EntryCostStorage.GetCost(partName) == 1)
                 return true;
 
             partName = Crew.TrainingDatabase.SynonymReplace(partName);

--- a/Source/Maintenance/MaintenanceGUI.cs
+++ b/Source/Maintenance/MaintenanceGUI.cs
@@ -221,7 +221,7 @@ namespace RP0
                     GUILayout.Space(40);
                     double rt = Crew.CrewHandler.Instance.kerbalRetireTimes[name];
                     GUILayout.Label(name, HighLogic.Skin.label, GUILayout.Width(120));
-                    GUILayout.Label(KSPUtil.PrintDate(rt, false), HighLogic.Skin.label, GUILayout.Width(80));
+                    GUILayout.Label(Crew.CrewHandler.Instance.retirementEnabled ? KSPUtil.PrintDate(rt, false) : "(n/a)", HighLogic.Skin.label, GUILayout.Width(80));
                 } finally {
                     GUILayout.EndHorizontal();
                 }


### PR DESCRIPTION
Added options into the game's difficulty settings menu for toggling the RP-1 crew training and automatic retirement features. I know that a lot of people (including me) would prefer to play without having to micromanage their crews. This commit adds the option for disabling either of these features. For new games, these options are now by-default disabled on 'easy' difficult but 'normal' and above  still has them turned on.

The training and retirement updates are still done in the background. Also beware that because retirement dates are unaffected, re-enabling the retirement feature after playing for 10 years can cause most of the old nauts to retire almost instantly. But I thought that it's a better option than increasing the retirement deadline that gets stored for each individual crewmember.

Here's how it looks ingame:
![screenshot](https://i.imgur.com/GjPijSc.png "KSP settings")