### PR TITLE
Fix Exceptions from UIBase()

### DIFF
--- a/Source/Crew/CrewHandler.cs
+++ b/Source/Crew/CrewHandler.cs
@@ -125,7 +125,7 @@ namespace RP0.Crew
         protected HashSet<string> partSynsHandled = new HashSet<string>();
         protected TrainingDatabase trainingDatabase = new TrainingDatabase();
 
-        public FSGUI fsGUI = new FSGUI();
+        public FSGUI fsGUI;
 
         #region Instance
 
@@ -146,7 +146,6 @@ namespace RP0.Crew
 
         public override void OnAwake()
         {
-
             if (_instance != null)
             {
                 GameObject.Destroy(_instance);
@@ -165,6 +164,11 @@ namespace RP0.Crew
             
             FindAllCourseConfigs(); //find all applicable configs
             GenerateOfferedCourses(); //turn the configs into offered courses
+        }
+
+        public void Start()
+        {
+            fsGUI = new FSGUI();
         }
 
         public override void OnLoad(ConfigNode node)

--- a/Source/UI/UIHolder.cs
+++ b/Source/UI/UIHolder.cs
@@ -10,7 +10,7 @@ namespace RP0
         // GUI
         private bool guiEnabled = false;
         private ApplicationLauncherButton button;
-        private TopWindow tw = new TopWindow();
+        private TopWindow tw;
 
         protected void Awake()
         {
@@ -20,6 +20,11 @@ namespace RP0
                 Debug.LogError("RP0 failed to register UIHolder.OnGuiAppLauncherReady");
                 Debug.LogException(ex);
             }
+        }
+
+        protected void Start()
+        {
+            tw = new TopWindow();
         }
 
         private void ShowWindow()


### PR DESCRIPTION
Unity is unhappy with some UI calls from a Monobehavior constructor.  Move UIHolder's TopWindow and CrewHandler's FSGUI instantiation to Start methods