### PR TITLE
Remove experiment ECMs from 20in probe

### DIFF
--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -662,7 +662,7 @@
     RP0probeAvionics1-4m = 500, avionicsUpperBasic
     RP0probeAvionics1-5m = 2000, avionicsUpperBasic, avionicsHibernation
     RP0probeSounding0-3m = 1
-    RP0probeVanguardXray = 1000, avionicsProbesEarly, Geiger, IonMass, Micrometeorite
+    RP0probeVanguardXray = 1000, avionicsProbesEarly
     RSBRibbedBase = 1
     RSBRibbedBase-Boattail = 1
     RSBRibbedBase-Interstage = 1

--- a/Source/Tech Tree/Parts Browser/data/SXT.json
+++ b/Source/Tech Tree/Parts Browser/data/SXT.json
@@ -463,7 +463,7 @@
         "spacecraft": "Vanguard 2",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "1000, avionicsProbesEarly, Geiger, IonMass, Micrometeorite",
+        "entry_cost_mods": "1000, avionicsProbesEarly",
         "identical_part_name": "",
         "module_tags": [
             "Avionics",


### PR DESCRIPTION
Because rp-1 removes all experiments from it