### PR TITLE
General rebalance of Procedural avionics

### DIFF
--- a/GameData/RP-0/Tree/EntryCostModifiers.cfg
+++ b/GameData/RP-0/Tree/EntryCostModifiers.cfg
@@ -161,56 +161,56 @@ ENTRYCOSTMODS
 	avionicsEarly = 8000, avionicsPW
 	avionicsBasic = 5000, avionicsEarly
 	avionicsIP = 5000, avionicsBasic
-	avionicsImproved = 0, avionicsIP
-	avionicsMature = 0, avionicsImproved
-	avionicsLargeScale = 0, avionicsMature
-	avionicsAdvanced = 0, avionicsLargeScale
-	avionicsNextGen = 0, avionicsAdvanced
-	avionicsLongTerm = 0, avionicsNextGen
+	avionicsImproved = 10000, avionicsIP
+	avionicsMature = 12000, avionicsImproved
+	avionicsLargeScale = 15000, avionicsMature
+	avionicsAdvanced = 20000, avionicsLargeScale
+	avionicsNextGen = 0 , avionicsAdvanced
+	avionicsLongTerm = 25000, avionicsNextGen
 	avionicsInternational = 0, avionicsLongTerm
-	avionicsModern = 0, avionicsInternational
+	avionicsModern = 30000, avionicsInternational
 
 	// Booster
 	avionicsBoosterPW = 2000, avionicsPW
-	avionicsBoosterEarly = 10000, avionicsEarly, avionicsBoosterPW
+	avionicsBoosterEarly = 3000, avionicsEarly, avionicsBoosterPW
 	avionicsBoosterBasic = 0, avionicsBasic, avionicsBoosterEarly
-	avionicsBoosterIP = 15000, avionicsImproved, avionicsBoosterBasic
-	avionicsBoosterImproved = 10000, avionicsImproved, avionicsBoosterIP
-	avionicsBoosterMature = 0, avionicsMature, avionicsBoosterImproved
-	avionicsBoosterLargeScale = 0, avionicsLargeScale, avionicsBoosterMature
-	avionicsBoosterAdvanced = 0, avionicsAdvanced, avionicsBoosterLargeScale
+	avionicsBoosterIP = 5000, avionicsImproved, avionicsBoosterBasic
+	avionicsBoosterImproved = 8000, avionicsImproved, avionicsBoosterIP
+	avionicsBoosterMature = 10000, avionicsMature, avionicsBoosterImproved
+	avionicsBoosterLargeScale = 10000, avionicsLargeScale, avionicsBoosterMature
+	avionicsBoosterAdvanced = 10000, avionicsAdvanced, avionicsBoosterLargeScale
 	avionicsBoosterNextGen = 0, avionicsNextGen, avionicsBoosterAdvanced
-	avionicsBoosterLongTerm = 0, avionicsLongTerm, avionicsBoosterNextGen
+	avionicsBoosterLongTerm = 10000, avionicsLongTerm, avionicsBoosterNextGen
 	avionicsBoosterInternational = 0, avionicsInternational, avionicsBoosterLongTerm
-	avionicsBoosterModern = 0, avionicsModern, avionicsBoosterInternational
+	avionicsBoosterModern = 10000, avionicsModern, avionicsBoosterInternational
 
 	// Probe Cores
 	avionicsProbesPW = 500, avionicsPW
 	avionicsProbesEarly = 3000, avionicsEarly, avionicsProbesPW
 	avionicsProbesBasic = 5000, avionicsBasic, avionicsProbesEarly, avionicsHibernation
 	avionicsProbesIP = 15000, avionicsImproved, avionicsProbesBasic
-	avionicsProbesImproved = 10000, avionicsImproved, avionicsProbesIP
-	avionicsProbesMature = 0, avionicsMature, avionicsProbesImproved
-	avionicsProbesLargeScale = 0, avionicsLargeScale, avionicsProbesMature
-	avionicsProbesAdvanced = 0, avionicsAdvanced, avionicsProbesLargeScale
+	avionicsProbesImproved = 20000, avionicsImproved, avionicsProbesIP
+	avionicsProbesMature = 25000, avionicsMature, avionicsProbesImproved
+	avionicsProbesLargeScale = 30000, avionicsLargeScale, avionicsProbesMature
+	avionicsProbesAdvanced = 35000, avionicsAdvanced, avionicsProbesLargeScale
 	avionicsProbesNextGen = 0, avionicsNextGen, avionicsProbesAdvanced
