### PR TITLE
Update GameData/RP-0/Tree/TREE-Parts.cfg

### DIFF
--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -21069,9 +21069,9 @@
 @PART[rn_lro]:FOR[xxxRP0]
 {
     %TechRequired = modernAvionics
-    %cost = 6500
-    %entryCost = 500
-    RP0conf = false
+    %cost = 3700
+    %entryCost = 74000
+    RP0conf = true
     @description ^=:$: <b><color=green>From RN US Probes mod</color></b>
 }
 @PART[CXA_RTAS_A]:FOR[xxxRP0]
@@ -21709,9 +21709,9 @@
 @PART[rn_juno_spacecraft]:FOR[xxxRP0]
 {
     %TechRequired = modernAvionics
-    %cost = 6500
-    %entryCost = 500
-    RP0conf = false
+    %cost = 7702
+    %entryCost = 154041
+    RP0conf = true
     @description ^=:$: <b><color=green>From RN US Probes mod</color></b>
 }
 @PART[XDRAGON--ADAPTERX]:FOR[xxxRP0]
@@ -22027,9 +22027,9 @@
 @PART[rn_ladee]:FOR[xxxRP0]
 {
     %TechRequired = modernAvionics
-    %cost = 6500
-    %entryCost = 500
-    RP0conf = false
+    %cost = 1893
+    %entryCost = 37861
+    RP0conf = true
     @description ^=:$: <b><color=green>From RN US Probes mod</color></b>
 }
 @PART[noseConeAdapter]:FOR[xxxRP0]


### PR DESCRIPTION
Changed EntryCost/ Cost for rn_ladee/rn_juno_spacecraft and rn_lro
juno:
https://www.jpl.nasa.gov/news/press_kits/juno/facts/ entrycost: 1100 Mio $ =2011to1965/1000= 154.041$
lro: 
https://www.cnet.com/news/atlas-5-rocket-launches-nasa-moon-mission/ entrycost: 504 Mio $ =2009to1965/1000= 74000$
ladee: 
https://www.nasa.gov/sites/default/files/files/LADEE-Press-Kit-08292013.pdf entrycost: 280 Mio $ =2013to1965/1000= 37861$