### PR TITLE
Change SpaceAltitudeThresholds

### DIFF
--- a/GameData/RP-0/Contracts/Flyby Contracts/Ariel Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Ariel Flyby.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Ariel with a closest approach of 11,000 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Ariel with a closest approach of 2,000 km or closer, then record observations and transmit.
 
 	synopsis = Flyby Ariel closer than 2,000 km and transmit science
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Ariel Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Ariel Flyby.cfg
@@ -1,13 +1,13 @@
 CONTRACT_TYPE
 {
-	name = flybyTriton
-	title = Triton Flyby
+	name = flybyAriel
+	title = Ariel Flyby
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Triton with a closest approach of 11,000 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Ariel with a closest approach of 11,000 km or closer, then record observations and transmit.
 
-	synopsis = Flyby Triton closer than 11,000 km and transmit science
+	synopsis = Flyby Ariel closer than 2,000 km and transmit science
 
 	completedMessage = Congratulations on the flyby! The data is coming in now.
 
@@ -22,7 +22,7 @@ CONTRACT_TYPE
 	maxSimultaneous = 1
 	deadline = 3650  // 10 years
 
-	targetBody = Triton
+	targetBody = Ariel
 
 
 
@@ -40,7 +40,7 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = flybyNeptune
+		contractType = flybyUranus
 		title = Complete @contractType Contract
 	}
 
