### PR TITLE
Wrong description for GEO weather sat

### DIFF
--- a/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = WeatherSats
 
 	description = Geostationary satellites provide the best views of the clouds in specific areas for our meteorologists. Place a weather satellite in geostationary orbit near the marked area. This contract can be completed up to 6 times.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: $GEOWeather_Count</b>
-	genericDescription = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like. The orbits will be chosen randomly from Tundra, Geostationary, Molniya and Geosynchronous orbits.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.
+	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a geostationary weather satellite to the marked area
 


### PR DESCRIPTION
Looks like it was copied from comms sats. Also references other orbits even though contract is only for GEO.
Replaced with genericDescription from other weather sat contracts.