### PR TITLE
Added highlight to 2nd gen navsat contract for unexpected resource type

### DIFF
--- a/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = NavSats
 
 
-	description = A more accurate technique for satellite navigation is to use Time-Difference Of Arrival of pulsed radio signals.  Please place a new test navigational satellite into the proper orbit around Earth.  This contract can be completed up to 3 times.  Note that these TDOA satellites use ComSatPayload rather than NavSatPayload.
+	description = A more accurate technique for satellite navigation is to use Time-Difference Of Arrival of pulsed radio signals.  Please place a new test navigational satellite into the proper orbit around Earth.  This contract can be completed up to 3 times.  <b><color=white>Note that these TDOA satellites use ComSatPayload rather than NavSatPayload.</color></b>
 
 	synopsis = Launch a navigational satellite into the proper orbit
 

--- a/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = NavSats
 
 
-	description = A more accurate technique for satellite navigation is to use Time-Difference Of Arrival of pulsed radio signals.  Please place a new test navigational satellite into the proper orbit around Earth.  This contract can be completed up to 3 times.  <b><color=white>Note that these TDOA satellites use ComSatPayload rather than NavSatPayload.</color></b>
+	description = A more accurate technique for satellite navigation is to use Time-Difference Of Arrival of pulsed radio signals.  Please place a new test navigational satellite into the proper orbit around Earth.  This contract can be completed up to 3 times.  <b><color=red>Note that these TDOA satellites use ComSatPayload rather than NavSatPayload.</color></b>
 
 	synopsis = Launch a navigational satellite into the proper orbit
 


### PR DESCRIPTION
The second generation Navsat contracts have ComSatPayload as a requirement, which is not intuitive. Added highlighting in the contract blurb to aid players somewhat.