@@ -50,8 +50,8 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Flyby Triton
-		define = FlybyTriton
+		title = Flyby Ariel
+		define = FlybyAriel
 	
 		PARAMETER
 		{
@@ -66,9 +66,9 @@ CONTRACT_TYPE
 		{
 			name = FlybyPlanet
 			type = ReachState
-			maxAltitude = 11000000
+			maxAltitude = 2000000
 			disableOnStateChange = true
-			title = Flyby Triton within 11,000 km
+			title = Flyby Ariel within 2,000 km
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Flyby Contracts/Miranda Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Miranda Flyby.cfg
@@ -5,9 +5,9 @@ CONTRACT_TYPE
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Miranda with a closest approach of 11,000 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Miranda with a closest approach of 450 km or closer, then record observations and transmit.
 
-	synopsis = Flyby Miranda closer than 11,000 km and transmit science
+	synopsis = Flyby Miranda closer than 450 km and transmit science
 
 	completedMessage = Congratulations on the flyby! The data is coming in now.
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Miranda Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Miranda Flyby.cfg
@@ -1,13 +1,13 @@
 CONTRACT_TYPE
 {
-	name = flybyTriton
-	title = Triton Flyby
+	name = flybyMiranda
+	title = Miranda Flyby
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Triton with a closest approach of 11,000 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Miranda with a closest approach of 11,000 km or closer, then record observations and transmit.
 
-	synopsis = Flyby Triton closer than 11,000 km and transmit science
+	synopsis = Flyby Miranda closer than 11,000 km and transmit science
 
 	completedMessage = Congratulations on the flyby! The data is coming in now.
 
@@ -22,7 +22,7 @@ CONTRACT_TYPE
 	maxSimultaneous = 1
 	deadline = 3650  // 10 years
 
-	targetBody = Triton
+	targetBody = Miranda
 
 
 
@@ -40,7 +40,7 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = flybyNeptune
+		contractType = flybyUranus
 		title = Complete @contractType Contract
 	}
 
@@ -50,8 +50,8 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Flyby Triton
-		define = FlybyTriton
+		title = Flyby Miranda
+		define = FlybyMiranda
 	
 		PARAMETER
 		{
@@ -66,9 +66,9 @@ CONTRACT_TYPE
 		{
 			name = FlybyPlanet
 			type = ReachState
-			maxAltitude = 11000000
+			maxAltitude = 450000
 			disableOnStateChange = true
-			title = Flyby Triton within 11,000 km
+			title = Flyby Miranda within 450 km
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Flyby Contracts/Oberon Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Oberon Flyby.cfg
@@ -1,13 +1,13 @@
 CONTRACT_TYPE
 {
-	name = flybyTriton
-	title = Triton Flyby
+	name = flybyOberon
+	title = Oberon Flyby
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Triton with a closest approach of 11,000 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Oberon with a closest approach of 11,000 km or closer, then record observations and transmit.
 
-	synopsis = Flyby Triton closer than 11,000 km and transmit science
+	synopsis = Flyby Oberon closer than 9,000 km and transmit science
 
 	completedMessage = Congratulations on the flyby! The data is coming in now.
 
@@ -22,7 +22,7 @@ CONTRACT_TYPE
 	maxSimultaneous = 1
 	deadline = 3650  // 10 years
 
-	targetBody = Triton
+	targetBody = Oberon
 
 
 
@@ -40,7 +40,7 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = flybyNeptune
+		contractType = flybyUranus
 		title = Complete @contractType Contract
 	}
 
@@ -50,8 +50,8 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Flyby Triton
-		define = FlybyTriton
+		title = Flyby Oberon
+		define = FlybyOberon
 	
 		PARAMETER
 		{
@@ -66,9 +66,9 @@ CONTRACT_TYPE
 		{
 			name = FlybyPlanet
 			type = ReachState
-			maxAltitude = 11000000
+			maxAltitude = 9000000
 			disableOnStateChange = true
-			title = Flyby Triton within 11,000 km
+			title = Flyby Oberon within 9,000 km
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Flyby Contracts/Oberon Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Oberon Flyby.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Oberon with a closest approach of 11,000 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Oberon with a closest approach of 9,000 km or closer, then record observations and transmit.
 
 	synopsis = Flyby Oberon closer than 9,000 km and transmit science
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Titania Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Titania Flyby.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Titania with a closest approach of 11,000 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Titania with a closest approach of 7,000 km or closer, then record observations and transmit.
 
 	synopsis = Flyby Titania closer than 7,000 km and transmit science
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Titania Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Titania Flyby.cfg
@@ -1,13 +1,13 @@
 CONTRACT_TYPE
 {
-	name = flybyTriton
-	title = Triton Flyby
+	name = flybyTitania
+	title = Titania Flyby
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Triton with a closest approach of 11,000 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Titania with a closest approach of 11,000 km or closer, then record observations and transmit.
 
-	synopsis = Flyby Triton closer than 11,000 km and transmit science
+	synopsis = Flyby Titania closer than 7,000 km and transmit science
 
 	completedMessage = Congratulations on the flyby! The data is coming in now.
 
@@ -22,7 +22,7 @@ CONTRACT_TYPE
 	maxSimultaneous = 1
 	deadline = 3650  // 10 years
 
-	targetBody = Triton
+	targetBody = Titania
 
 
 
@@ -40,7 +40,7 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = flybyNeptune
+		contractType = flybyUranus
 		title = Complete @contractType Contract
 	}
 
@@ -50,8 +50,8 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Flyby Triton
-		define = FlybyTriton
+		title = Flyby Titania
+		define = FlybyTitania
 	
 		PARAMETER
 		{
@@ -66,9 +66,9 @@ CONTRACT_TYPE
 		{
 			name = FlybyPlanet
 			type = ReachState
-			maxAltitude = 11000000
+			maxAltitude = 7000000
 			disableOnStateChange = true
-			title = Flyby Triton within 11,000 km
+			title = Flyby Titania within 7,000 km
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Flyby Contracts/Umbriel Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Umbriel Flyby.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Umbriel with a closest approach of 11,000 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Umbriel with a closest approach of 3,000 km or closer, then record observations and transmit.
 
 	synopsis = Flyby Umbriel closer than 3,000 km and transmit science
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Umbriel Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Umbriel Flyby.cfg
@@ -1,13 +1,13 @@
 CONTRACT_TYPE
 {
-	name = flybyTriton
-	title = Triton Flyby
+	name = flybyUmbriel
+	title = Umbriel Flyby
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Triton with a closest approach of 11,000 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Umbriel with a closest approach of 11,000 km or closer, then record observations and transmit.
 
-	synopsis = Flyby Triton closer than 11,000 km and transmit science
+	synopsis = Flyby Umbriel closer than 3,000 km and transmit science
 
 	completedMessage = Congratulations on the flyby! The data is coming in now.
 
@@ -22,7 +22,7 @@ CONTRACT_TYPE
 	maxSimultaneous = 1
 	deadline = 3650  // 10 years
 
-	targetBody = Triton
+	targetBody = Umbriel
 
 
 
@@ -40,7 +40,7 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = flybyNeptune
+		contractType = flybyUranus
 		title = Complete @contractType Contract
 	}
 
@@ -50,8 +50,8 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Flyby Triton
-		define = FlybyTriton
+		title = Flyby Umbriel
+		define = FlybyUmbriel
 	
 		PARAMETER
 		{
@@ -66,9 +66,9 @@ CONTRACT_TYPE
 		{
 			name = FlybyPlanet
 			type = ReachState
-			maxAltitude = 11000000
+			maxAltitude = 3000000
 			disableOnStateChange = true
-			title = Flyby Triton within 11,000 km
+			title = Flyby Umbriel within 3,000 km
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Science/BodyScienceParams.cfg
+++ b/GameData/RP-0/Science/BodyScienceParams.cfg
@@ -32,8 +32,8 @@
 				%spaceAltitudeThreshold = 150000
 				
 				%landedDataValue = 4.0
-				%inSpaceLowDataValue = 1.75
-				%inSpaceHighDataValue = 1.5
+				%inSpaceLowDataValue = 1.5
+				%inSpaceHighDataValue = 1.25
 				%recoveryValue = 2.5
 			}
 		}
@@ -44,7 +44,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 5000000
+				%spaceAltitudeThreshold = 3000000
 				%flyingAltitudeThreshold = 50000
 				
 				%landedDataValue = 10.0
@@ -79,7 +79,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 5000
+				%spaceAltitudeThreshold = 7000
 				
 				%landedDataValue = 7.0
 				%flyingLowDataValue = 5.0 // no atmo
@@ -96,7 +96,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 5000000
+				%spaceAltitudeThreshold = 6000000
 				%flyingAltitudeThreshold = 50000
 				
 				%landedDataValue = 20.0
@@ -114,7 +114,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 5000000
+				%spaceAltitudeThreshold = 2500000
 				
 				%landedDataValue = 40.0
 				%flyingLowDataValue = 29.0
@@ -124,14 +124,48 @@
 				%recoveryValue = 4.5
 			}
 		}
-	}	
+	}
+	@Body[Vesta]
+	{
+		@Properties
+		{
+			%ScienceValues
+			{
+				%spaceAltitudeThreshold = 300000
+				
+				%landedDataValue = 20.0
+				%flyingLowDataValue = 12.0
+				%flyingHighDataValue = 7.0
+				%inSpaceLowDataValue = 5.0
+				%inSpaceHighDataValue = 4.0
+				%recoveryValue = 3.0
+			}
+		}
+	}
+	@Body[Ceres]
+	{
+		@Properties
+		{
+			%ScienceValues
+			{
+				%spaceAltitudeThreshold = 450000
+				
+				%landedDataValue = 20.0
+				%flyingLowDataValue = 12.0
+				%flyingHighDataValue = 7.0
+				%inSpaceLowDataValue = 5.0
+				%inSpaceHighDataValue = 4.0
+				%recoveryValue = 3.0
+			}
+		}
+	}
 	@Body[Jupiter]
 	{
 		@Properties
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 100000000
+				%spaceAltitudeThreshold = 70000000
 				%flyingAltitudeThreshold = 1000000
 				
 				%landedDataValue = 40.0
@@ -166,7 +200,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 1500000
 				
 				%landedDataValue = 30.0
 				%flyingLowDataValue = 24.0
@@ -183,7 +217,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 2500000
 				
 				%landedDataValue = 30.0
 				%flyingLowDataValue = 24.0
@@ -200,7 +234,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 2500000
 				
 				%landedDataValue = 30.0
 				%flyingLowDataValue = 24.0
@@ -217,7 +251,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 100000000
+				%spaceAltitudeThreshold = 60000000
 				%flyingAltitudeThreshold = 1000000
 				
 				%landedDataValue = 40.0
@@ -235,7 +269,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 200000
 				
 				%landedDataValue = 35.0
 				%flyingLowDataValue = 26.0
@@ -252,7 +286,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 250000
 				
 				%landedDataValue = 35.0
 				%flyingLowDataValue = 26.0
@@ -269,7 +303,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 550000
 				
 				%landedDataValue = 35.0
 				%flyingLowDataValue = 26.0
@@ -286,7 +320,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 550000
 				
 				%landedDataValue = 35.0
 				%flyingLowDataValue = 26.0
@@ -303,7 +337,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 750000
 				
 				%landedDataValue = 35.0
 				%flyingLowDataValue = 26.0
@@ -320,7 +354,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 2500000
 				%flyingAltitudeThreshold = 50000
 				
 				%landedDataValue = 35.0
@@ -338,7 +372,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 750000
 				
 				%landedDataValue = 35.0
 				%flyingLowDataValue = 26.0
@@ -355,7 +389,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 100000000
+				%spaceAltitudeThreshold = 25000000
 				%flyingAltitudeThreshold = 1000000
 				
 				%landedDataValue = 40.0
@@ -367,13 +401,98 @@
 			}
 		}
 	}
+	@Body[Ariel]
+	{
+		@Properties
+		{
+			%ScienceValues
+			{
+				%spaceAltitudeThreshold = 600000
+
+				%landedDataValue = 40.0
+				%flyingLowDataValue = 28.0
+				%flyingHighDataValue = 20.0
+				%inSpaceLowDataValue = 18.0
+				%inSpaceHighDataValue = 13.0
+				%recoveryValue = 10.0
+			}
+		}
+	}
+	@Body[Miranda]
+	{
+		@Properties
+		{
+			%ScienceValues
+			{
+				%spaceAltitudeThreshold = 250000
+
+				%landedDataValue = 40.0
+				%flyingLowDataValue = 28.0
+				%flyingHighDataValue = 20.0
+				%inSpaceLowDataValue = 18.0
+				%inSpaceHighDataValue = 13.0
+				%recoveryValue = 10.0
+			}
+		}
+	}
+	@Body[Titania]
+	{
+		@Properties
+		{
+			%ScienceValues
+			{
+				%spaceAltitudeThreshold = 800000
+
+				%landedDataValue = 40.0
+				%flyingLowDataValue = 28.0
+				%flyingHighDataValue = 20.0
+				%inSpaceLowDataValue = 18.0
+				%inSpaceHighDataValue = 13.0
+				%recoveryValue = 10.0
+			}
+		}
+	}	
+	@Body[Umbriel]
+	{
+		@Properties
+		{
+			%ScienceValues
+			{
+				%spaceAltitudeThreshold = 600000
+
+				%landedDataValue = 40.0
+				%flyingLowDataValue = 28.0
+				%flyingHighDataValue = 20.0
+				%inSpaceLowDataValue = 18.0
+				%inSpaceHighDataValue = 13.0
+				%recoveryValue = 10.0
+			}
+		}
+	}
+	@Body[Oberon]
+	{
+		@Properties
+		{
+			%ScienceValues
+			{
+				%spaceAltitudeThreshold = 800000
+				
+				%landedDataValue = 40.0
+				%flyingLowDataValue = 29.0
+				%flyingHighDataValue = 21.0
+				%inSpaceLowDataValue = 23.0
+				%inSpaceHighDataValue = 18.0
+				%recoveryValue = 11.0
+			}
+		}
+	}
 	@Body[Neptune]
 	{
 		@Properties
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 100000000
+				%spaceAltitudeThreshold = 25000000
 				%flyingAltitudeThreshold = 1000000
 				
 				%landedDataValue = 40.0
@@ -391,7 +510,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 1500000
 				%flyingAltitudeThreshold = 50000
 				
 				%landedDataValue = 40.0
@@ -409,7 +528,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 1200000
 				%flyingAltitudeThreshold = 50000
 				
 				%landedDataValue = 50.0
@@ -427,7 +546,7 @@
 		{
 			%ScienceValues
 			{
-				%spaceAltitudeThreshold = 2000000
+				%spaceAltitudeThreshold = 600000
 				
 				%landedDataValue = 50.0
 				%flyingLowDataValue = 29.0


### PR DESCRIPTION
Many moons had altitude thresholds for space low above their SoIs.
* This changes all (except Earth/Moon) thresholds to be the radius of the body, rounded to look nicer.
* Also reduces the science multipliers of the Moon as requested by @pap1723 
* This PR incorporates what @Bornholio did in #999
* Also adds Flyby contracts for Uranus moons. I used most parameters from the Triton flyby, adjusting only the altitude to fit inside the SoI.