### PR TITLE
Remove claim that HP Tanks II to IV can hold Sounding Rocket Payload

### DIFF
--- a/GameData/RP-0/Parts/RFProcTanks.cfg
+++ b/GameData/RP-0/Parts/RFProcTanks.cfg
@@ -54,7 +54,7 @@
 
 	@title = Tank, II
 	@manufacturer = Generic
-	@description = Level II tank. Better mass-ratio than the Level I Tank and similar to tanks on the Redstone, R-5, and Able rockets. Can be configured with normal or high pressurization. High pressurization tanks are required by some engines and they are heavier than normal tanks. <b><color=green>Max Utilization: 92% </color><color=white>HP version can hold Sounding Rocket Payload</color></b>
+	@description = Level II tank. Better mass-ratio than the Level I Tank and similar to tanks on the Redstone, R-5, and Able rockets. Can be configured with normal or high pressurization. High pressurization tanks are required by some engines and they are heavier than normal tanks. <b><color=green>Max Utilization: 92%</b>
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15
@@ -104,7 +104,7 @@
 
 	@title = Tank, III
 	@manufacturer = Generic
-	@description = Level III tank. Better mass-ratio than the Level II Tank similar to tanks used on early Titan, Thor and Vanguard rockets. Can be configured with normal or high pressurization.  High pressurization tanks are required by some engines and they are heavier than normal tanks. <b><color=green>Max Utilization: 95% </color><color=white>HP version can hold Sounding Rocket Payload</color></b>
+	@description = Level III tank. Better mass-ratio than the Level II Tank similar to tanks used on early Titan, Thor and Vanguard rockets. Can be configured with normal or high pressurization.  High pressurization tanks are required by some engines and they are heavier than normal tanks. <b><color=green>Max Utilization: 95%</b>
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15
@@ -154,7 +154,7 @@
 
 	@title = Tank, IV
 	@manufacturer = Generic
-	@description = Level IV tank. Better mass-ratio than the Level III Tank, similar to tanks used on Titan II, Agena and Saturn S-II rockets. Can be configured with normal or high pressurization.  High pressurization tanks are required by some engines and they are heavier than normal tanks. <b><color=green>Max Utilization: 97% </color><color=white>HP version can hold Sounding Rocket Payload</color></b>
+	@description = Level IV tank. Better mass-ratio than the Level III Tank, similar to tanks used on Titan II, Agena and Saturn S-II rockets. Can be configured with normal or high pressurization.  High pressurization tanks are required by some engines and they are heavier than normal tanks. <b><color=green>Max Utilization: 97%</b>
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15

--- a/GameData/RP-0/Parts/RFProcTanks.cfg
+++ b/GameData/RP-0/Parts/RFProcTanks.cfg
@@ -54,7 +54,7 @@
 
 	@title = Tank, II
 	@manufacturer = Generic
-	@description = Level II tank. Better mass-ratio than the Level I Tank and similar to tanks on the Redstone, R-5, and Able rockets. Can be configured with normal or high pressurization. High pressurization tanks are required by some engines and they are heavier than normal tanks. <b><color=green>Max Utilization: 92%</b>
+	@description = Level II tank. Better mass-ratio than the Level I Tank and similar to tanks on the R-5 and Able rockets. Can be configured with normal or high pressurization. High pressurization tanks are required by some engines and they are heavier than normal tanks. <b><color=green>Max Utilization: 92%</b>
 
 	@maxTemp = 773.15
 	%skinMaxTemp = 873.15


### PR DESCRIPTION
The ability to hold Sounding Rocket Payload was recently removed from the HP versions of  Tank II, II, and IV.  See 36d027672216f5f9ccdc9c35a3b13574c0d2b0d6.  But the descriptions of these tanks in-game still claims that those HP tanks can hold SR payloads.  This edit just removes those chunks of description, so that they match, e.g., Tank III (Balloon).