### PR TITLE
Added pricing to the SSTU LC2-POD

### DIFF
--- a/Source/Tech Tree/Parts Browser/data/SSTU.json
+++ b/Source/Tech Tree/Parts Browser/data/SSTU.json
@@ -20,7 +20,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-DC-D2",
@@ -43,7 +45,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-DC-D3",
@@ -66,7 +70,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-DC-D4",
@@ -89,7 +95,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-DC-D5",
@@ -112,7 +120,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-DC-D6",
@@ -135,7 +145,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-FR-D1",
@@ -278,19 +290,19 @@
     {
         "name": "SSTU-LC2-POD",
         "title": "SSTU - LC2-POD",
-        "description": "LC2-POD",
+        "description": "LC2-POD\n2 crew Lunar Lander\nHas Four 4 way RCS thrusters\nOptional Accent Fuel Tanks \n\nAlternative design of the Lunar Exploration Module for NASA's mission to land on the moon \nDesigned by hobbyist aerospace engineer and CEO of SSTU Shadow mage\nUltimately the contract was won by Grumman Aircraft inc\nSome Say LC2 was a better craft, but due to Shadowmage being some 50 odd years late to submit the design, we will never know.",
         "mod": "SSTU",
-        "cost": "1800",
-        "entry_cost": "7200",
+        "cost": "8000",
+        "entry_cost": "280000",
         "category": "EDL",
         "info": "Lander",
         "year": "1968",
         "technology": "lunarLanding",
         "era": "05-LUNAR",
         "ro": true,
-        "rp0": false,
+        "rp0": true,
         "orphan": false,
-        "rp0_conf": false,
+        "rp0_conf": true,
         "spacecraft": "",
         "engine_config": "",
         "upgrade": false,
@@ -620,8 +632,8 @@
         "entry_cost": "50000",
         "category": "COMMAND",
         "info": "LES",
-        "year": "1965",
-        "technology": "secondGenCapsules",
+        "year": "1967",
+        "technology": "matureCapsules",
         "era": "05-LUNAR",
         "ro": true,
         "rp0": true,
@@ -633,20 +645,21 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "EngineSolid"
+            "EngineSolid",
+            "HumanRated"
         ]
     },
     {
         "name": "SSTU-SC-A-DM",
-        "title": "Soyuz 7K-OK Descent Module",
+        "title": "Soyuz Descent Module",
         "description": "SSTU - Ship Core: Series A - Descent Module.  This cozy module seats two Kerbals and is intended to allow for safe re-entry from low-Kerbin orbit.  Includes SAS, reaction wheels, parachutes, cabin lighting, heat-shield, batteries, decouplers on both top and bottom, and an integrated short-range transmitter (WIP).",
         "mod": "SSTU",
-        "cost": "8400",
-        "entry_cost": "0",
+        "cost": "2500",
+        "entry_cost": "70000",
         "category": "COMMAND",
         "info": "Command Module",
-        "year": "1965",
-        "technology": "secondGenCapsules",
+        "year": "1967",
+        "technology": "matureCapsules",
         "era": "05-LUNAR",
         "ro": true,
         "rp0": true,
@@ -655,25 +668,26 @@
         "spacecraft": "Soyuz TM",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesSoyuz",
-        "identical_part_name": "7KOKdescent",
+        "entry_cost_mods": "",
+        "identical_part_name": "",
         "module_tags": [
+            "Avionics",
+            "Habitable",
             "HumanRated",
-            "NoResourceCostMult",
             "Reentry"
         ]
     },
     {
         "name": "SSTU-SC-A-OM",
-        "title": "Soyuz 7K-OK Orbital Module",
+        "title": "Soyuz Orbital Module",
         "description": "SSTU - Ship Core: Series A - Orbital Module.  An orbital support module for the Series A spacecraft enabling docking operations and including additional (not-so-cramped) living space for the two Kerbals from the Descent Module.  Includes integrated SAS, reaction wheels, batteries, docking port, docking lights, cabin lighting, and short-range transmitter (WIP).  Not intended to be launched with crew; the crew should undergo the launch while seated in the Descent Module.",
         "mod": "SSTU",
-        "cost": "7000",
-        "entry_cost": "0",
+        "cost": "1500",
+        "entry_cost": "50000",
         "category": "COMMAND",
         "info": "Command Module",
-        "year": "1965",
-        "technology": "secondGenCapsules",
+        "year": "1967",
+        "technology": "matureCapsules",
         "era": "05-LUNAR",
         "ro": true,
         "rp0": true,
@@ -682,11 +696,12 @@
         "spacecraft": "Soyuz TM",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesSoyuz",
-        "identical_part_name": "7KOKorbital",
+        "entry_cost_mods": "",
+        "identical_part_name": "",
         "module_tags": [
-            "HumanRated",
-            "NoResourceCostMult"
+            "Avionics",
+            "Habitable",
+            "HumanRated"
         ]
     },
     {
@@ -698,8 +713,8 @@
         "entry_cost": "75000",
         "category": "COMMAND",
         "info": "Service Module",
-        "year": "1965",
-        "technology": "secondGenCapsules",
+        "year": "1967",
+        "technology": "matureCapsules",
         "era": "05-LUNAR",
         "ro": true,
         "rp0": true,
@@ -709,9 +724,10 @@
         "engine_config": "",
         "upgrade": false,
         "entry_cost_mods": "",
-        "identical_part_name": "7KOKService",
+        "identical_part_name": "",
         "module_tags": [
-            "NoResourceCostMult"
+            "Habitable",
+            "HumanRated"
         ]
     },
     {
@@ -744,10 +760,10 @@
         "mod": "SSTU",
         "cost": "5000",
         "entry_cost": "175000",
-        "category": "SOLID",
+        "category": "COMMAND",
         "info": "LES",
-        "year": "1966",
-        "technology": "solids1966",
+        "year": "1968",
+        "technology": "matureCapsules",
         "era": "05-LUNAR",
         "ro": true,
         "rp0": true,
@@ -759,7 +775,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "Apollo LES",
         "module_tags": [
-            "EngineSolid"
+            "EngineSolid",
+            "HumanRated"
         ]
     },
     {
@@ -767,8 +784,8 @@
         "title": "Apollo Command Module",
         "description": "Apollo Command Module. Contains three astronauts.",
         "mod": "SSTU",
-        "cost": "35000",
-        "entry_cost": "0",
+        "cost": "9000",
+        "entry_cost": "350000",
         "category": "COMMAND",
         "info": "Command Module",
         "year": "1968",
@@ -781,11 +798,12 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesApollo",
+        "entry_cost_mods": "",
         "identical_part_name": "Apollo CM",
         "module_tags": [
+            "Avionics",
+            "Habitable",
             "HumanRated",
-            "NoResourceCostMult",
             "Reentry"
         ]
     },
