### PR TITLE
Crew training changes

### DIFF
--- a/GameData/RP-0/CrewHandlerSettings.cfg
+++ b/GameData/RP-0/CrewHandlerSettings.cfg
@@ -17,7 +17,6 @@ CREWHANDLERSETTINGS
 	retireCourageMax = 3
 	retireStupidMin = 1
 	retireStupidMax = 0
-	trainingProficiencyExpirationYears = 4
 	trainingProficiencyStupidMin = 1.5 // multiplier to how long proficiency lasts at 0 stupidity
 	trainingProficiencyStupidMax = 0.5 // multiplier to how long proficiency lasts at 1 stupidity
 	trainingProficiencyRefresherTimeMult = 0.25
@@ -25,4 +24,5 @@ CREWHANDLERSETTINGS
 	trainingMissionExpirationDays = 120
 	trainingMissionStupidMin = 0.5 // multiplier to how long the training course takes at 0 stupidity
 	trainingMissionStupidMax = 1.5 // multiplier to how long the training course takes at 1 stupidity
+	minFlightDurationSecondsForTrainingExpire = 30
 }

--- a/Source/Crew/CrewHandlerSettings.cs
+++ b/Source/Crew/CrewHandlerSettings.cs
@@ -20,13 +20,16 @@ namespace RP0.Crew
         public double retireBaseYears = 5d, retireCourageMin = 0d, retireCourageMax = 3d, retireStupidMin = 1d, retireStupidMax = 0d;
 
         [Persistent]
-        public double trainingProficiencyExpirationYears = 4d, trainingProficiencyStupidMin = 1.5d, trainingProficiencyStupidMax = 0.5d, trainingProficiencyRefresherTimeMult = 0.25d;
+        public double trainingProficiencyStupidMin = 1.5d, trainingProficiencyStupidMax = 0.5d, trainingProficiencyRefresherTimeMult = 0.25d;
 
         [Persistent]
         public int trainingProficiencyXP = 1;
 
         [Persistent]
         public double trainingMissionExpirationDays = 120d, trainingMissionStupidMin = 0.5d, trainingMissionStupidMax = 1.5d;
+
+        [Persistent]
+        public double minFlightDurationSecondsForTrainingExpire = 30d;
 
 
         public void Load(ConfigNode node)

--- a/Source/KCTBinderModule.cs
+++ b/Source/KCTBinderModule.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using UnityEngine;
 using KerbalConstructionTime;
+using RP0.Crew;
 
 namespace RP0
 {
@@ -39,27 +37,26 @@ namespace RP0
             if (!requireTraining || EntryCostStorage.GetCost(partName) == 1)
                 return true;
 
-            partName = Crew.TrainingDatabase.SynonymReplace(partName);
+            partName = TrainingDatabase.SynonymReplace(partName);
 
             FlightLog.Entry ent = pcm.careerLog.Last();
             if (ent == null)
                 return false;
 
-            int lastFlight = ent.flight;
             bool lacksMission = true;
             for (int i = pcm.careerLog.Entries.Count; i-- > 0;)
             {
                 FlightLog.Entry e = pcm.careerLog.Entries[i];
                 if (lacksMission)
                 {
-                    if (e.flight < lastFlight)
-                        return false;
-
                     if (string.IsNullOrEmpty(e.type) || string.IsNullOrEmpty(e.target))
                         continue;
 
                     if (e.type == "TRAINING_mission" && e.target == partName)
-                        lacksMission = false;
+                    {
+                        double exp = CrewHandler.Instance.GetExpiration(pcm.name, e);
+                        lacksMission = exp == 0d || exp < Planetarium.GetUniversalTime();
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
* Proficiency trainings no longer expire, removed refresher courses
* Flight trainings do not expire when flight duration was less than 30 seconds
* Allow only 1 mission training to be active at a time