### PR TITLE
Use ClickThroughBlocker for GUI

### DIFF
--- a/Source/Avionics/ModuleProceduralAvionics.cs
+++ b/Source/Avionics/ModuleProceduralAvionics.cs
@@ -3,6 +3,7 @@ using RP0.Utilities;
 using System;
 using System.Linq;
 using UnityEngine;
+using ClickThroughFix;
 
 using static RP0.ProceduralAvionics.ProceduralAvionicsUtils;
 
@@ -552,7 +553,7 @@ namespace RP0.ProceduralAvionics
         {
             if (showGUI)
             {
-                windowRect = GUILayout.Window(GetInstanceID(), windowRect, WindowFunction, "Configure Procedural Avionics");
+                windowRect = ClickThruBlocker.GUILayoutWindow(GetInstanceID(), windowRect, WindowFunction, "Configure Procedural Avionics");
             }
         }
 

--- a/Source/RP0.csproj
+++ b/Source/RP0.csproj
@@ -128,6 +128,9 @@
       <HintPath>..\..\..\..\..\..\..\..\Games\Kerbal Space Program 1.3.1 - RO\KSP_x64_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="ClickThroughBlocker">
+      <HintPath>C:\Games\KSP 1.6.1 RP-1\GameData\000_ClickThroughBlocker\Plugins\ClickThroughBlocker.dll</HintPath>
+    </Reference>
     <Reference Include="ModularFlightIntegrator">
       <HintPath>..\..\..\..\..\..\Games\RP1\GameData\ModularFlightIntegrator\ModularFlightIntegrator.dll</HintPath>
       <Private>False</Private>

--- a/Source/UI/TopWindow.cs
+++ b/Source/UI/TopWindow.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using UnityEngine;
 using KSP.UI.Screens;
+using ClickThroughFix;
 
 namespace RP0
 {
@@ -22,7 +23,7 @@ namespace RP0
 
         public void OnGUI()
         {
-            windowPos = GUILayout.Window("RP0Top".GetHashCode(), windowPos, DrawWindow, "RP-1");
+            windowPos = ClickThruBlocker.GUILayoutWindow("RP0Top".GetHashCode(), windowPos, DrawWindow, "RP-1");
         }
 
         public static void SwitchTabTo(tabs newTab)


### PR DESCRIPTION
I use this locally to prevent click through on the RP-0 windows.

This would make ClickThroughBlocker a hard dependency instead of a indirect one (e.g through KRASH). I don't know the policy on that so you might not want to merge this. But I thought it might be useful to others.