### PR TITLE
x-planes supersonic contract should allow > 1 crew

### DIFF
--- a/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
@@ -60,7 +60,7 @@ CONTRACT_TYPE
 			name = Has Crew
 			type = HasCrew
 			minCrew = 1
-			maxCrew = 1
+			maxCrew = 99
 			title = Have 1 crewmember on board
 			hideChildren = true
 		}


### PR DESCRIPTION
No reason for the contract to require exactly 1 crew member.
You can EVA additional passengers after taking them for the ride to satisfy maxCrew = 1.

Crewed flight and crewed high contracts both have maxCrew = 99.