### PR TITLE
Reduced Nike Part Cost

### DIFF
--- a/GameData/RP-0/Tree/TREE-Engines.cfg
+++ b/GameData/RP-0/Tree/TREE-Engines.cfg
@@ -535,7 +535,7 @@
 
             @CONFIG[GCRC]
             {
-                %techRequired = basicSolids
+                %techRequired = solids1956
                 %cost = 0
             }
 

--- a/Source/Tech Tree/Parts Browser/data/ROEngines.json
+++ b/Source/Tech Tree/Parts Browser/data/ROEngines.json
@@ -2940,7 +2940,7 @@
         "title": "Nike-M5E1",
         "description": "",
         "mod": "ROEngines",
-        "cost": "361",
+        "cost": "180",
         "entry_cost": "1200",
         "category": "SOLID",
         "info": "",


### PR DESCRIPTION
Despite the (I assume) historical accuracy of this cost, it's well over double that of the Castor-1 and over seven times as expensive as the AJ2.5. For a reasonable Aerobee 200 analogue (we don't have an AJ60-92, but the AJ10-27 produces comparable thrust), the Nike alone is up to 3/4 the total cost.  Halving the cost will keep it expensive compared to similar motors but not stupidly so.