### PR TITLE
Update MS01-IonMassSpectrometer.cfg

### DIFF
--- a/GameData/RP-0/Parts/Science/MS01-IonMassSpectrometer.cfg
+++ b/GameData/RP-0/Parts/Science/MS01-IonMassSpectrometer.cfg
@@ -33,7 +33,9 @@ PART
 	subcategory = 0
 	title = Ion Mass Spectrometer
 	manufacturer = Bluedog Design Bureau
-	description = Commonly called Bennet Radio frequency mass spectrometers, they are only sensitive to charged atoms and molecules since they do not incorporate an ion source. Mass spectrometry is an analytical technique that ionizes chemical species and sorts the ions based on their mass-to-charge ratio. Historically, these simple experiments were flown on many Aerobee sounding rockets and returned to Earth for study.\n\n<b><color=white>This experiment can only be transmitted for 50% of the science.</color></b>\n\nLevel 1 Mass Spectrometry Experiment. Can gather 25% of Mass Spectrometry Science.
+	description = Commonly called Bennet Radio frequency mass spectrometers, they are only sensitive to charged atoms and molecules since they do not incorporate an ion source. Mass spectrometry is an analytical technique that ionizes chemical species and sorts the ions based on their mass-to-charge ratio. Historically, these simple experiments were flown on many Aerobee sounding rockets and returned to Earth for study.\n\nLevel 1 Mass Spectrometry Experiment. Can gather 25% of Mass Spectrometry Science.
+	// removed: <b><color=white>This experiment can only be transmitted for 50% of the science.</color></b>\n\n
+	
 	attachRules = 0,1,0,0,1
 	mass = 0.0022  // Source: https://www.jstage.jst.go.jp/article/jgg1949/27/4/27_4_303/_pdf
 	dragModelType = default


### PR DESCRIPTION
In https://github.com/KSP-RO/RP-0/commit/621ed1e115f51201c5b100923108e735faa099cc
the science transmission ratio is set to 100%. Therefore I delete the 50% sentence from the description.