### PR TITLE
Made waypoint naming for the lunar rover contract consistent

### DIFF
--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Rover.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Rover.cfg
@@ -94,7 +94,7 @@ CONTRACT_TYPE
 
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 1
 			distance = 100.0
@@ -147,7 +147,7 @@ CONTRACT_TYPE
 
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Lunar Rover Beta
+			name = Lunar Rover Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			targetBody = Moon
@@ -162,7 +162,7 @@ CONTRACT_TYPE
 	   RANDOM_WAYPOINT_NEAR
 		{
 			name = Lunar Rover Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			targetBody = Moon
 			count = 1

--- a/GameData/RP-0/Contracts/Rovers/Callisto Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Callisto Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Charon Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Charon Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Dione Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Dione Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Enceladus Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Enceladus Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Europa Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Europa Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Ganymede Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Ganymede Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Iapetus Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Iapetus Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Io Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Io Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Mars Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Mars Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Mercury Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Mercury Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Mimas Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Mimas Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Pluto Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Pluto Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Rhea Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Rhea Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Tethys Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Tethys Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Titan Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Titan Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Triton Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Triton Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker

--- a/GameData/RP-0/Contracts/Rovers/Venus Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Venus Rover.cfg
@@ -75,12 +75,12 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = WaypointBeta
+			name = WaypointBravo
 			type = VisitWaypoint
 			index = 0
 			distance = 100.0
 			disableOnStateChange = true
-			title = Visit Rover Site Beta
+			title = Visit Rover Site Bravo
 			hideChildren = true
 			showMessages = true
 		}
@@ -123,7 +123,7 @@ CONTRACT_TYPE
 		}
 		RANDOM_WAYPOINT_NEAR
 		{
-			name = Rover Site Beta
+			name = Rover Site Bravo
 			parameter = WaypointAlpha
 			hidden = false
 			count = 1
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 		RANDOM_WAYPOINT_NEAR
 		{
 			name = Rover Site Charlie
-			parameter = WaypointBeta
+			parameter = WaypointBravo
 			hidden = false
 			count = 1
 			icon = marker


### PR DESCRIPTION
In certain config points the second waypoint was labeled 'Beta', in others 'Bravo'. Now it's all NATO compliant. _Loud cheering in the background_