### PR TITLE
Fix the elusive return capsule parachute bug

### DIFF
--- a/GameData/RP-0/Parts/SampleReturnCapsule/RP0SampleReturnCommand.cfg
+++ b/GameData/RP-0/Parts/SampleReturnCapsule/RP0SampleReturnCommand.cfg
@@ -106,8 +106,8 @@ PART
 		
 		atmosphereCurve
 		{
-			key = 0 195
-			key = 1 80
+			key = 0 80
+			key = 1 73
 			key = 4 0.001
 		}
 	}
@@ -160,6 +160,7 @@ PART
         mustGoDown = True
         spareChutes = 0
         cutSpeed = 0.5
+	reverseOrientation = true
 
         PARACHUTE
         {
@@ -177,7 +178,6 @@ PART
             deploymentSpeed = 6
             deploymentAlt = 1000
             cutAlt = 0
-			reverseOrientation = true
         }
     }
 	


### PR DESCRIPTION
reverseOrientation = true needed to be outside PARACHUTE... ¯\_(ツ)_/¯

Also changed the ISP to theoretical max values for cold gas Nitrogen in vacuum and at 1 atm.
Used 500 bar for RCS tank pressure for calculation at 1 atm. It's probably a bit generous, but it's better than the current hydrazine numbers.

Ref for theoretical cold gas ISP, http://cdn.intechopen.com/pdfs/37528/InTech-Cold_gas_propulsion_system_an_ideal_choice_for_remote_sensing_small_satellites.pdf