### PR TITLE
Tweak new science-SR contracts

### DIFF
--- a/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingDifficult.cfg
@@ -170,6 +170,24 @@ CONTRACT_TYPE
 			title = Have not accepted @contractType Contract
 			invertRequirement = true
 		}
+
+		REQUIREMENT
+		{
+			name = AcceptContract
+			type = AcceptContract
+			contractType = SoundingRocketBio
+			title = Have not accepted @contractType Contract
+			invertRequirement = true
+		}
+
+		REQUIREMENT
+		{
+			name = AcceptContract
+			type = AcceptContract
+			contractType = SoundingRocketFilm
+			title = Have not accepted @contractType Contract
+			invertRequirement = true
+		}
 	}
 		
 	

--- a/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingIntermediate.cfg
@@ -171,6 +171,24 @@ CONTRACT_TYPE
 			title = Have not accepted @contractType Contract
 			invertRequirement = true
 		}
+
+		REQUIREMENT
+		{
+			name = AcceptContract
+			type = AcceptContract
+			contractType = SoundingRocketBio
+			title = Have not accepted @contractType Contract
+			invertRequirement = true
+		}
+
+		REQUIREMENT
+		{
+			name = AcceptContract
+			type = AcceptContract
+			contractType = SoundingRocketFilm
+			title = Have not accepted @contractType Contract
+			invertRequirement = true
+		}
 	}
 	
 	PARAMETER

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingBio.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingBio.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	
 	title = Low Space Biological Experimentation
 	genericTitle = Low Space Biological Experimentation
-	description = Launching small mammals will prepare us for the monumental task of putting an astronaut into space. Carry a small biological capsule and @payload units of monitoring instrumentation above the Karman line, then recover the experiment. <br>This is a series of 3 contracts, of which $SoundingBio_Count have been completed. After series completion, crewed suborbital contracts will become available.
+	description = Launching small mammals will prepare us for the monumental task of putting an astronaut into space. Carry a small biological capsule and @payload units of monitoring instrumentation above the Karman line, then recover the experiment. <br>This is a series of 3 contracts, of which $SoundingBio_Count have been completed.<br> <color=white><b>After series completion, crewed suborbital contracts will become available</b></color>.
 	genericDescription = Put a biological experiment and a new scientific payload above the Karman Line and recover the experiment and payload safely.
 	synopsis = Launch and recover a biological capsule and @payload units of scientific equipment from over @/altitudeKm km
 	completedMessage = Well done! Our scientists are now studying the sample to see the effects of the journey.
@@ -133,6 +133,10 @@ CONTRACT_TYPE
 	{
 		name = IncrementTheCount
 		type = Expression
+		CONTRACT_OFFERED
+		{
+			SoundingBio_Count = $SoundingBio_Count + 0
+		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			SoundingBio_Count = $SoundingBio_Count + 1

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingDifficult.cfg
@@ -167,6 +167,24 @@ CONTRACT_TYPE
 			title = Have not accepted @contractType Contract
 			invertRequirement = true
 		}
+
+		REQUIREMENT
+		{
+			name = AcceptContract
+			type = AcceptContract
+			contractType = SoundingRocketBio
+			title = Have not accepted @contractType Contract
+			invertRequirement = true
+		}
+
+		REQUIREMENT
+		{
+			name = AcceptContract
+			type = AcceptContract
+			contractType = SoundingRocketFilm
+			title = Have not accepted @contractType Contract
+			invertRequirement = true
+		}
 		
 		//REQUIREMENT
 		//{

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingFilm.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingFilm.cfg
@@ -134,6 +134,10 @@ CONTRACT_TYPE
 	{
 		name = IncrementTheCount
 		type = Expression
+		CONTRACT_OFFERED
+		{
+			SoundingFilm_Count = $SoundingFilm_Count + 0
+		}                
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			SoundingFilm_Count = $SoundingFilm_Count + 1

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingIntermediate.cfg
@@ -168,6 +168,24 @@ CONTRACT_TYPE
 			title = Have not accepted @contractType Contract
 			invertRequirement = true
 		}
+
+		REQUIREMENT
+		{
+			name = AcceptContract
+			type = AcceptContract
+			contractType = SoundingRocketBio
+			title = Have not accepted @contractType Contract
+			invertRequirement = true
+		}
+
+		REQUIREMENT
+		{
+			name = AcceptContract
+			type = AcceptContract
+			contractType = SoundingRocketFilm
+			title = Have not accepted @contractType Contract
+			invertRequirement = true
+		}
 		
 		//REQUIREMENT
 		//{


### PR DESCRIPTION
- initialize the completion counts so that 'N completed' actually shows
  zero (hackish, probably a better way)
- make the 'Bio SR unlocks Crewed Suborbital' message stand out
- remove other SR contracts when bio or film SR are accepted
  (because accepting them hides bio & film, even if already accepted)