@@ -811,17 +829,18 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated",
-            "NoResourceCostMult"
+            "Avionics",
+            "Habitable",
+            "HumanRated"
         ]
     },
     {
         "name": "SSTU-SC-B-SM",
-        "title": "Apollo Service Module",
+        "title": "AJ10-137 (Service Propulsion System)",
         "description": "The Aerojet AJ10-137 rocket engine used on the Apollo Service Module as the Service Propulsion System. Diameter: [3.9 m]. Plume configured by RealPlume.",
         "mod": "SSTU",
         "cost": "10000",
-        "entry_cost": "",
+        "entry_cost": "350000",
         "category": "COMMAND",
         "info": "Service Module",
         "year": "1968",
@@ -834,10 +853,12 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "ApolloSM",
-        "identical_part_name": "Apollo SM",
+        "entry_cost_mods": "",
+        "identical_part_name": "AJ10-137",
         "module_tags": [
-            "NoResourceCostMult"
+            "EngineLiquidPF",
+            "HumanRated",
+            "Toxic"
         ]
     },
     {
@@ -885,7 +906,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "Orion LAS",
         "module_tags": [
-            "EngineSolid"
+            "EngineSolid",
+            "HumanRated"
         ]
     },
     {
@@ -910,8 +932,9 @@
         "entry_cost_mods": "",
         "identical_part_name": "Orion CM",
         "module_tags": [
+            "Avionics",
+            "Habitable",
             "HumanRated",
-            "NoResourceCostMult",
             "Reentry"
         ]
     },
