### PR TITLE
Make the crew training feature less complex

### DIFF
--- a/GameData/RP-0/CrewHandlerSettings.cfg
+++ b/GameData/RP-0/CrewHandlerSettings.cfg
@@ -17,10 +17,8 @@ CREWHANDLERSETTINGS
 	retireCourageMax = 3
 	retireStupidMin = 1
 	retireStupidMax = 0
-	trainingProficiencyExpirationYears = 4
 	trainingProficiencyStupidMin = 1.5 // multiplier to how long proficiency lasts at 0 stupidity
 	trainingProficiencyStupidMax = 0.5 // multiplier to how long proficiency lasts at 1 stupidity
-	trainingProficiencyRefresherTimeMult = 0.25
 	trainingProficiencyXP = 1
 	trainingMissionExpirationDays = 120
 	trainingMissionStupidMin = 0.5 // multiplier to how long the training course takes at 0 stupidity

--- a/Source/Crew/ActiveCourse.cs
+++ b/Source/Crew/ActiveCourse.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UniLinq;
-using System.Text;
 
 namespace RP0.Crew
 {
@@ -12,8 +11,7 @@ namespace RP0.Crew
         public double elapsedTime = 0;
         public double startTime = 0d;
         public bool Started = false, Completed = false;
-
-
+        
         public ActiveCourse(CourseTemplate template)
         {
             sourceNode = template.sourceNode;
@@ -122,6 +120,7 @@ namespace RP0.Crew
             }
             return true;
         }
+
         public void AddStudent(ProtoCrewMember student)
         {
             if (seatMax <= 0 || Students.Count < seatMax)
@@ -130,6 +129,7 @@ namespace RP0.Crew
                     Students.Add(student);
             }
         }
+
         public void AddStudent(string student)
         {
             AddStudent(HighLogic.CurrentGame.CrewRoster[student]);
@@ -148,6 +148,7 @@ namespace RP0.Crew
                 }
             }
         }
