### PR TITLE
Tool all improvements

### DIFF
--- a/Source/Tooling/ModuleTooling.cs
+++ b/Source/Tooling/ModuleTooling.cs
@@ -133,5 +133,31 @@ namespace RP0
         {
             return ModifierChangeWhen.FIXED;
         }
+
+        /// <summary>
+        /// Checks whether two toolings are considered the same by checking their types and dimensions (if applicable).
+        /// Dimension comparison is done with an error margin of 4%.
+        /// </summary>
+        /// <param name="a">Tooling 1</param>
+        /// <param name="b">Tooling 2</param>
+        /// <returns>True if toolings match</returns>
+        public static bool IsSame(ModuleTooling a, ModuleTooling b)
+        {
+            if (a.toolingType != b.toolingType) return false;
+
+            if (a is ModuleToolingDiamLen || b is ModuleToolingDiamLen)
+            {
+                var d1 = a as ModuleToolingDiamLen;
+                var d2 = b as ModuleToolingDiamLen;
+                if (d1 == null || d2 == null) return false;
+
+                d1.GetDimensions(out float diam1, out float len1);
+                d2.GetDimensions(out float diam2, out float len2);
+
+                return ToolingDatabase.IsSameSize(diam1, len1, diam2, len2);
+            }
+
+            return true;
+        }
     }
 }

--- a/Source/Tooling/ModuleTooling.cs
+++ b/Source/Tooling/ModuleTooling.cs
@@ -135,6 +135,56 @@ namespace RP0
         }
 
         /// <summary>
+        /// Use for purchasing multiple toolings at once. Does it's best to determine the best order to buy them so that the cost would be minimal.
+        /// Also deducuts the funds required for purchase. 
+        /// Has an option for running a simulation to calculate the accurate cost of toolings while the tooling DB and funds are left untouched.
+        /// </summary>
+        /// <param name="toolingColl">Collection of toolings to purchase.</param>
+        /// <param name="isSimulation">Whether to simulate the purchase to get the accurate cost of all toolings.</param>
+        /// <returns>Total cost of all the toolings purchased.</returns>
+        public static float PurchaseToolingBatch(List<ModuleTooling> toolingColl, bool isSimulation = false)
+        {
+            ConfigNode toolingBackup = null;
+            if (isSimulation)
+            {
+                toolingBackup = new ConfigNode();
+                ToolingDatabase.Save(toolingBackup);
+            }
+
+            float totalCost = 0;
+            try
+            {
+                // Currently all cost reducers are applied correctly when the tooling types are first sorted in alphabetical order
+                toolingColl.Sort((mt1, mt2) => mt1.toolingType.CompareTo(mt2.toolingType));
+
+                //TODO: find the most optimal order to purchase toolings that have diameter and length.
+                //      If there are diameters 2.9; 3 and 3.1 only 3 needs to be purchased and others will fit inside the stretch margin.
+
+                toolingColl.ForEach(mt =>
+                {
+                    if (mt.IsUnlocked()) return;
+
+                    totalCost += mt.GetToolingCost();
+                    mt.PurchaseTooling();
+                });
+
+                if (totalCost > 0 && !isSimulation)
+                {
+                    Funding.Instance.AddFunds(-totalCost, TransactionReasons.RnDPartPurchase);
+                }
+            }
+            finally
+            {
+                if (isSimulation)
+                {
+                    ToolingDatabase.Load(toolingBackup);
+                }
+            }
+
+            return totalCost;
+        }
+
+        /// <summary>
         /// Checks whether two toolings are considered the same by checking their types and dimensions (if applicable).
         /// Dimension comparison is done with an error margin of 4%.
         /// </summary>

--- a/Source/Tooling/ModuleToolingDiamLen.cs
+++ b/Source/Tooling/ModuleToolingDiamLen.cs
@@ -8,7 +8,7 @@ namespace RP0
 {
     public abstract class ModuleToolingDiamLen : ModuleTooling
     {
-        protected abstract void GetDimensions(out float diam, out float len);
+        public abstract void GetDimensions(out float diam, out float len);
 
         public virtual string GetDimensions()
         {

--- a/Source/Tooling/ModuleToolingGeneric.cs
+++ b/Source/Tooling/ModuleToolingGeneric.cs
@@ -40,7 +40,8 @@ namespace RP0
             if (!string.IsNullOrEmpty(partModuleName))
                 pm = part.Modules[partModuleName];
         }
-        protected override void GetDimensions(out float diam, out float len)
+
+        public override void GetDimensions(out float diam, out float len)
         {
             diam = 0f;
             len = 0f;

--- a/Source/Tooling/ModuleToolingPFSide.cs
+++ b/Source/Tooling/ModuleToolingPFSide.cs
@@ -23,7 +23,8 @@ namespace RP0
             base.OnLoad(node);
             pm = part.Modules["ProceduralFairingSide"];
         }
-        protected override void GetDimensions(out float diam, out float len)
+
+        public override void GetDimensions(out float diam, out float len)
         {
             diam = 0f;
             len = 0f;

--- a/Source/Tooling/ModuleToolingPTank.cs
+++ b/Source/Tooling/ModuleToolingPTank.cs
@@ -20,7 +20,8 @@ namespace RP0
 
             procTank = part.Modules["ProceduralPart"];
         }
-        protected override void GetDimensions(out float diam, out float len)
+
+        public override void GetDimensions(out float diam, out float len)
         {
             diam = 0f;
             len = 0f;

--- a/Source/Tooling/ModuleToolingSSTUTank.cs
+++ b/Source/Tooling/ModuleToolingSSTUTank.cs
@@ -24,7 +24,8 @@ namespace RP0
             // ******* 1.4+ SSTUTank = part.Modules["SSTUModularPart"];
             SSTUTank = part.Modules["SSTUModularFuelTank"];
         }
-        protected override void GetDimensions(out float diam, out float len)
+
+        public override void GetDimensions(out float diam, out float len)
         {
             diam = 0f;
             len = 0f;

--- a/Source/Tooling/ToolingDatabase.cs
+++ b/Source/Tooling/ToolingDatabase.cs
@@ -99,6 +99,19 @@ namespace RP0
             Full = 2
         };
 
+        /// <summary>
+        /// Compares two tooling sizes and checks whether their diameter and length are within a predefined epsilon (currently 4%).
+        /// </summary>
+        /// <param name="diam1">Diameter of tooling 1</param>
+        /// <param name="len1">Length of tooling 1</param>
+        /// <param name="diam2">Diameter of tooling 2</param>
+        /// <param name="len2">Length of tooling 2</param>
+        /// <returns>True if the two tooling sizes are considered the same.</returns>
+        public static bool IsSameSize(float diam1, float len1, float diam2, float len2)
+        {
+            return EpsilonCompare(diam1, diam2) == 0 && EpsilonCompare(len1, len2) == 0;
+        }
+
         public static ToolingLevel HasTooling(string type, float diam, float len)
         {
             List<ToolingDiameter> lst;


### PR DESCRIPTION
This fixes an issue where tooling for (near) identical untooled parts were purchased multiple times when using the 'Tool All' button. Also takes into account the 4% stretch margin and cost reducers.