### PR TITLE
Let Sounding Rocket (Altitude) reach its maximum

### DIFF
--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingAltitude.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingAltitude.cfg
@@ -62,7 +62,7 @@ CONTRACT_TYPE
 	DATA
 	{ //extend the max possible height by a factor based off the current max
 		type = int
-		targetAltitudeKM = int( Min(6000, @targetAltitudeKMInternal))
+		targetAltitudeKM = int( Min(10000, @targetAltitudeKMInternal))
 	}
 	
 	DATA


### PR DESCRIPTION
Contract used to be repeatable until 6Mm, is now repeatable until 10Mm. That means the max target must also be 10Mm, otherwise the limit is never reached and the contract is repeatable forever.