### PR TITLE
Fixed power draw for non-toggleable avionics

### DIFF
--- a/Source/Avionics/ModuleAvionics.cs
+++ b/Source/Avionics/ModuleAvionics.cs
@@ -74,12 +74,12 @@ namespace RP0
         }
 
         public float PowerDraw(bool onRails = false) =>
-            part.protoModuleCrew?.Count > 0 || (!GetToggleable() || (systemEnabled && !onRails)) ?
+            part.protoModuleCrew?.Count > 0 || (systemEnabled && !(GetToggleable() && onRails)) ?
             GetEnabledkW() : GetDisabledkW();
 
         protected void UpdateRate(bool onRails = false)
         {
-            currentlyEnabled = !GetToggleable() || (systemEnabled && !onRails);
+            currentlyEnabled = systemEnabled && !(GetToggleable() && onRails);
             float currentKW = PowerDraw(onRails);
             ecConsumption = new KeyValuePair<string, double>(ecName, -currentKW);
             currentWatts = currentKW * 1000;
@@ -105,6 +105,7 @@ namespace RP0
             Events[nameof(ToggleEvent)].guiActive = toggleAble;
             Events[nameof(ToggleEvent)].guiActiveEditor = toggleAble;
             Events[nameof(ToggleEvent)].guiName = (systemEnabled ? "Shutdown" : "Activate") + " Avionics";
+            Events[nameof(ToggleEvent)].active = toggleAble;
             Actions[nameof(ActivateAction)].active = (!systemEnabled || HighLogic.LoadedSceneIsEditor) && toggleAble;
             Actions[nameof(ShutdownAction)].active = (systemEnabled || HighLogic.LoadedSceneIsEditor) && toggleAble;
             Actions[nameof(ToggleAction)].active = toggleAble;
@@ -250,6 +251,11 @@ namespace RP0
             {
                 systemEnabled = true;
                 ScreenMessages.PostScreenMessage("Cannot shut down avionics while crewed");
+            }
+            else if (!GetToggleable())
+            {
+                systemEnabled = true;
+                ScreenMessages.PostScreenMessage("Cannot shut down avionics on this part");
             }
             UpdateRate();
             SetActionsAndGui();

--- a/Source/Avionics/ModuleAvionics.cs
+++ b/Source/Avionics/ModuleAvionics.cs
@@ -74,12 +74,12 @@ namespace RP0
         }
 
         public float PowerDraw(bool onRails = false) =>
-            part.protoModuleCrew?.Count > 0 || (systemEnabled && !(GetToggleable() && onRails)) ?
+            part.protoModuleCrew?.Count > 0 || (!GetToggleable() || (systemEnabled && !onRails)) ?
             GetEnabledkW() : GetDisabledkW();
 
         protected void UpdateRate(bool onRails = false)
         {
-            currentlyEnabled = systemEnabled && !(GetToggleable() && onRails);
+            currentlyEnabled = !GetToggleable() || (systemEnabled && !onRails);
             float currentKW = PowerDraw(onRails);
             ecConsumption = new KeyValuePair<string, double>(ecName, -currentKW);
             currentWatts = currentKW * 1000;

--- a/Source/Avionics/ModuleAvionics.cs
+++ b/Source/Avionics/ModuleAvionics.cs
@@ -9,7 +9,7 @@ namespace RP0
     class ModuleAvionics : PartModule
     {
         #region Members
-        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Controllable", guiFormat = "N1", guiUnits = "T")]
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "Controllable", guiFormat = "N2", guiUnits = "T")]
         public float massLimit = float.MaxValue; // default is unlimited
 
         [KSPField]
@@ -291,7 +291,7 @@ namespace RP0
         public string PlannerUpdate(List<KeyValuePair<string, double>> resources, CelestialBody _, Dictionary<string, double> environment)
         {
             resources.Add(ecConsumption);   // ecConsumption is updated by the Toggle event
-            return "Avionics";
+            return "avionics";
         }
 
         public static string BackgroundUpdate(Vessel v,
@@ -306,13 +306,13 @@ namespace RP0
                 if (module_snapshot.moduleValues.TryGetValue("currentWatts", ref cw))
                     resourceChangeRequest.Add(new KeyValuePair<string, double>(ecName, -cw / 1000));
             }
-            return "Avionics";
+            return "avionics";
         }
 
         public virtual string ResourceUpdate(Dictionary<string, double> availableResources, List<KeyValuePair<string, double>> resourceChangeRequest)
         {
             resourceChangeRequest.Add(ecConsumption);   // ecConsumption is updated by the Toggle event
-            return "Avionics";
+            return "avionics";
         }
 
         #endregion


### PR DESCRIPTION
Currently it's possible to toggle non-toggleable avionics via kOS or similar mods (and also possibly via an action group) as the action is still valid, even though its gui is disabled.

This change fixes the logic such that the power draw is always full for non-toggleable avionics.