### PR TITLE
Fix Mk1 pod's avionics and training configs

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -31,7 +31,7 @@
 
 // *** Command parts (Crewed)
 // FIXME: Add any other 1-person capsules here
-@PART[mk1pod|FASAMercuryPod|avionicsNoseCone|ROC-MercuryCM]:FOR[RP-0]
+@PART[mk1pod|mk1pod_v2|FASAMercuryPod|avionicsNoseCone|ROC-MercuryCM]:FOR[RP-0]
 {
 	MODULE
 	{

--- a/GameData/RP-0/CrewTrainingTimes.cfg
+++ b/GameData/RP-0/CrewTrainingTimes.cfg
@@ -65,6 +65,7 @@ TRAININGTIMES
 	Mercury = 100, BasicCapsules								// 260
 		FASAMercuryPod = Mercury
 		mk1pod = Mercury
+		mk1pod-v2 = Mercury
 		orbitaiespod = Mercury
 		ROC-MercuryCM = Mercury
 	Mercury-Mission = 75


### PR DESCRIPTION
ksp 1.6 introduced a mk1pod.v2 part. Most of rp-1 was switched over to
it; avionics and training, which live in their own file, were overlooked