### PR TITLE
Unlock First EVA with any EVA-enabling tech

### DIFF
--- a/GameData/RP-0/Contracts/Human Milestones/First EVA.cfg
+++ b/GameData/RP-0/Contracts/Human Milestones/First EVA.cfg
@@ -54,10 +54,24 @@ CONTRACT_TYPE
 	
 	REQUIREMENT
 	{
-		name = AdvCapsulesResearched
-		type = TechResearched
-		tech = secondGenCapsules
-		title = Must have the second generation capsules tech unlocked.
+		name = Any
+		type = Any
+		title = Must have the tech for an EVA-capable craft unlocked
+
+		REQUIREMENT
+		{
+			name = AdvCapsulesResearched
+			type = TechResearched
+			tech = secondGenCapsules
+			title = Second Generation Capsules
+		}
+		REQUIREMENT
+		{
+			name = ProtoSpaceplanesResearched
+			type = TechResearched
+			tech = prototypeSpaceplanes
+			title = Prototype Spaceplanes
+		}
 	}
 	
 	PARAMETER


### PR DESCRIPTION
First EVA milestone was recently hidden behind 'must unlock 2nd gen
capsules', to protect players from thinking they can do it with
Mercury

But 2ndgen capsules aren't the only way to go EVA, prototype spaceplanes
are an alternate path. It'd be silly if the player could go EVA and not
hit the milestone.