-	avionicsProbesLongTerm = 0, avionicsLongTerm, avionicsProbesNextGen
+	avionicsProbesLongTerm = 40000, avionicsLongTerm, avionicsProbesNextGen
 	avionicsProbesInternational = 0, avionicsInternational, avionicsProbesLongTerm
-	avionicsProbesModern = 0, avionicsModern, avionicsProbesInternational
+	avionicsProbesModern = 50000, avionicsModern, avionicsProbesInternational
 
 	// Upper Stage Avionics
 	avionicsUpperPW = 3000, avionicsPW
 	avionicsUpperEarly = 3000, avionicsEarly, avionicsUpperPW
 	avionicsUpperBasic = 5000, avionicsBasic, avionicsUpperEarly
-	avionicsUpperIP = 0, avionicsImproved, avionicsUpperBasic
-	avionicsUpperImproved = 0, avionicsImproved, avionicsUpperIP
-	avionicsUpperMature = 0, avionicsMature, avionicsUpperImproved
-	avionicsUpperLargeScale = 0, avionicsLargeScale, avionicsUpperMature
-	avionicsUpperAdvanced = 0, avionicsAdvanced, avionicsUpperLargeScale
+	avionicsUpperIP = 8000, avionicsImproved, avionicsUpperBasic
+	avionicsUpperImproved = 10000, avionicsImproved, avionicsUpperIP
+	avionicsUpperMature = 15000, avionicsMature, avionicsUpperImproved
+	avionicsUpperLargeScale = 15000, avionicsLargeScale, avionicsUpperMature
+	avionicsUpperAdvanced = 15000, avionicsAdvanced, avionicsUpperLargeScale
 	avionicsUpperNextGen = 0, avionicsNextGen, avionicsUpperAdvanced
-	avionicsUpperLongTerm = 0, avionicsLongTerm, avionicsUpperNextGen
+	avionicsUpperLongTerm = 15000, avionicsLongTerm, avionicsUpperNextGen
 	avionicsUpperInternational = 0, avionicsInternational, avionicsUpperLongTerm
-	avionicsUpperModern = 0, avionicsModern, avionicsUpperInternational
+	avionicsUpperModern = 15000, avionicsModern, avionicsUpperInternational
 
 	booster-start = 0
 	booster-avionicsPrototypes = avionicsBoosterPW
@@ -230,6 +230,14 @@ ENTRYCOSTMODS
 	upperStage-advancedAvionics = avionicsUpperAdvanced
 	upperStage-longTermAvionics = avionicsUpperLongTerm
 	upperStage-modernAvionics = avionicsUpperModern
+	
+	upperStage-basicAvionicsInter = avionicsUpperBasic, avionicsHibernation
+	upperStage-interplanetaryProbesInter = 5000, avionicsUpperIP, avionicsHibernation
+	upperStage-matureAvionicsInter = 7000, avionicsUpperMature, avionicsHibernation
+	upperStage-largeScaleAvionicsInter = 10000, avionicsUpperLargeScale, avionicsHibernation
+	upperStage-advancedAvionicsInter = 10000, avionicsUpperAdvanced, avionicsHibernation
+	upperStage-longTermAvionicsInter = 10000, avionicsUpperLongTerm, avionicsHibernation
+	upperStage-modernAvionicsInter = 10000, avionicsUpperModern, avionicsHibernation
 
 	probeCore-basicAvionics = avionicsProbesBasic
 	probeCore-interplanetaryProbes = avionicsProbesIP

--- a/GameData/RP-0/Tree/ProceduralAvionics.cfg
+++ b/GameData/RP-0/Tree/ProceduralAvionics.cfg
@@ -115,7 +115,7 @@
 				tonnageToMassRatio = 32
 				costPerControlledTon = 20
 				enabledkWPerTon = 0.16
-				standardAvionicsDensity = 3
+				standardAvionicsDensity = 1.5
 				minimumTonnage = 15
 				SASServiceLevel = 0
 				interplanetary = False
@@ -125,8 +125,8 @@
 				name = avionicsPrototypes
 				tonnageToMassRatio = 180
 				costPerControlledTon = 8
