### PR TITLE
Attempt to fix CI by increasing clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: c
 
+git:
+  depth: 500
+
 install:
     - sudo apt-get update
     - sudo apt-get install zip libyaml-libyaml-perl libipc-system-simple-perl


### PR DESCRIPTION
Travis defaults to last 50 commits, but this does not include the most recent tag so `git describe` failed.  Increasing the clone depth should allow it to find the tag.