### PR TITLE
Remove 'solar power' param from Comm Sat contracts

### DIFF
--- a/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
@@ -92,15 +92,6 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = HasSolarPower
-			title = Can Generate Solar Power
-			type = PartValidation
-			hideChildren = true
-			partModule = ModuleDeployableSolarPanel
-			minCount = 1
-		}
-		PARAMETER
-		{
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload

--- a/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = EarlySatellites
 
 
-	description = There are groups that want to understand more about communications with satellites. Launch a new communications test satellite into the proper orbit. Be sure to include solar panels to generate power.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Communications Satellite (Early) contract</color></b>&br;&br;<b>Number of Contracts Completed: $ComTestSat_Count</b>
+	description = There are groups that want to understand more about communications with satellites. Launch a new communications test satellite into the proper orbit. &br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Communications Satellite (Early) contract</color></b>&br;&br;<b>Number of Contracts Completed: $ComTestSat_Count</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a Communications Test Satellite
@@ -87,15 +87,6 @@ CONTRACT_TYPE
 			maxCrew = 0
 			title = Uncrewed
 			hideChildren = true
-		}
-		PARAMETER
-		{
-			name = HasSolarPower
-			title = Can Generate Solar Power
-			type = PartValidation
-			hideChildren = true
-			partModule = ModuleDeployableSolarPanel
-			minCount = 1
 		}
 		PARAMETER
 		{


### PR DESCRIPTION
Because the requirement is just a 'gotcha'.
- All those contracts are gated behind First Scientific Satellites,
  so solar panels are necessarily available
- Without any specific power output needed, the requirement can
  be satisfied with a single tiny panel that doesn't actually provide
  enough power for anything

So the requirement doesn't increase contract difficulty in any way
other than punishing players who fail to notice it