### PR TITLE
Reduce tech node & entry costs for early solid motors

### DIFF
--- a/GameData/RP-0/Tree/ECM-Engines.cfg
+++ b/GameData/RP-0/Tree/ECM-Engines.cfg
@@ -67,7 +67,7 @@
     CECE-Base = 80000
     CECE-High = 80000
     CECE-Methane = 80000
-    Castor-1 = 5000, SolidsHollow
+    Castor-1 = 30000, SolidsHollow
     Castor-1-SL = 5000, Castor-1
     Castor-1-Vac = 5000, Castor-1
     Castor-120 = 0
@@ -380,7 +380,7 @@
     Star-9 = 0
     Star48BV = 0
     SuperDraco = 0
-    T17-E2 = 5000, Castor-1
+    T17-E2 = 10000, SolidsHollow
     TD-339 = 0
     TR-201 = 2000
     TRITON = 0
@@ -413,6 +413,6 @@
     XLR81-BA-5 = Model8048
     XLR81-BA-7 = Model8081, PumpReignition
     XLR99 = 50000, XLR11
-    XM-20 = 5000, SolidsHollow
+    XM-20 = Castor-1
     XRS-2200 = 0
 }

--- a/GameData/RP-0/Tree/EntryCostModifiers.cfg
+++ b/GameData/RP-0/Tree/EntryCostModifiers.cfg
@@ -26,12 +26,12 @@ ENTRYCOSTMODS
 	PumpReignition = 20000 // Ability to Relight
 	Gimbal = 0 // Given it's standard in turbopump engines, I think this can be applied only for PF ones
 
-	SolidsHollow = 50000
+	SolidsHollow = 25000
 	SolidsFiber = 10000
-	SolidsHTPB = 50000, SolidsHollow
+	SolidsHTPB = 75000, SolidsHollow
 	SolidsTVC = 100000
 	SolidsSegmented = 300000, SolidsLarge
-	SolidsPBAN = 70000, SolidsHollow
+	SolidsPBAN = 95000, SolidsHollow
 	SolidsLarge = 100000
 	Minuteman = 30000, SolidsPBAN
 	Polaris = 20000, SolidsHTPB

--- a/GameData/RP-0/Tree/RP0TechTree.cfg
+++ b/GameData/RP-0/Tree/RP0TechTree.cfg
@@ -3228,7 +3228,7 @@
 		id = basicSolids
 		title = Basic Solid Rocket Engines
 		description = Basic Solid Rocket Engines (1952-1955)
-		cost = 2
+		cost = 1
 		hideEmpty = False
 		nodeName = basicSolids
 		anyToUnlock = False
@@ -3247,7 +3247,7 @@
 		id = solids1956
 		title = 1956-1957 Solid Rocket Engines
 		description = 1956-1957 Solid Rocket Engines
-		cost = 6
+		cost = 5
 		hideEmpty = False
 		nodeName = solids1956
 		anyToUnlock = False
@@ -3272,7 +3272,7 @@
 		id = solids1958
 		title = 1958 Solid Rocket Engines
 		description = 1958 Solid Rocket Engines
-		cost = 10
+		cost = 5
 		hideEmpty = False
 		nodeName = solids1958
 		anyToUnlock = False
@@ -3291,7 +3291,7 @@
 		id = solids1959
 		title = 1959-1960 Solid Rocket Engines
 		description = 1959-1960 Solid Rocket Engines
-		cost = 19
+		cost = 7
 		hideEmpty = False
 		nodeName = solids1959
 		anyToUnlock = False
@@ -3310,7 +3310,7 @@
 		id = solids1962
 		title = 1962-1963 Solid Rocket Engines
 		description = 1962-1963 Solid Rocket Engines
-		cost = 37
+		cost = 12
 		hideEmpty = False
 		nodeName = solids1962
 		anyToUnlock = False
@@ -3335,7 +3335,7 @@
 		id = solids1964
 		title = 1964-1965 Solid Rocket Engines
 		description = 1964-1965 Solid Rocket Engines
-		cost = 50
+		cost = 35
 		hideEmpty = False
 		nodeName = solids1964
 		anyToUnlock = False
@@ -3360,7 +3360,7 @@
 		id = solids1966
 		title = 1966 Solid Rocket Engines
 		description = 1966 Solid Rocket Engines
-		cost = 60
+		cost = 45
 		hideEmpty = False
 		nodeName = solids1966
 		anyToUnlock = False
@@ -3379,7 +3379,7 @@
 		id = solids1967
 		title = 1967-1968 Solid Rocket Engines
 		description = 1967-1968 Solid Rocket Engines
-		cost = 80
+		cost = 50
 		hideEmpty = False
 		nodeName = solids1967
 		anyToUnlock = False
@@ -3404,7 +3404,7 @@
 		id = solids1969
 		title = 1969-1971 Solid Rocket Engines
 		description = 1969-1971 Solid Rocket Engines
-		cost = 90
+		cost = 60
 		hideEmpty = False
 		nodeName = solids1969
 		anyToUnlock = False
@@ -3423,7 +3423,7 @@
 		id = solids1972
 		title = 1972-1975 Solid Rocket Engines
 		description = 1972-1975 Solid Rocket Engines
-		cost = 116
+		cost = 90
 		hideEmpty = False
 		nodeName = solids1972
 		anyToUnlock = False

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -8519,7 +8519,7 @@
         "spacecraft": "Baby Sergeant",
         "engine_config": "BabySergeant",
         "upgrade": false,
-        "entry_cost_mods": "5000, Castor-1",
+        "entry_cost_mods": "10000, SolidsHollow",
         "identical_part_name": "",
         "module_tags": []
     },
@@ -9280,7 +9280,7 @@
         "spacecraft": "",
         "engine_config": "Castor-1",
         "upgrade": false,
-        "entry_cost_mods": "5000, SolidsHollow",
+        "entry_cost_mods": "Castor-1",
         "identical_part_name": "",
         "module_tags": []
     },


### PR DESCRIPTION
Part entry cost for upper stage solids was reduced by 25K. The biggest change is probably in the tech tree where early nodes got a sci point reduction in the range of 2-3x. I would've liked to reduce the first node to 0.5 points but unfortunately KSP doesn't support floating point values there. I chose the new values based on how much useful tech you get by researching it. Because of that the 1956 node ~~got a higher cost than 1958.~~ has the same cost as 1958.