### PR TITLE
Make Maneuver Nodes available with Lunar Comms TS

### DIFF
--- a/GameData/RP-0/CustomBarnKit.cfg
+++ b/GameData/RP-0/CustomBarnKit.cfg
@@ -86,8 +86,8 @@
 		@upgradesVisual = 1, 1, 2, 2, 2, 3, 3, 3, 3, 3
 		@upgrades = 50000, 50000, 50000, 100000, 175000, 100000, 150000, 1000000, 300000, 300000
 		@unlockedSpaceObjectDiscovery = 8
-		@orbitDisplayMode = 1, 2, 3, 3, 3, 3, 3, 3, 3, 3
-		@patchesAheadLimit = 0, 1, 2, 3, 3, 4, 4, 4, 4, 4
+		@orbitDisplayMode = 2, 3, 3, 3, 3, 3, 3, 3, 3, 3
+		@patchesAheadLimit = 0, 1, 2, 3, 4, 4, 4, 4, 4, 4
 		@trackedObjectLimit = 0, 1, 2, 3, 4, 5, 6, 8, 10, -1
 		@DSNRange = 4.2047e11, 8.4093e11, 1.3329e12, 4.2652e12, 1.3649e13, 4.0946e13, 1.1465e14, 3.6688e14, 5.1363e14, 8.9885e14
 		@DSNRangeCurve


### PR DESCRIPTION
TS upgrade levels were tweaked according to newComms
rules, but the corresponding change to orbitDisplayMode
was left out.

(see https://github.com/MikeOnTea/RealismOverhaul/commit/7b79de36a93c2db9c321957ee7ccfa6ba9b301a5 )