@@ -937,8 +960,9 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated",
-            "NoResourceCostMult"
+            "Avionics",
+            "Habitable",
+            "HumanRated"
         ]
     },
     {
@@ -1009,7 +1033,7 @@
         "entry_cost_mods": "",
         "identical_part_name": "Orion MPCV",
         "module_tags": [
-            "NoResourceCostMult"
+            "HumanRated"
         ]
     },
     {
@@ -1035,6 +1059,7 @@
         "identical_part_name": "AJ10-137",
         "module_tags": [
             "EngineLiquidPF",
+            "HumanRated",
             "Toxic"
         ]
     },
@@ -1083,7 +1108,8 @@
         "entry_cost_mods": "F-1",
         "identical_part_name": "F-1",
         "module_tags": [
-            "EngineLiquidTurbo"
+            "EngineLiquidTurbo",
+            "HumanRated"
         ]
     },
     {
@@ -1108,7 +1134,8 @@
         "entry_cost_mods": "F-1B",
         "identical_part_name": "F-1B",
         "module_tags": [
-            "EngineLiquidTurbo"
+            "EngineLiquidTurbo",
+            "HumanRated"
         ]
     },
     {
@@ -1116,7 +1143,7 @@
         "title": "H-1/RS-27 Series",
         "description": "The H-1 is an upgrade to the LR79 engine that propelled the Saturn-I and IB vehicles, as well as late-model Delta rockets (as the RS-27). The H-1/RS-27 are optimized for the first-stage main engine role. The RS-27A has a higher expansion ratio for increased performance at altitude since liftoff thrust on the Delta II is augmented by solid boosters and the core burns rather longer. Diameter: [1.0 m]. Using the patented SSTU Engine-Clustering technology the number of engines, engine layout, mounting or shroud type, and mount/shroud size are configurable, and each set of engines are built to your specifications. Plume configured by RealPlume.",
         "mod": "SSTU",
-        "cost": 250,
+        "cost": "200",
         "entry_cost": "4000",
         "category": "ORBITAL",
         "info": "FS Engine",
@@ -1210,7 +1237,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "Apollo LMAE",
         "module_tags": [
-            "EngineLiquidPF"
+            "EngineLiquidPF",
+            "HumanRated"
         ]
     },
     {
@@ -1235,7 +1263,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "Apollo LMDE",
         "module_tags": [
-            "EngineLiquidPF"
+            "EngineLiquidPF",
+            "HumanRated"
         ]
     },
     {
@@ -1469,7 +1498,7 @@
         "description": "An upper stage Kerosene/LOX engine designed for the Molniya launch vehicle. Also be used with the Voskhod and Soyuz launchers. Diameter: [1.7 m]. Using the patented SSTU Engine-Clustering technology the number of engines, engine layout, mounting or shroud type, and mount/shroud size are configurable, and each set of engines are built to your specifications. Plume configured by RealPlume.",
         "mod": "SSTU",
         "cost": "350",
-        "entry_cost": "0",
+        "entry_cost": "8000",
         "category": "ORBITAL",
         "info": "US Engine",
         "year": "1960",
@@ -1593,7 +1622,7 @@
         "title": "RL10 Series Vacuum Engine",
         "description": "Hydrolox restartable expander-cycle vacuum engine used in multiple upper stages, including Centaur, the Saturn I S-IV, and the Delta Cryogenic Second Stage. It has low thrust, but very high specific impulse and low mass, making it ideal for high energy, beyond-low-Earth-orbit applications like launching satellites to geostationary transfer orbits or to the Moon or other planets. However, like all hydrolox engines, hydrogen boiloff is a serious issue without heat pumps or radiators. Diameter: [0.92 m]. Using the patented SSTU Engine-Clustering technology the number of engines, engine layout, mounting or shroud type, and mount/shroud size are configurable, and each set of engines are built to your specifications. Plume configured by RealPlume.",
         "mod": "SSTU",
-        "cost": 500,
+        "cost": "1300",
         "entry_cost": "60000",
         "category": "HYDROLOX",
         "info": "US Engine",
@@ -1619,7 +1648,7 @@
         "title": "RL10A-4 Series Vacuum Engine",
         "description": "Hydrolox restartable expander-cycle vacuum engine used in countless applications. Most famous applications include the Centaur upper stage, the S-IV upper stage of the original Saturn I launcher, and the new Delta Cryogenic Second Stage. The RL10 uses liquid hydrogen and liquid oxygen (so beware of boiloff); it has very low thrust, but very high specific impulse, and is designed for beyond-Low-Earth-Orbit applications like launching satellites to geostationary transfer orbits or to the Moon or other planets. However, like all cryogenic engines, boiloff is a serious issue without heat pumps or radiators. Mount size can be adjusted from 1.25m to 10m in 1m increments. Diameter: [1.25 m]. Using the patented SSTU Engine-Clustering technology the number of engines, engine layout, mounting or shroud type, and mount/shroud size are configurable, and each set of engines are built to your specifications. Plume configured by RealPlume.",
         "mod": "SSTU",
-        "cost": 500,
+        "cost": "1300",
         "entry_cost": "26000",
         "category": "HYDROLOX",
         "info": "US Engine",
@@ -1645,7 +1674,7 @@
         "title": "RL10A-5",
         "description": "Throttleable RL10 engine redesigned for atmospheric use. used on the DC-X VTVL test vehicle. Diameter: [1.02 m]. Using the patented SSTU Engine-Clustering technology the number of engines, engine layout, mounting or shroud type, and mount/shroud size are configurable, and each set of engines are built to your specifications. Plume configured by RealPlume.",
         "mod": "SSTU",
-        "cost": 500,
+        "cost": "1300",
         "entry_cost": "26000",
         "category": "HYDROLOX",
         "info": "US Engine",
@@ -1788,9 +1817,11 @@
         "spacecraft": "Apollo",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "15000, dockingCrew, dockingAndro",
+        "entry_cost_mods": "",
         "identical_part_name": "Apollo Docking Port",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-SC-GEN-DP-1P",
@@ -1813,7 +1844,10 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "NASA Docking System",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated",
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-SC-GEN-FR-I",
@@ -1836,7 +1870,9 @@
         "upgrade": false,
         "entry_cost_mods": "1",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-SC-GEN-FR-N",
@@ -1859,7 +1895,9 @@
         "upgrade": false,
         "entry_cost_mods": "1",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-SC-GEN-FR-W",
@@ -1882,7 +1920,9 @@
         "upgrade": false,
         "entry_cost_mods": "1",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-SC-GEN-HGA",
@@ -1928,7 +1968,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-SC-GEN-IPA-W",
@@ -1951,7 +1993,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-SC-GEN-ISDC",
@@ -1974,7 +2018,9 @@
         "upgrade": false,
         "entry_cost_mods": "1",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-SC-GEN-PDC",
@@ -1985,8 +2031,8 @@
         "entry_cost": "0",
         "category": "MATERIALS",
         "info": "Decoupler",
-        "year": "0",
-        "technology": "unlockParts",
+        "year": "1952",
+        "technology": "earlyMaterialsScience",
         "era": "01-PW",
         "ro": true,
         "rp0": true,
@@ -1997,7 +2043,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-SC-GEN-RBDC",
@@ -2020,7 +2068,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Decoupler"
+        ]
     },
     {
         "name": "SSTU-SC-GEN-RCS-4A-V",
@@ -2031,8 +2081,8 @@
         "entry_cost": "2000",
         "category": "RCS",
         "info": "RCS",
-        "year": "1966",
-        "technology": "dockingCrewTransfer",
+        "year": "1967",
+        "technology": "advancedFlightControl",
         "era": "05-LUNAR",
         "ro": true,
         "rp0": true,
@@ -2081,8 +2131,8 @@
         "entry_cost": "2000",
         "category": "RCS",
         "info": "RCS",
-        "year": "1966",
-        "technology": "dockingCrewTransfer",
+        "year": "1967",
+        "technology": "advancedFlightControl",
         "era": "05-LUNAR",
         "ro": true,
         "rp0": true,


### PR DESCRIPTION
Added RP-0 pricing to the SSTU LC2-POD. it was previously RP-0 no cost.
I priced it the same as the FASA Lunar ascent module both similar functionally, Both have built in RCS