+
         public void RemoveStudent(string student)
         {
             RemoveStudent(HighLogic.CurrentGame.CrewRoster[student]);
@@ -188,7 +189,6 @@ namespace RP0.Crew
 
         public void CompleteCourse()
         {
-
             //assign rewards to all kerbals and set them to free
             if (Completed)
             {
@@ -196,53 +196,18 @@ namespace RP0.Crew
                 {
                     if (student == null)
                         continue;
-
-                    if (ExpireLog != null)
-                    {
-                        foreach (ConfigNode.Value v in ExpireLog.values)
-                        {
-                            for (int i = student.careerLog.Count; i-- > 0;)
-                            {
-                                FlightLog.Entry e = student.careerLog.Entries[i];
-                                if (CrewHandler.TrainingExpiration.Compare(v.value, e))
-                                {
-                                    e.type = "expired_" + e.type;
-                                    CrewHandler.Instance.RemoveExpiration(student.name, v.value);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
+                    
                     if (RewardLog != null)
                     {
                         if (student.flightLog.Count > 0)
                             student.ArchiveFlightLog();
-
-                        CrewHandler.TrainingExpiration exp = null;
-                        if (expiration > 0d)
-                        {
-                            exp = new CrewHandler.TrainingExpiration();
-                            exp.pcmName = student.name;
-                            exp.expiration = expiration;
-                            if (expirationUseStupid)
-                                exp.expiration *= UtilMath.Lerp(CrewHandler.Instance.settings.trainingProficiencyStupidMin,
-                                    CrewHandler.Instance.settings.trainingProficiencyStupidMax,
-                                    student.stupidity);
-                            exp.expiration += Planetarium.GetUniversalTime();
-                        }
-
+                        
                         foreach (ConfigNode.Value v in RewardLog.values)
                         {
                             string[] s = v.value.Split(new char[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
                             student.flightLog.AddEntry(s[0], s.Length == 1 ? null : s[1]);
                             student.ArchiveFlightLog();
-                            if (expiration > 0d)
-                                exp.entries.Add(v.value);
                         }
-
-                        if (expiration > 0d)
-                            CrewHandler.Instance.AddExpiration(exp);
                     }
 
                     if (rewardXP != 0)

--- a/Source/Crew/CourseTemplate.cs
+++ b/Source/Crew/CourseTemplate.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace RP0.Crew
 {
@@ -29,16 +27,12 @@ namespace RP0.Crew
         public string[] classes = { }; //which classes can take this course (empty == all)
         public int minLevel = 0; //minimum kerbal level required to take the course
         public int maxLevel = 99; //max kerbal level allowed to take the course
-
-        public double expiration = 0d;
-        public bool expirationUseStupid = false;
-
+        
         public int seatMax = -1; //maximum number of kerbals allowed in the course at once
         public int seatMin = 0; //minimum number of kerbals required to start the course
         
         public int rewardXP = 0; //pure XP reward
         public ConfigNode RewardLog = null; //the flight log to insert
-        public ConfigNode ExpireLog = null; // expire all these on complete
 
         public CourseTemplate(ConfigNode source)
         {
@@ -130,8 +124,6 @@ namespace RP0.Crew
 
             source.TryGetValue("time", ref time);
             source.TryGetValue("timeUseStupid", ref timeUseStupid);
-            source.TryGetValue("expiration", ref expiration);
-            source.TryGetValue("expirationUseStupid", ref expirationUseStupid);
 
             source.TryGetValue("required", ref required);
 
@@ -162,7 +154,6 @@ namespace RP0.Crew
             if (r != null)
             {
                 RewardLog = r.GetNode("FLIGHTLOG");
-                ExpireLog = r.GetNode("EXPIRELOG");
                 r.TryGetValue("XPAmt", ref rewardXP);
             }
         }
@@ -180,14 +171,6 @@ namespace RP0.Crew
             averageStupid /= sC;
 
             return time * UtilMath.Lerp(CrewHandler.Instance.settings.trainingMissionStupidMin, CrewHandler.Instance.settings.trainingMissionStupidMax, averageStupid);
-        }
-
-        public double GetExpiration(ProtoCrewMember pcm)
-        {
-            if (pcm == null || !expirationUseStupid)
-                return expiration;
-
-            return expiration * (1.5d - pcm.stupidity);
         }
     }
 }

--- a/Source/Crew/CrewHandlerSettings.cs
+++ b/Source/Crew/CrewHandlerSettings.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using KSP;
-using UnityEngine;
-using System.Reflection;
+﻿using UnityEngine;
 
 namespace RP0.Crew
 {
@@ -18,16 +13,12 @@ namespace RP0.Crew
 
         [Persistent]
         public double retireBaseYears = 5d, retireCourageMin = 0d, retireCourageMax = 3d, retireStupidMin = 1d, retireStupidMax = 0d;
-
-        [Persistent]
-        public double trainingProficiencyExpirationYears = 4d, trainingProficiencyStupidMin = 1.5d, trainingProficiencyStupidMax = 0.5d, trainingProficiencyRefresherTimeMult = 0.25d;
-
+        
         [Persistent]
         public int trainingProficiencyXP = 1;
 
         [Persistent]
-        public double trainingMissionExpirationDays = 120d, trainingMissionStupidMin = 0.5d, trainingMissionStupidMax = 1.5d;
-
+        public double trainingMissionStupidMin = 0.5d, trainingMissionStupidMax = 1.5d;
 
         public void Load(ConfigNode node)
         {

--- a/Source/KCTBinderModule.cs
+++ b/Source/KCTBinderModule.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using UnityEngine;
 using KerbalConstructionTime;
 
 namespace RP0
@@ -45,30 +42,11 @@ namespace RP0
             if (ent == null)
                 return false;
 
-            int lastFlight = ent.flight;
-            bool lacksMission = true;
             for (int i = pcm.careerLog.Entries.Count; i-- > 0;)
             {
                 FlightLog.Entry e = pcm.careerLog.Entries[i];
-                if (lacksMission)
-                {
-                    if (e.flight < lastFlight)
-                        return false;
-
-                    if (string.IsNullOrEmpty(e.type) || string.IsNullOrEmpty(e.target))
-                        continue;
-
-                    if (e.type == "TRAINING_mission" && e.target == partName)
-                        lacksMission = false;
-                }
-                else
-                {
-                    if (string.IsNullOrEmpty(e.type) || string.IsNullOrEmpty(e.target))
-                        continue;
-
-                    if (e.type == "TRAINING_proficiency" && e.target == partName)
-                        return true;
-                }
+                if (e.type == "TRAINING_proficiency" && e.target == partName)
+                    return true;
             }
             return false;
         }


### PR DESCRIPTION
Based on the feedback of RO Discord, make proficiency trainings no longer expire and remove mission trainings. This commit also removes all code that's related to training expirations.

Test DLLs are available here: https://github.com/siimav/RP-0/releases/tag/dev3
But be sure to back up your save before loading a game with these DLLs.
It looks like my changes will cause the training expiration blocks to be removed from saves. So even after going back to old DLLs, all trainings would still lack expiration dates.