### PR TITLE
Added ROCapsules Mercury avionics

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -20,7 +20,7 @@
 
 // *** Command parts (Crewed)
 // FIXME: Add any other 1-person capsules here
-@PART[mk1pod|FASAMercuryPod|avionicsNoseCone]:FOR[RP-0]
+@PART[mk1pod|FASAMercuryPod|avionicsNoseCone|ROC-MercuryCM]:FOR[RP-0]
 {
 	MODULE
 	{


### PR DESCRIPTION
The other capsules in ROCapsules were tagged along their counterparts from other mods but the Mercury pod got left out. Simple fix.