### PR TITLE
#1148 Add No-EVA tag to 1.25m Crew Carrier

### DIFF
--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -5707,6 +5707,8 @@
     MODULE
     { name = ModuleTagHumanRated }
     MODULE
+    { name = ModuleNoEVA }
+    MODULE
     { name = ModuleTagNoResourceCostMult }
 
 }

--- a/Source/Tech Tree/Parts Browser/data/Ven_Stock_Revamp.json
+++ b/Source/Tech Tree/Parts Browser/data/Ven_Stock_Revamp.json
@@ -123,6 +123,7 @@
         "identical_part_name": "",
         "module_tags": [
             "HumanRated",
+            "NoEVA",
             "NoResourceCostMult"
         ]
     },


### PR DESCRIPTION
Minimal fix for overpowered part: a 1959 tech node shouldn't have a part
that allows EVA.

There's other arguably-OP aspects to the part (mass, power usage, cost),
but how to address those is less clear-cut. Until someone tackles the larger issue, at least this should go in.