-				enabledkWPerTon = 0.007
-				standardAvionicsDensity = 3
+				enabledkWPerTon = 0.03
+				standardAvionicsDensity = 1.5
 				minimumTonnage = 45
 				SASServiceLevel = 0
 				interplanetary = False
@@ -136,8 +136,8 @@
 				name = earlyAvionics
 				tonnageToMassRatio = 300
 				costPerControlledTon = 3
-				enabledkWPerTon = 0.006
-				standardAvionicsDensity = 3
+				enabledkWPerTon = 0.01
+				standardAvionicsDensity = 1.5
 				minimumTonnage = 60
 				SASServiceLevel = 0
 				interplanetary = False
@@ -147,8 +147,8 @@
 				name = improvedAvionics
 				tonnageToMassRatio = 500
 				costPerControlledTon = 2.5
-				enabledkWPerTon = 0.0035
-				standardAvionicsDensity = 3
+				enabledkWPerTon = 0.005
+				standardAvionicsDensity = 1.5
 				minimumTonnage = 90
 				SASServiceLevel = 0
 				interplanetary = False
@@ -158,8 +158,8 @@
 				name = matureAvionics
 				tonnageToMassRatio = 750
 				costPerControlledTon = 2
-				enabledkWPerTon = 0.001
-				standardAvionicsDensity = 3
+				enabledkWPerTon = 0.003
+				standardAvionicsDensity = 1.5
 				minimumTonnage = 120
 				SASServiceLevel = 0
 				interplanetary = False
@@ -169,8 +169,8 @@
 				name = largeScaleAvionics
 				tonnageToMassRatio = 1500
 				costPerControlledTon = 1.5
-				enabledkWPerTon = 0.0008
-				standardAvionicsDensity = 3
+				enabledkWPerTon = 0.001
+				standardAvionicsDensity = 1.5
 				minimumTonnage = 200
 				SASServiceLevel = 0
 				interplanetary = False
