### PR TITLE
Crew Training for Spaceplane cockpits

### DIFF
--- a/GameData/RP-0/CrewTrainingTimes.cfg
+++ b/GameData/RP-0/CrewTrainingTimes.cfg
@@ -58,6 +58,15 @@ TRAININGTIMES
 	Mk1 Su30 Cockpit = 100, XPlane
 	Typhoon Cockpit = 100, XPlane
 	
+	ProtoSpaceplane = 100, EVA, Docking // a bit more than SecondGenCapsule because it needs actual piloting
+		RO-Mk1Cockpit = ProtoSpaceplane
+		RO-Mk1CockpitInline = ProtoSpaceplane
+	ProtoSpaceplane-Mission = 120
+
+	Spaceplane = 25, ProtoSpaceplanes
+		mk2Cockpit.Inline = Spaceplane
+	Spaceplane-Mission = 150
+	
 //**********************************************************************************
 //  Capsules
 //**********************************************************************************	


### PR DESCRIPTION
Only x-15 was configured, not higher tiers.
This handles the next 2.