### PR TITLE
Have Tank-III be cost-reduced by Tank-II, not Tank-I and SM-I

### DIFF
--- a/GameData/RP-0/Contracts/Early Satellites/Tundra Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Tundra Satellite.cfg
@@ -101,7 +101,7 @@ CONTRACT_TYPE
 		{
 			name = ReachOrbit
 			type = Orbit
-			title = Reach the correct orbit within the parameters. Note, the Argument of Periapsis values mean that the Apogee needs to be high in the northern latitudes. Since you have already completed the Molniya Orbit, this is the same type of orbit, but with an orbital period the same as an Earth sidreal day.
+			title = Reach the correct orbit within the parameters. Note, the Argument of Periapsis values mean that the Apogee needs to be high in the northern latitudes. Since you have already completed the Molniya Orbit, this is the same type of orbit, but with an orbital period the same as an Earth sidereal day.
 			minInclination = 61.4
 			maxInclination = 65.4
 			minEccentricity = 0.3

--- a/GameData/RP-0/Parts/RFProcTanks.cfg
+++ b/GameData/RP-0/Parts/RFProcTanks.cfg
@@ -123,7 +123,7 @@
 		toolingType = Tank-III
 		untooledMultiplier = 0.25
 		finalToolingCostMultiplier = 0.75
-		costReducers = Tank-II
+		costReducers = Tank-II, SM-I
 	}
 	@MODULE[ProceduralPart]
 	{

--- a/GameData/RP-0/Parts/RFProcTanks.cfg
+++ b/GameData/RP-0/Parts/RFProcTanks.cfg
@@ -123,7 +123,7 @@
 		toolingType = Tank-III
 		untooledMultiplier = 0.25
 		finalToolingCostMultiplier = 0.75
-		costReducers = Tank-I,SM-I
+		costReducers = Tank-II
 	}
 	@MODULE[ProceduralPart]
 	{


### PR DESCRIPTION
@pap1723 

I'm not sure why SM-I would have been in the cost reduction list for a non-SM tank. Maybe something related to the fact that the original sounding rocket payloads are in Tank-I-HP, but if anything, I would see that as a reason to have SM-1 be cost-reduced by Tank-I. I'm guessing this was just an oversight.
