### PR TITLE
Early Science-Core proc avionics overhaul

### DIFF
--- a/GameData/RP-0/Tree/ProceduralAvionics.cfg
+++ b/GameData/RP-0/Tree/ProceduralAvionics.cfg
@@ -544,25 +544,34 @@
 			{
 				name = start
 				techLevel = 0
-				massFactor = 20
+				massFactor = 58
 				costFactor = 3
-				powerFactor = 4
+				powerFactor = 100
+				avionicsDensity = 2
+			}
+			TECHLIMIT
+			{
+				name = postWarAvionics
+				techLevel = 1
+				massFactor = 38
+				costFactor = 6
+				powerFactor = 50
 				avionicsDensity = 0.5
 			}
 			TECHLIMIT
 			{
 				name = avionicsPrototypes
-				techLevel = 1
-				massFactor = 4
+				techLevel = 2
+				massFactor = 17
 				costFactor = 8
-				powerFactor = 0.5
+				powerFactor = 25
 				avionicsDensity = 0.5
 			}
 			TECHLIMIT
 			{
 				name = earlyAvionics
-				techLevel = 2
-				massFactor = 1.5
+				techLevel = 3
+				massFactor = 4
 				costFactor = 10
 				powerFactor = 0.15
 				avionicsDensity = 0.5
@@ -570,8 +579,8 @@
 			TECHLIMIT
 			{
 				name = basicAvionics
-				techLevel = 3
-				massFactor = 1
+				techLevel = 4
+				massFactor = 1.5
 				costFactor = 12
 				powerFactor = 0.1
 				avionicsDensity = 0.5
@@ -580,8 +589,8 @@
 			TECHLIMIT
 			{
 				name = interplanetaryProbes
-				techLevel = 4
-				massFactor = 0.9
+				techLevel = 5
+				massFactor = 1
 				costFactor = 12
 				powerFactor = 0.09
 				avionicsDensity = 0.5
@@ -590,7 +599,7 @@
 			TECHLIMIT
 			{
 				name = improvedAvionics
-				techLevel = 5
+				techLevel = 6
 				massFactor = 0.81
 				costFactor = 12
 				powerFactor = 0.081
@@ -600,7 +609,7 @@
 			TECHLIMIT
 			{
 				name = matureAvionics
-				techLevel = 6
+				techLevel = 7
 				massFactor = 0.73
 				costFactor = 12
 				powerFactor = 0.073
@@ -610,7 +619,7 @@
 			TECHLIMIT
 			{
 				name = largeScaleAvionics
-				techLevel = 7
+				techLevel = 8
 				massFactor = 0.66
 				costFactor = 10
 				powerFactor = 0.066
@@ -620,7 +629,7 @@
 			TECHLIMIT
 			{
 				name = advancedAvionics
-				techLevel = 8
+				techLevel = 9
 				massFactor = 0.59
 				costFactor = 9
 				powerFactor = 0.059
@@ -630,7 +639,7 @@
 			TECHLIMIT
 			{
 				name = nextGenAvionics
-				techLevel = 9
+				techLevel = 10
 				massFactor = 0.53
 				costFactor = 8.1
 				powerFactor = 0.053
@@ -640,7 +649,7 @@
 			TECHLIMIT
 			{
 				name = longTermAvionics
-				techLevel = 10
+				techLevel = 11
 				massFactor = 0.48
 				costFactor = 7.3
 				powerFactor = 0.048
@@ -650,7 +659,7 @@
 			TECHLIMIT
 			{
 				name = internationalAvionics
-				techLevel = 11
+				techLevel = 12
 				massFactor = 0.43
 				costFactor = 6.6
 				powerFactor = 0.043
@@ -660,7 +669,7 @@
 			TECHLIMIT
 			{
 				name = modernAvionics
-				techLevel = 12
+				techLevel = 13
 				massFactor = 0.39
 				costFactor = 5.9
 				powerFactor = 0.039
@@ -709,6 +718,19 @@
 }
 
 // Avionics Upgrades ************************************************
+
+PARTUPGRADE
+{
+	name = procAvionics-tltech0
+	partIcon = proceduralAvionics
+	techRequired = postWarAvionics
+	entryCost = 0
+	cost = 0
+	title = Procedural Avionics Upgrade
+	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+	manufacturer = Generic
+	description = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
+}
 
 PARTUPGRADE
 {


### PR DESCRIPTION
Changed the progression to be closer to prefab parts. Also added an additional level to the postWarAvionics node which was currently empty.
The mass figures are now:
* lvl 0 (starting) - 60kg
* lvl 1 (new) - 40kg
* lvl 2 (Sputnik) - 20kg
* lvl 3 (Explorer) - 10kg
* lvl 4 (Early controllable probe core) - 2kg