@@ -178,10 +178,10 @@
 			TECHLIMIT # TL6 - Space Station Era
 			{
 				name = advancedAvionics
-				tonnageToMassRatio = 3079.4
+				tonnageToMassRatio = 3000
 				costPerControlledTon = 1
 				enabledkWPerTon = 0.0005
-				standardAvionicsDensity = 3
+				standardAvionicsDensity = 1.5
 				minimumTonnage = 300
 				SASServiceLevel = 0
 				interplanetary = False
@@ -189,10 +189,10 @@
 			TECHLIMIT # TL7 - Long Term Habitation
 			{
 				name = longTermAvionics
-				tonnageToMassRatio = 6928.7
+				tonnageToMassRatio = 7000
 				costPerControlledTon = 0.75
 				enabledkWPerTon = 0.0002
-				standardAvionicsDensity = 3
+				standardAvionicsDensity = 1.5
 				minimumTonnage = 400
 				SASServiceLevel = 0
 				interplanetary = False
@@ -200,10 +200,10 @@
 			TECHLIMIT # TL8 - Commercial Era
 			{
 				name = modernAvionics
-				tonnageToMassRatio = 15590
+				tonnageToMassRatio = 15000
 				costPerControlledTon = 0.5
 				enabledkWPerTon = 0.0001
-				standardAvionicsDensity = 3
+				standardAvionicsDensity = 1.5
 				minimumTonnage = 500
 				SASServiceLevel = 0
 				interplanetary = False
@@ -218,8 +218,8 @@
 				name = avionicsPrototypes
 				tonnageToMassRatio = 35
 				costPerControlledTon = 20
-				enabledkWPerTon = 0.03
-				standardAvionicsDensity = 2
+				enabledkWPerTon = 0.025
+				standardAvionicsDensity = 1
 				minimumTonnage = 5
 				SASServiceLevel = 0
 				interplanetary = False
@@ -229,61 +229,120 @@
 			{
 				name = earlyAvionics
 				tonnageToMassRatio = 60
-				costPerControlledTon = 18
-				enabledkWPerTon = 0.012
-				standardAvionicsDensity = 2
-				minimumTonnage = 8
+				costPerControlledTon = 15
+				enabledkWPerTon = 0.01
+				standardAvionicsDensity = 1
+				minimumTonnage = 7
 				SASServiceLevel = 0
 				interplanetary = False
+			}
+
+			TECHLIMIT #TL1 - Satellite era Interplanetary cfg
+			{
+				name = basicAvionicsInter
+				tonnageToMassRatio = 50
+				costPerControlledTon = 80
+				enabledkWPerTon = 0.012
+				disabledkWPerTon = 0.004
+				standardAvionicsDensity = 1
+				minimumTonnage = 12
+				SASServiceLevel = 0
+				interplanetary = True
 			}
 
 			TECHLIMIT # TL2 - Human and Interplanetary probes
 			{
 				name = interplanetaryProbes
 				tonnageToMassRatio = 100
-				costPerControlledTon = 10
-				enabledkWPerTon = 0.008
-				standardAvionicsDensity = 2
-				minimumTonnage = 12
+				costPerControlledTon = 11
+				enabledkWPerTon = 0.007
+				standardAvionicsDensity = 1
+				minimumTonnage = 10
 				SASServiceLevel = 0
 				interplanetary = False
+			}
+			
+			TECHLIMIT # TL2 - Human and Interplanetary probes Interplanetary cfg
+			{
+				name = interplanetaryProbesInter
+				tonnageToMassRatio = 80
+				costPerControlledTon = 50
+				enabledkWPerTon = 0.008
+				disabledkWPerTon = 0.0016
+				standardAvionicsDensity = 1
+				minimumTonnage = 16
+				SASServiceLevel = 0
+				interplanetary = True
 			}
 
 			TECHLIMIT # TL3 - Advanced Capsules
 			{
 				name = matureAvionics
 				tonnageToMassRatio = 180
-				costPerControlledTon = 20
-				enabledkWPerTon = 0.005
-				disabledkWPerTon = 0.0005
-				standardAvionicsDensity = 2
-				minimumTonnage = 20
+				costPerControlledTon = 7
+				enabledkWPerTon = 0.004
+				standardAvionicsDensity = 1
+				minimumTonnage = 15
 				SASServiceLevel = 0
 				interplanetary = False
+			}
+			TECHLIMIT # TL3 - Advanced Capsules Interplanetary cfg
+			{
+				name = matureAvionicsInter
+				tonnageToMassRatio = 140
+				costPerControlledTon = 30
+				enabledkWPerTon = 0.005
+				disabledkWPerTon = 0.0007
+				standardAvionicsDensity = 1
+				minimumTonnage = 22
+				SASServiceLevel = 0
+				interplanetary = True
 			}
 
 			TECHLIMIT # TL4 - Lunar Era
 			{
 				name = largeScaleAvionics
 				tonnageToMassRatio = 300
-				costPerControlledTon = 15
+				costPerControlledTon = 5
 				enabledkWPerTon = 0.002
-				disabledkWPerTon = 0.0002
-				standardAvionicsDensity = 2
-				minimumTonnage = 30
+				standardAvionicsDensity = 1
+				minimumTonnage = 22
 				SASServiceLevel = 0
 				interplanetary = False
+			}
+			TECHLIMIT # TL4 - Lunar Era Interplanetary cfg
+			{
+				name = largeScaleAvionicsInter
+				tonnageToMassRatio = 250
+				costPerControlledTon = 25
+				enabledkWPerTon = 0.002
+				disabledkWPerTon = 0.0002
+				standardAvionicsDensity = 1
+				minimumTonnage = 30
+				SASServiceLevel = 0
+				interplanetary = True
 			}
 
 			TECHLIMIT # TL5 - Space Station Era
 			{
 				name = advancedAvionics
-				tonnageToMassRatio = 1161.3
-				costPerControlledTon = 1.47
-				enabledkWPerTon = 6.48
-				disabledkWPerTon = 0.648
-				standardAvionicsDensity = 0.0995
-				minimumTonnage = 12
+				tonnageToMassRatio = 450
+				costPerControlledTon = 3.5
+				enabledkWPerTon = 0.001
+				standardAvionicsDensity = 1
+				minimumTonnage = 30
+				SASServiceLevel = 0
+				interplanetary = False
+			}
+			TECHLIMIT # TL5 - Space Station Era Interplanetary cfg
+			{
+				name = advancedAvionicsInter
+				tonnageToMassRatio = 400
+				costPerControlledTon = 15
+				enabledkWPerTon = 0.001
+				disabledkWPerTon = 0.0001
+				standardAvionicsDensity = 1
+				minimumTonnage = 30
 				SASServiceLevel = 0
 				interplanetary = True
 			}
@@ -291,12 +350,23 @@
 			TECHLIMIT # TL6 - Long Term Habitation
 			{
 				name = longTermAvionics
-				tonnageToMassRatio = 2322
-				costPerControlledTon = 0.886
-				enabledkWPerTon = 3.889
-				disabledkWPerTon = 0.389
-				standardAvionicsDensity = 0.0995
-				minimumTonnage = 12
+				tonnageToMassRatio = 600
+				costPerControlledTon = 2.5
+				enabledkWPerTon = 0.00075
+				standardAvionicsDensity = 1
+				minimumTonnage = 30
+				SASServiceLevel = 0
+				interplanetary = False
+			}
+			TECHLIMIT # TL6 - Long Term Habitation Interplanetary cfg
+			{
+				name = longTermAvionicsInter
+				tonnageToMassRatio = 500
+				costPerControlledTon = 10
+				enabledkWPerTon = 0.00075
+				disabledkWPerTon = 0.000075
+				standardAvionicsDensity = 1
+				minimumTonnage = 30
 				SASServiceLevel = 0
 				interplanetary = True
 			}
@@ -304,15 +374,27 @@
 			TECHLIMIT # TL7 - Commercial Era
 			{
 				name = modernAvionics
-				tonnageToMassRatio = 4645
-				costPerControlledTon = 0.527
-				enabledkWPerTon = 2.33
-				disabledkWPerTon = 0.23
-				standardAvionicsDensity = 0.0995
-				minimumTonnage = 12
+				tonnageToMassRatio = 750
+				costPerControlledTon = 1.5
+				enabledkWPerTon = 0.0005
+				standardAvionicsDensity = 1
+				minimumTonnage = 30
+				SASServiceLevel = 0
+				interplanetary = False
+			}
+			TECHLIMIT # TL7 - Commercial Era Interplanetary cfg
+			{
+				name = modernAvionicsInter
+				tonnageToMassRatio = 600
+				costPerControlledTon = 5
+				enabledkWPerTon = 0.0005
+				disabledkWPerTon = 0.00005
+				standardAvionicsDensity = 1
+				minimumTonnage = 30
 				SASServiceLevel = 0
 				interplanetary = True
 			}
+			
 		}
 		AVIONICSCONFIG
 		{
@@ -375,9 +457,10 @@
 				name = advancedAvionics
 				tonnageToMassRatio = 12
 				costPerControlledTon = 1750
-				enabledkWPerTon = 20.48
-				disabledkWPerTon = 0.3
+				enabledkWPerTon = 0.02
+				disabledkWPerTon = 0.0003
 				standardAvionicsDensity = 0.25
+				minimumTonnage = 0.35
 				SASServiceLevel = 5
 				hasScienceContainer = true
 				interplanetary = True
@@ -387,9 +470,10 @@
 				name = longTermAvionics
 				tonnageToMassRatio = 15
 				costPerControlledTon = 1500
-				enabledkWPerTon = 13
-				disabledkWPerTon = 0.18
+				enabledkWPerTon = 0.013
+				disabledkWPerTon = 0.00018
 				standardAvionicsDensity = 0.25
+				minimumTonnage = 0.35
 				SASServiceLevel = 5
 				hasScienceContainer = true
 				interplanetary = True
@@ -399,9 +483,10 @@
 				name = modernAvionics
 				tonnageToMassRatio = 18.5
 				costPerControlledTon = 1200
-				enabledkWPerTon = 9.3
-				disabledkWPerTon = 0.1
+				enabledkWPerTon = 0.0093
+				disabledkWPerTon = 0.0001
 				standardAvionicsDensity = 0.25
+				minimumTonnage = 0.35
 				SASServiceLevel = 5
 				hasScienceContainer = true
 				interplanetary = True
@@ -575,6 +660,19 @@ PARTUPGRADE
 
 PARTUPGRADE
 {
+	name = procAvionics-upperInter-tltech1
+	partIcon = proceduralAvionics
+	techRequired = basicAvionics
+	entryCost = 0
+	cost = 0
+	title = Procedural Avionics - Deep Space Upper Stage Avionics
+	basicInfo = Deep Space Upper Stage Avionics are now available for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+	manufacturer = Generic
+	description = Upper Stage Avionics are now available for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+}
+
+PARTUPGRADE
+{
 	name = procAvionics-upper-tltech2
 	partIcon = proceduralAvionics
 	techRequired = interplanetaryProbes
@@ -584,6 +682,19 @@ PARTUPGRADE
 	basicInfo = This is an upgrade for the Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
 	description = This is an upgrade for the Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+}
+
+PARTUPGRADE
+{
+	name = procAvionics-upperInter-tltech2
+	partIcon = proceduralAvionics
+	techRequired = basicAvionics
+	entryCost = 0
+	cost = 0
+	title = Procedural Avionics - Deep Space Upper Stage Upgrade
+	basicInfo = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+	manufacturer = Generic
+	description = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 }
 
 PARTUPGRADE
@@ -601,6 +712,19 @@ PARTUPGRADE
 
 PARTUPGRADE
 {
+	name = procAvionics-upperInter-tltech3
+	partIcon = proceduralAvionics
+	techRequired = basicAvionics
+	entryCost = 0
+	cost = 0
+	title = Procedural Avionics - Deep Space Upper Stage Upgrade
+    basicInfo = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+	manufacturer = Generic
+	description = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+}
+
+PARTUPGRADE
+{
 	name = procAvionics-upper-tltech4
 	partIcon = proceduralAvionics
 	techRequired = largeScaleAvionics
@@ -610,6 +734,19 @@ PARTUPGRADE
 	basicInfo = This is an upgrade for the Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
 	description = This is an upgrade for the Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+}
+
+PARTUPGRADE
+{
+	name = procAvionics-upperInter-tltech4
+	partIcon = proceduralAvionics
+	techRequired = basicAvionics
+	entryCost = 0
+	cost = 0
+	title = Procedural Avionics - Deep Space Upper Stage Upgrade
+	basicInfo = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+	manufacturer = Generic
+	description = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 }
 
 PARTUPGRADE
@@ -627,6 +764,19 @@ PARTUPGRADE
 
 PARTUPGRADE
 {
+	name = procAvionics-upperInter-tltech5
+	partIcon = proceduralAvionics
+	techRequired = basicAvionics
+	entryCost = 0
+	cost = 0
+	title = Procedural Avionics - Deep Space Upper Stage Upgrade
+	basicInfo = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+	manufacturer = Generic
+	description = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+}
+
+PARTUPGRADE
+{
 	name = procAvionics-upper-tltech6
 	partIcon = proceduralAvionics
 	techRequired = longTermAvionics
@@ -640,6 +790,19 @@ PARTUPGRADE
 
 PARTUPGRADE
 {
+	name = procAvionics-upperInter-tltech6
+	partIcon = proceduralAvionics
+	techRequired = basicAvionics
+	entryCost = 0
+	cost = 0
+	title = Procedural Avionics - Deep Space Upper Stage Upgrade
+	basicInfo = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+	manufacturer = Generic
+	description = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+}
+
+PARTUPGRADE
+{
 	name = procAvionics-upper-tltech7
 	partIcon = proceduralAvionics
 	techRequired = modernAvionics
@@ -649,6 +812,19 @@ PARTUPGRADE
 	basicInfo = This is an upgrade for the Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
 	description = This is an upgrade for the Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+}
+
+PARTUPGRADE
+{
+	name = procAvionics-upperInter-tltech7
+	partIcon = proceduralAvionics
+	techRequired = basicAvionics
+	entryCost = 0
+	cost = 0
+	title = Procedural Avionics - Deep Space Upper Stage Upgrade
+	basicInfo = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+	manufacturer = Generic
+	description = This is an upgrade for the Deep Space Upper Stage Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 }
 
 // Probe Core Avionics Upgrades *********************************************


### PR DESCRIPTION
* Adds a Deep Space Upper stage avionics. it is capable of going interplanetary and hibernates. Focused in crewed spacecraft and satellite buses

* Makes the "normal" upper stage slightly cheaper and unable to hibernate or go into deep space

* Tentative values for all ECMs for avionics

* Small tweaks to all avionics, increasing energy consumption in boosters, and imputing values for more advanced parts.

* Reduce density of booster and upper avionics, as those were getting too small