### PR TITLE
Allow proficiency training while the part is still being researched

### DIFF
--- a/Source/Crew/CourseTemplate.cs
+++ b/Source/Crew/CourseTemplate.cs
@@ -40,6 +40,8 @@ namespace RP0.Crew
         public ConfigNode RewardLog = null; //the flight log to insert
         public ConfigNode ExpireLog = null; // expire all these on complete
 
+        public bool isTemporary = false;
+
         public CourseTemplate(ConfigNode source)
         {
             sourceNode = source;
@@ -134,6 +136,7 @@ namespace RP0.Crew
             source.TryGetValue("expirationUseStupid", ref expirationUseStupid);
 
             source.TryGetValue("required", ref required);
+            source.TryGetValue("isTemporary", ref isTemporary);
 
             string repeatStr = source.GetValue("repeatable");
             if (!string.IsNullOrEmpty(repeatStr))

--- a/Source/Crew/CrewHandler.cs
+++ b/Source/Crew/CrewHandler.cs
@@ -513,8 +513,10 @@ namespace RP0.Crew
             if (!partSynsHandled.Contains(name))
             {
                 partSynsHandled.Add(name);
-                GenerateCourseProf(ap);
-                if (ResearchAndDevelopment.PartModelPurchased(ap))
+                bool isPartUnlocked = ResearchAndDevelopment.PartModelPurchased(ap);
+
+                GenerateCourseProf(ap, !isPartUnlocked);
+                if (isPartUnlocked)
                 {
                     GenerateCourseMission(ap);
                 }
@@ -843,7 +845,7 @@ namespace RP0.Crew
             //fire an event to let other mods add available courses (where they can pass variables through then)
         }
 
-        protected void GenerateCourseProf(AvailablePart ap)
+        protected void GenerateCourseProf(AvailablePart ap, bool isTemporary)
         {
             ConfigNode n = new ConfigNode("FS_COURSE");
             string name = TrainingDatabase.SynonymReplace(ap.name);
@@ -851,6 +853,7 @@ namespace RP0.Crew
             n.AddValue("id", "prof_" + name);
             n.AddValue("name", "Proficiency: " + name);
             n.AddValue("time", 1d + (TrainingDatabase.GetTime(name) * 86400d));
+            n.AddValue("isTemporary", isTemporary);
 
             n.AddValue("conflicts", "TRAINING_proficiency:" + name);
 
@@ -872,6 +875,7 @@ namespace RP0.Crew
             n.AddValue("id", "msn_" + name);
             n.AddValue("name", "Mission: " + name);
             n.AddValue("time", 1d + TrainingDatabase.GetTime(name + "-Mission") * 86400d);
+            n.AddValue("isTemporary", false);
             n.AddValue("timeUseStupid", true);
             n.AddValue("seatMax", ap.partPrefab.CrewCapacity * 2);
             n.AddValue("expiration", settings.trainingMissionExpirationDays * 86400d);

--- a/Source/Crew/CrewHandler.cs
+++ b/Source/Crew/CrewHandler.cs
@@ -494,7 +494,33 @@ namespace RP0.Crew
         {
             expireTimes.Add(e);
         }
-        
+
+        public void AddCoursesForTechNode(RDTech tech)
+        {
+            for (int i = 0; i < tech.partsAssigned.Count; i++)
+            {
+                AvailablePart ap = tech.partsAssigned[i];
+                if (ap.partPrefab.CrewCapacity > 0)
+                {
+                    AddPartCourses(ap);
+                }
+            }
+        }
+
+        public void AddPartCourses(AvailablePart ap)
+        {
+            string name = TrainingDatabase.SynonymReplace(ap.name);
+            if (!partSynsHandled.Contains(name))
+            {
+                partSynsHandled.Add(name);
+                GenerateCourseProf(ap);
+                if (ResearchAndDevelopment.PartModelPurchased(ap))
+                {
+                    GenerateCourseMission(ap);
+                }
+            }
+        }
+
         #endregion
 
         #region Methods
@@ -806,28 +832,15 @@ namespace RP0.Crew
 
             foreach (AvailablePart ap in PartLoader.LoadedPartsList)
             {
-                if (ap.partPrefab.CrewCapacity > 0 /*&& ap.TechRequired != "start"*/)
+                if (ap.partPrefab.CrewCapacity > 0 && /*&& ap.TechRequired != "start"*/
+                    ResearchAndDevelopment.PartModelPurchased(ap))
                 {
-                    if (ResearchAndDevelopment.PartModelPurchased(ap))
-                    {
-                        string name = TrainingDatabase.SynonymReplace(ap.name);
-                        if (!partSynsHandled.Contains(name))
-                        {
-                            partSynsHandled.Add(name);
-                            AddPartCourses(ap);
-                        }
-                    }
+                    AddPartCourses(ap);
                 }
             }
 
             Debug.Log("[FS] Offering " + OfferedCourses.Count + " courses.");
             //fire an event to let other mods add available courses (where they can pass variables through then)
-        }
-
-        protected void AddPartCourses(AvailablePart ap)
-        {
-            GenerateCourseProf(ap);
-            GenerateCourseMission(ap);
         }
 
         protected void GenerateCourseProf(AvailablePart ap)

--- a/Source/Crew/FSGUI.cs
+++ b/Source/Crew/FSGUI.cs
@@ -14,6 +14,8 @@ namespace RP0.Crew
         private Vector2 nautListScroll = new Vector2();
         private Dictionary<ProtoCrewMember, ActiveCourse> activeMap = new Dictionary<ProtoCrewMember, ActiveCourse>();
         private Vector2 courseSelectorScroll = new Vector2();
+        private GUIStyle courseBtnStyle = null;
+        private GUIStyle tempCourseLblStyle = null;
         private GUIContent nautRowAlarmBtnContent = new GUIContent(GameDatabase.Instance.GetTexture("RP-0/KACIcon15", false));
         
         protected void nautListHeading()
@@ -171,10 +173,17 @@ namespace RP0.Crew
 
         protected void courseSelector()
         {
+            if (courseBtnStyle == null)
+            {
+                courseBtnStyle = new GUIStyle(GUI.skin.button);
+                courseBtnStyle.normal.textColor = Color.yellow;
+            }
+            
             courseSelectorScroll = GUILayout.BeginScrollView(courseSelectorScroll, GUILayout.Width(505), GUILayout.Height(430));
             try {
                 foreach (CourseTemplate course in CrewHandler.Instance.OfferedCourses) {
-                    if (GUILayout.Button(course.name))
+                    var style = course.isTemporary ? courseBtnStyle : GUI.skin.button;
+                    if (GUILayout.Button(course.name, style))
                         selectedCourse = new ActiveCourse(course);
                 }
             } finally {
@@ -191,6 +200,12 @@ namespace RP0.Crew
 
         public tabs newCourseTab()
         {
+            if (tempCourseLblStyle == null)
+            {
+                tempCourseLblStyle = new GUIStyle(GUI.skin.label);
+                tempCourseLblStyle.normal.textColor = Color.yellow;
+            }
+
             GUILayout.BeginHorizontal();
             try {
                 GUILayout.FlexibleSpace();
@@ -199,7 +214,10 @@ namespace RP0.Crew
             } finally {
                 GUILayout.EndHorizontal();
             }
-            GUILayout.Label(selectedCourse.description);
+            if (!string.IsNullOrEmpty(selectedCourse.description))
+                GUILayout.Label(selectedCourse.description);
+            if (selectedCourse.isTemporary)
+                GUILayout.Label("Tech for this part is still being researched", tempCourseLblStyle);
             summaryBody(tabs.NewCourse);
             if (selectedCourse.seatMax > 0)
                 GUILayout.Label(selectedCourse.seatMax - selectedCourse.Students.Count + " remaining seat(s).");


### PR DESCRIPTION
Creates proficiency courses for all crewed parts that are in the KCT's research list. Mission trainings are not available before the part is actually purchased. If the research is finished but the user does not unlock the part, then the proficiency course will also disappear. I think it might actually be a good thing because this way the list wouldn't get cluttered up with entries for parts that will never be used.