### PR TITLE
Generic value contracts

### DIFF
--- a/GameData/RP-0/Contracts/Advanced Satellites/Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Communications Satellites.cfg
@@ -26,12 +26,8 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = ((12000 + ((@AdvComSat/HasComSatPayload/minQuantity)*2)) * (1 + Max(@AdvComSat/ReachSpecificOrbit/index, 1) * 0.4)) * 1.25 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = Round(1 + (@advanceFunds / 500))
-	rewardFunds = (@advanceFunds * 1.5)
-	failureReputation = @rewardReputation * 1.5
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 2.5 * 2.4 * ((12000 + ((@AdvComSat/HasComSatPayload/minQuantity)*2)) * (1 + Max(@AdvComSat/ReachSpecificOrbit/index, 1) * 0.4)) * 1.25 
+	genericAdvanceMultiplier = 2.0 / 5.0
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Advanced Satellites/Earth Imaging Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Earth Imaging Satellites.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 	
 	
 	prestige = Trivial       // 1.0x
-	advanceFunds = 20000 * @RP0:globalHardContractMultiplier
+	genericValue = 72000
 	rewardScience = 0.6
-	rewardReputation = 5
-	rewardFunds = 10000 * @RP0:globalHardContractMultiplier
-	failureReputation = 5
-	failureFunds = @advanceFunds * 0.5
 	
 	// ************ REQUIREMENTS ************
 	

--- a/GameData/RP-0/Contracts/Advanced Satellites/Geostationary Communications Network.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Geostationary Communications Network.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 100000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 15
-	rewardFunds = 150000 * @RP0:globalHardContractMultiplier
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 600000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Advanced Satellites/IridiumNEXT.cfg.disabled
+++ b/GameData/RP-0/Contracts/Advanced Satellites/IridiumNEXT.cfg.disabled
@@ -25,12 +25,7 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 	
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 125000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 35
-	rewardFunds = 200000 * @RP0:globalHardContractMultiplier
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 780000
 	
 	
 	// ************ REQUIREMENTS ************

--- a/GameData/RP-0/Contracts/Atmospheric Probes/Jupiter Probe.cfg
+++ b/GameData/RP-0/Contracts/Atmospheric Probes/Jupiter Probe.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 3200 * @RP0:globalHardContractMultiplier
+	genericReward = 38400
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.15
-	rewardReputation = 35
-	rewardFunds = 12800 * @RP0:globalHardContractMultiplier
-	failureReputation = 45
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Atmospheric Probes/Mars Probe.cfg
+++ b/GameData/RP-0/Contracts/Atmospheric Probes/Mars Probe.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 3200 * @RP0:globalHardContractMultiplier
+	genericReward = 38400
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.15
-	rewardReputation = 35
-	rewardFunds = 12800 * @RP0:globalHardContractMultiplier
-	failureReputation = 45
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Atmospheric Probes/Neptune Probe.cfg
+++ b/GameData/RP-0/Contracts/Atmospheric Probes/Neptune Probe.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 3200 * @RP0:globalHardContractMultiplier
+	genericReward = 38400
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.15
-	rewardReputation = 35
-	rewardFunds = 12800 * @RP0:globalHardContractMultiplier
-	failureReputation = 45
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Atmospheric Probes/Pluto Probe.cfg
+++ b/GameData/RP-0/Contracts/Atmospheric Probes/Pluto Probe.cfg
@@ -27,13 +27,10 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 3200 * @RP0:globalHardContractMultiplier
+	genericReward = 38400
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.15
-	rewardReputation = 35
-	rewardFunds = 12800 * @RP0:globalHardContractMultiplier
-	failureReputation = 45
-	failureFunds = @advanceFunds * 0.5
-
+	
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/Atmospheric Probes/Saturn Probe.cfg
+++ b/GameData/RP-0/Contracts/Atmospheric Probes/Saturn Probe.cfg
@@ -27,13 +27,10 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 3200 * @RP0:globalHardContractMultiplier
+	genericReward = 38400
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.15
-	rewardReputation = 35
-	rewardFunds = 12800 * @RP0:globalHardContractMultiplier
-	failureReputation = 45
-	failureFunds = @advanceFunds * 0.5
-
+	
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/Atmospheric Probes/Titan Probe.cfg
+++ b/GameData/RP-0/Contracts/Atmospheric Probes/Titan Probe.cfg
@@ -27,13 +27,10 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 3200 * @RP0:globalHardContractMultiplier
+	genericReward = 38400
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.15
-	rewardReputation = 35
-	rewardFunds = 12800 * @RP0:globalHardContractMultiplier
-	failureReputation = 45
-	failureFunds = @advanceFunds * 0.5
-
+	
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/Atmospheric Probes/Uranus Probe.cfg
+++ b/GameData/RP-0/Contracts/Atmospheric Probes/Uranus Probe.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 3200 * @RP0:globalHardContractMultiplier
+	genericReward = 38400
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.15
-	rewardReputation = 35
-	rewardFunds = 12800 * @RP0:globalHardContractMultiplier
-	failureReputation = 45
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Atmospheric Probes/Venus Probe.cfg
+++ b/GameData/RP-0/Contracts/Atmospheric Probes/Venus Probe.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 3200 * @RP0:globalHardContractMultiplier
+	genericReward = 38400
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.15
-	rewardReputation = 35
-	rewardFunds = 12800 * @RP0:globalHardContractMultiplier
-	failureReputation = 45
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/Atmosphere Analysis.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Atmosphere Analysis.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = (4000 + (@VesselGroup/Orbit/minPeA * 0.005)) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 5
-	rewardFunds = 10000 * @RP0:globalHardContractMultiplier
-	failureReputation = 2
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 9600 + @VesselGroup/Orbit/minPeA * 0.012
+	genericBonus = 24000
+	genericAdvanceMultiplier = 1
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
@@ -28,12 +28,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = (5000 + (@EarlyComSat/HasComSatPayload/minQuantity * 2)) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 5
-	rewardFunds = (13000.0 + (Pow((@EarlyComSat/Orbit/minApA), 0.5) * 2) + (@EarlyComSat/HasComSatPayload/minQuantity * 5)) * @RP0:globalHardContractMultiplier
-	failureReputation = 2
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 2.4 * (18000 + (@EarlyComSat/HasComSatPayload/minQuantity * 7) + (2 * Pow(@EarlyComSat/Orbit/minApA, 0.5)))
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
@@ -28,12 +28,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = 5000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 5
-	rewardFunds = (10000.0 + @TestComSat/Orbit/minPeA*0.005 + (@TestComSat/HasComSatPayload/minQuantity)*2) * @RP0:globalHardContractMultiplier
-	failureReputation = 2
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 36000 + @TestComSat/Orbit/minPeA * 0.012 + @TestComSat/HasComSatPayload/minQuantity * 4.8
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/Early CommNet (3 Sat).cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Early CommNet (3 Sat).cfg
@@ -27,13 +27,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 20000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 30
-	rewardFunds = 60000 * @RP0:globalHardContractMultiplier
-	failureFunds = @advanceFunds * 0.5
-
-
+	genericReward = 192000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/Early CommNet (4 Sat).cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Early CommNet (4 Sat).cfg
@@ -27,11 +27,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 20000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 30
-	rewardFunds = 90000 * @RP0:globalHardContractMultiplier
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 264000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/First Com Sat.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/First Com Sat.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial
-	advanceFunds = (5000 + (@FirstComSat/HasComSatPayload/minQuantity * 2)) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 5
-	rewardFunds = 15000 * @RP0:globalHardContractMultiplier
-	failureReputation = 2
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 48000 + @FirstComSat/HasComSatPayload/minQuantity * 4.8
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/First Nav Sat.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/First Nav Sat.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = (5000 + (@FirstNavSat/HasNavSatPayload/minQuantity * 2)) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 5
-	rewardFunds = 10000 * @RP0:globalHardContractMultiplier
-	failureReputation = 2
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 36000 + @FirstNavSat/HasNavSatPayload/minQuantity * 4.8
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/Geostationary.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Geostationary.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = (10000 + (@GeostationarySat/HasComSatPayload/minQuantity * 4)) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = 50000 * @RP0:globalHardContractMultiplier
-	failureReputation = 20
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 144000 + @GeostationarySat/HasComSatPayload/minQuantity * 9.6
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/Molniya Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Molniya Satellite.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = 7500 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 5
-	rewardFunds = (20000 + (@VesselGroup/HasComSatPayload/minQuantity * 2)) * @RP0:globalHardContractMultiplier
-	failureReputation = 2
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 66000 + @VesselGroup/HasComSatPayload/minQuantity * 4.8
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/Polar Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Polar Satellite.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 		
 	// ************ REWARDS ************	
 	prestige = Trivial       // 1.0x	
-	advanceFunds = 5000	* @RP0:globalHardContractMultiplier
-	rewardScience = 0	
-	rewardReputation = 5	
-	rewardFunds = 15000 * @RP0:globalHardContractMultiplier
-	failureReputation = 2	
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 48000
 		
 	// ************ REQUIREMENTS ************	
 		

--- a/GameData/RP-0/Contracts/Early Satellites/Solar Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Solar Satellite.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = 5000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 5
-	rewardFunds = 15000 * @RP0:globalHardContractMultiplier
-	failureReputation = 2
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 48000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/Sun Sync Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Sun Sync Satellite.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = 7500 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 5
-	rewardFunds = 20000 * @RP0:globalHardContractMultiplier
-	failureReputation = 2
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 66000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Early Satellites/Tundra Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Tundra Satellite.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 		
 	// ************ REWARDS ************	
 	prestige = Trivial       // 1.0x	
-	advanceFunds = 10000	 * @RP0:globalHardContractMultiplier
-	rewardScience = 0	
-	rewardReputation = 10	
-	rewardFunds = (35000	+ (@VesselGroup/HasComSatPayload/minQuantity * 4)) * @RP0:globalHardContractMultiplier
-	failureReputation = 5	
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 108000 + @VesselGroup/HasComSatPayload/minQuantity * 9.6
 		
 	// ************ REQUIREMENTS ************	
 		

--- a/GameData/RP-0/Contracts/Flyby Contracts/Ariel Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Ariel Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Callisto Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Callisto Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Ceres Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Ceres Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Charon Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Charon Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Deimos Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Deimos Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Dione Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Dione Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Enceladus Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Enceladus Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Europa Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Europa Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Ganymede Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Ganymede Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Iapetus Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Iapetus Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Io Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Io Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Jupiter Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Jupiter Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Jupiter Moons Flyby.cfg.disabled
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Jupiter Moons Flyby.cfg.disabled
@@ -30,12 +30,7 @@ CONTRACT_TYPE
     // ************ REWARDS ************
 
     prestige            	= Exceptional // 1.50
-    advanceFunds        	= 2000 * @RP0:globalHardContractMultiplier
-    rewardScience       	= 0
-    rewardReputation    	= 20
-    rewardFunds         	= @advanceFunds * 4
-    failureReputation   	= 40
-    failureFunds        	= @advanceFunds * 1.5
+	genericReward = 24000
 
 
     // ************ DATA BLOCKS ************

--- a/GameData/RP-0/Contracts/Flyby Contracts/Mars Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Mars Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Mercury Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Mercury Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Mimas Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Mimas Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Miranda Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Miranda Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Neptune Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Neptune Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Oberon Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Oberon Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Phobos Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Phobos Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Pluto Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Pluto Flyby.cfg
@@ -27,13 +27,8 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
-
+	genericReward = 24000
+	
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/Flyby Contracts/Rhea Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Rhea Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Saturn Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Saturn Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Tethys Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Tethys Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Titan Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Titan Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Titania Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Titania Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Triton Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Triton Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Umbriel Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Umbriel Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Uranus Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Uranus Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Venus Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Venus Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Vesta Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Vesta Flyby.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 24000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Groups.cfg
+++ b/GameData/RP-0/Contracts/Groups.cfg
@@ -255,7 +255,6 @@ CONTRACT_GROUP
 		payoutMax = 15000 // This is the maximum total payout amount (before the in-game multiplier)
 		maxSoundingDifficultyLevels = 25 // Helps to cap the overall total payouts
 		maxXPlaneDifficultyLevels = 19
-		globalHardContractMultiplier = 2.4 // This is multiplied into the contract payouts
 
 		distanceMod = 0.9 // Overall Modifier for Distance Launch Costs
 		distancePayloadExponent = 0.7  // After the payloadAdder and payloadDivider are applied, the Payload is raised to this power

--- a/GameData/RP-0/Contracts/Human Contracts/Orbit Repeatable.cfg
+++ b/GameData/RP-0/Contracts/Human Contracts/Orbit Repeatable.cfg
@@ -29,12 +29,9 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = (1500 * (10 + (@NoOfOrbits / 10))) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 1.0 * (10 + (@NoOfOrbits / 10))
-	rewardFunds = @advanceFunds * 1.1
-	failureReputation = 10.0 * (10 + (@NoOfOrbits / 10))
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 7560 * (10 + (@NoOfOrbits / 10))
+	genericAdvanceMultiplier = 1.0 / 2.1
+
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Contracts/Suborbital Crewed.cfg
+++ b/GameData/RP-0/Contracts/Human Contracts/Suborbital Crewed.cfg
@@ -29,12 +29,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = (2000 + @VesselGroup/ReachAlt/minAltitude*0.03) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 3
-	rewardFunds = @advanceFunds
-	failureReputation = 3
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 9600 + @VesselGroup/ReachAlt/minAltitude * 0.144
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Contracts/Three Crew Orbit Repeatable.cfg
+++ b/GameData/RP-0/Contracts/Human Contracts/Three Crew Orbit Repeatable.cfg
@@ -29,12 +29,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = (6000 * (8 + (@DurationText * 0.2))) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 7.0 * (8 + (@DurationText * 0.2))
-	rewardFunds = @advanceFunds * 1.1
-	failureReputation = 21.0 * (8 + (@DurationText * 0.2))
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 30240 * (8 + (@DurationText * 0.2))
+	genericAdvanceMultiplier = 1.0 / 2.1
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Contracts/Two Crew Orbit Repeatable.cfg
+++ b/GameData/RP-0/Contracts/Human Contracts/Two Crew Orbit Repeatable.cfg
@@ -29,12 +29,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = (2500 * (13 + (@DurationText * 0.4) + ((@endApA / 100000) * 0.5))) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 5.0 * (13 + (@DurationText * 0.4) + ((@endApA / 100000) * 0.5))
-	rewardFunds = @advanceFunds * 1.1
-	failureReputation = 15.0 * (1 + (4 * @DurationText / 10))
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 12600 * (13 + @DurationText * 0.4 + @endApA / 200000)
+	genericAdvanceMultiplier = 1.0 / 2.1
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Exploration/Asteroid Landing Crew.cfg
+++ b/GameData/RP-0/Contracts/Human Exploration/Asteroid Landing Crew.cfg
@@ -27,13 +27,10 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 1000000 * @RP0:globalHardContractMultiplier
+	genericReward = 3600000
+	genericAdvanceMultiplier = 0.5
 	rewardScience = 0.6
-	rewardReputation = 100
-	rewardFunds = 500000 * @RP0:globalHardContractMultiplier
-	failureReputation = 150
-	failureFunds = @advanceFunds * 0.5
-
+	
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/Human Exploration/Jupiter Flyby Crew.cfg
+++ b/GameData/RP-0/Contracts/Human Exploration/Jupiter Flyby Crew.cfg
@@ -27,13 +27,10 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 285000 * @RP0:globalHardContractMultiplier
+	genericReward = 285000
+	genericAdvanceMultiplier = 0.5
 	rewardScience = 0.6
-	rewardReputation = 100
-	rewardFunds = 0.2 * 142500 * @RP0:globalHardContractMultiplier
-	failureReputation = 150
-	failureFunds = @advanceFunds * 0.5
-
+	
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/Human Exploration/Mars Flyby Crew.cfg
+++ b/GameData/RP-0/Contracts/Human Exploration/Mars Flyby Crew.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 175000 * @RP0:globalHardContractMultiplier
+	genericReward = 175000
+	genericAdvanceMultiplier = 0.5
 	rewardScience = 0.6
-	rewardReputation = 100
-	rewardFunds = @advanceFunds * 1.1
-	failureReputation = 150
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Exploration/Mars Landing Crew.cfg
+++ b/GameData/RP-0/Contracts/Human Exploration/Mars Landing Crew.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 500000 * @RP0:globalHardContractMultiplier
+	genericReward = 500000
+	genericAdvanceMultiplier = 0.5
 	rewardScience = 0.6
-	rewardReputation = 100
-	rewardFunds = @advanceFunds * 1.1
-	failureReputation = 150
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Exploration/Mars Orbit Crew.cfg
+++ b/GameData/RP-0/Contracts/Human Exploration/Mars Orbit Crew.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 192500 * @RP0:globalHardContractMultiplier
+	genericReward = 192500
+	genericAdvanceMultiplier = 0.5
 	rewardScience = 0.6
-	rewardReputation = 100
-	rewardFunds = @advanceFunds * 1.1
-	failureReputation = 150
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Exploration/Mercury Flyby Crew.cfg
+++ b/GameData/RP-0/Contracts/Human Exploration/Mercury Flyby Crew.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 165000 * @RP0:globalHardContractMultiplier
+	genericReward = 165000
+	genericAdvanceMultiplier = 0.5
 	rewardScience = 0.6
-	rewardReputation = 100
-	rewardFunds = @advanceFunds * 1.1
-	failureReputation = 150
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Exploration/Phobos Landing Crew.cfg
+++ b/GameData/RP-0/Contracts/Human Exploration/Phobos Landing Crew.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 400000 * @RP0:globalHardContractMultiplier
+	genericReward = 400000
+	genericAdvanceMultiplier = 0.5
 	rewardScience = 0.6
-	rewardReputation = 100
-	rewardFunds = @advanceFunds * 1.1
-	failureReputation = 150
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Exploration/Saturn Flyby Crew.cfg
+++ b/GameData/RP-0/Contracts/Human Exploration/Saturn Flyby Crew.cfg
@@ -27,12 +27,10 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 250000 * @RP0:globalHardContractMultiplier
+	genericReward = 250000
+	genericAdvanceMultiplier = 0.5
 	rewardScience = 0.6
-	rewardReputation = 100
-	rewardFunds = @advanceFunds * 1.1
-	failureReputation = 150
-	failureFunds = @advanceFunds * 0.5
+
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Exploration/Venus Flyby Crew.cfg
+++ b/GameData/RP-0/Contracts/Human Exploration/Venus Flyby Crew.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 135000 * @RP0:globalHardContractMultiplier
+	genericReward = 135000
+	genericAdvanceMultiplier = 0.5
 	rewardScience = 0.6
-	rewardReputation = 100
-	rewardFunds = @advanceFunds * 1.1
-	failureReputation = 150
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Exploration/Venus Orbit Crew.cfg
+++ b/GameData/RP-0/Contracts/Human Exploration/Venus Orbit Crew.cfg
@@ -25,12 +25,9 @@ CONTRACT_TYPE
 	targetBody = Venus
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 148500 * @RP0:globalHardContractMultiplier
+	genericReward = 148500
+	genericAdvanceMultiplier = 0.5
 	rewardScience = 0.6
-	rewardReputation = 100
-	rewardFunds = @advanceFunds * 1.1
-	failureReputation = 150
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Milestones/Break Sound Barrier.cfg
+++ b/GameData/RP-0/Contracts/Human Milestones/Break Sound Barrier.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 6000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 40
-	rewardFunds = @advanceFunds
-	failureReputation = 40
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 28800
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Milestones/First EVA.cfg
+++ b/GameData/RP-0/Contracts/Human Milestones/First EVA.cfg
@@ -27,13 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 200000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 200
-	rewardFunds = 100000 * @RP0:globalHardContractMultiplier
-	failureReputation = 200
-	failureFunds = @advanceFunds * 0.5
-
+	genericReward = 720000
+	
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/Human Milestones/First Orbit Crewed.cfg
+++ b/GameData/RP-0/Contracts/Human Milestones/First Orbit Crewed.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 200000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 200
-	rewardFunds = 100000 * @RP0:globalHardContractMultiplier
-	failureReputation = 200
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 720000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Milestones/Karman Line Crew.cfg
+++ b/GameData/RP-0/Contracts/Human Milestones/Karman Line Crew.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = Round(20000 * @RP0:globalHardContractMultiplier)
-	rewardScience = 0
-	rewardReputation = 80
-	rewardFunds = @advanceFunds
-	failureReputation = 80
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 96000
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Human Records/CrewedAltRecord.cfg
+++ b/GameData/RP-0/Contracts/Human Records/CrewedAltRecord.cfg
@@ -24,8 +24,9 @@ CONTRACT_TYPE
     maxSimultaneous = 1
 
     // Contract rewards
-    rewardFunds = Round((Pow(@crewedTargetAltitudeKM, 0.4) * 1000 - 800) * @RP0:globalHardContractMultiplier, 100)
-	rewardReputation = 5.0 + @crewedTargetAltitude*0.0001
+    genericReward = Round((Pow(@crewedTargetAltitudeKM, 0.4) * 1000 - 800) * 2.4, 100)
+    genericAdvanceMultiplier = 0.0
+    genericFailureMultiplier = 0.0
 
     DATA
     {

--- a/GameData/RP-0/Contracts/Human Records/CrewedCountRecord.cfg
+++ b/GameData/RP-0/Contracts/Human Records/CrewedCountRecord.cfg
@@ -24,8 +24,9 @@ CONTRACT_TYPE
     maxSimultaneous = 1
 
     // Contract rewards
-    rewardFunds = (20000.0 + @crewedTargetCount * 30000) * @RP0:globalHardContractMultiplier
-	rewardReputation = 30.0 + @crewedTargetCount * 5
+    genericReward = (20000.0 + @crewedTargetCount * 30000) * 2.4
+    genericAdvanceMultiplier = 0.0
+    genericFailureMultiplier = 0.0
 
     DATA
     {

--- a/GameData/RP-0/Contracts/Human Records/CrewedDurationRecord.cfg
+++ b/GameData/RP-0/Contracts/Human Records/CrewedDurationRecord.cfg
@@ -26,8 +26,9 @@ CONTRACT_TYPE
     maxSimultaneous = 1
 
     // Contract rewards
-    rewardFunds = (20000.0 + @crewedTargetDurationRew * 20000) * @RP0:globalHardContractMultiplier
-    rewardReputation = 30.0 + @crewedTargetDurationRew * 2
+    genericReward = (20000.0 + @crewedTargetDurationRew * 20000) * 2.4
+    genericAdvanceMultiplier = 0.0
+    genericFailureMultiplier = 0.0
 
     DATA
     {

--- a/GameData/RP-0/Contracts/Human Records/CrewedSpeedRecord.cfg
+++ b/GameData/RP-0/Contracts/Human Records/CrewedSpeedRecord.cfg
@@ -24,8 +24,9 @@ CONTRACT_TYPE
     maxSimultaneous = 1
 
     // Contract rewards
-    rewardFunds = (1000.0 + @crewedTargetSpeed * 2.5) * @RP0:globalHardContractMultiplier
-	rewardReputation = 3.0 + @crewedTargetSpeed*0.02
+    genericReward = (1000.0 + @crewedTargetSpeed * 2.5) * 2.4
+    genericAdvanceMultiplier = 0.0
+    genericFailureMultiplier = 0.0
 
     DATA
     {

--- a/GameData/RP-0/Contracts/Landings/Asteroid Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Asteroid Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 80000 * @RP0:globalHardContractMultiplier
+	genericReward = 4 * 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.6
-	rewardReputation = 80
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 100
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Callisto Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Callisto Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Charon Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Charon Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Deimos Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Deimos Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Dione Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Dione Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Enceladus Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Enceladus Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Europa Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Europa Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Ganymede Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Ganymede Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Iapetus Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Iapetus Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Io Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Io Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Mars Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Mars Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Mercury Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Mercury Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Mimas Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Mimas Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Phobos Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Phobos Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Pluto Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Pluto Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Rhea Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Rhea Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Tethys Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Tethys Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Titan Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Titan Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Triton Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Triton Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Landings/Venus Landing.cfg
+++ b/GameData/RP-0/Contracts/Landings/Venus Landing.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000 * @RP0:globalHardContractMultiplier
+	genericReward = 48000
+	genericAdvanceMultiplier = 0.2
 	rewardScience = 0.3
-	rewardReputation = 40
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 50
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Milestones/Docking.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Docking.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 300000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 80
-	rewardFunds = 100000 * @RP0:globalHardContractMultiplier
-	failureReputation = 80
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 960000
+	genericAdvanceMultiplier = 0.75
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Milestones/Downrange.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Downrange.cfg
@@ -26,11 +26,7 @@ CONTRACT_TYPE
 	
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = 6000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 15
-	rewardFunds = 12000 * @RP0:globalHardContractMultiplier
-	failureFunds = @advanceFunds * 0.5  
+	genericReward = 43200
   
 	REQUIREMENT
 	{

--- a/GameData/RP-0/Contracts/Milestones/First Flight.cfg
+++ b/GameData/RP-0/Contracts/Milestones/First Flight.cfg
@@ -27,10 +27,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = 1000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 0
-	rewardFunds = 500 * @RP0:globalHardContractMultiplier
+	genericReward = 3600
 
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Milestones/First Satellite.cfg
+++ b/GameData/RP-0/Contracts/Milestones/First Satellite.cfg
@@ -27,13 +27,9 @@ CONTRACT_TYPE
 		
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 17778 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 110
-	rewardFunds = 28889 * @RP0:globalHardContractMultiplier
-	failureReputation = 110
-	failureFunds = @advanceFunds * 0.5
-		
+	genericReward = 112000
+	genericAdvanceMultiplier = 1.0 / 3.0
+	
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/Milestones/First Science Sat.cfg
+++ b/GameData/RP-0/Contracts/Milestones/First Science Sat.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 		
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 117779 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 40
-	rewardFunds = 55556 * @RP0:globalHardContractMultiplier
-	failureReputation = 40
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 416000
+	genericAdvanceMultiplier = 1.0 / 3.0
 		
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Milestones/First Science Sat.cfg
+++ b/GameData/RP-0/Contracts/Milestones/First Science Sat.cfg
@@ -28,7 +28,6 @@ CONTRACT_TYPE
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
 	genericReward = 416000
-	genericAdvanceMultiplier = 1.0 / 3.0
 		
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Milestones/Karman Line.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Karman Line.cfg
@@ -27,11 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 10
-	rewardFunds = 10000 * @RP0:globalHardContractMultiplier
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 28800
+	genericAdvanceMultiplier = 0.2
 
 
 

--- a/GameData/RP-0/Contracts/Milestones/Orbital Recovery.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Orbital Recovery.cfg
@@ -26,12 +26,9 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 50000 * @RP0:globalHardContractMultiplier
+	genericReward = 240000
+	genericAdvanceMultiplier = 0.5
 	rewardScience = Random(0.6, 1.8)
-	rewardReputation = 10
-	rewardFunds = (Random(40000, 60000)) * @RP0:globalHardContractMultiplier
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Milestones/Rendezvous.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Rendezvous.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 250000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 30
-	rewardFunds = 50000 * @RP0:globalHardContractMultiplier
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 720000
+	genericAdvanceMultiplier = 0.75
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Milestones/Suborbital Return.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Suborbital Return.cfg
@@ -27,10 +27,8 @@ CONTRACT_TYPE
 		
 	// ************ REWARDS ************	
 	prestige = Trivial       // 1.0x	
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0	
-	rewardReputation = 5	
-	rewardFunds = 10000	* @RP0:globalHardContractMultiplier
+	genericReward = 28800
+	genericAdvanceMultiplier = 1.0 / 6.0
 		
 		
 		

--- a/GameData/RP-0/Contracts/Milestones/Unlock Tech.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Unlock Tech.cfg
@@ -27,10 +27,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = 0
-	rewardScience = 0
-	rewardReputation = 0
-	rewardFunds = 0
+	genericReward = 0
 
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Flyby.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Flyby.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.625 * 350000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 300
-	rewardFunds = 0.625 * 150000 * @RP0:globalHardContractMultiplier
-	failureReputation = 450
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 750000
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Orbit 1 Repeatable.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Orbit 1 Repeatable.cfg
@@ -28,12 +28,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.625 * 50000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 100
-	rewardFunds = @advanceFunds
-	failureReputation = 200
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 150000
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Orbit Repeatable.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Orbit Repeatable.cfg
@@ -29,12 +29,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.625 * (50000 + @/crewNum * 20000) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 100 + @/crewNum * 30
-	rewardFunds = @advanceFunds
-	failureReputation = @rewardReputation * 1.5
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 150000 + @/crewNum * 60000
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/Crewed Moon Landing and Rover.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Crewed Moon Landing and Rover.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.625 * 50000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 200
-	rewardFunds = @advanceFunds * 2
-	failureReputation = 300
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 225000
+	genericAdvanceMultiplier = 1.0 / 3.0
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/Crewed Targeted Moon Landing.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Crewed Targeted Moon Landing.cfg
@@ -28,12 +28,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.625 * (60000.0 * (2.75+(double(@/LandDur)/172800))) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 200.0 * (2.75+(double(@/LandDur)/172800))
-	rewardFunds = @advanceFunds
-	failureReputation = @rewardReputation * 1.5
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 180000 * (2.75 + (double(@/LandDur)/172800))
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/First Crewed Lunar Orbit.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/First Crewed Lunar Orbit.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.625 * 120000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 100
-	rewardFunds = @advanceFunds
-	failureReputation = 200
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 360000
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/First Moon Landing.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/First Moon Landing.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 347222.2222 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 400
-	rewardFunds = 150000 * @RP0:globalHardContractMultiplier
-	failureReputation = 600
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 1120000
+	genericAdvanceMultiplier = 0.7
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Flyby.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Flyby.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.625 * 20000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 20
-	rewardFunds = @advanceFunds
-	failureReputation = 20
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 60000
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Impactor.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Impactor.cfg
@@ -28,12 +28,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.625 * 25000 * @RP0:globalHardContractMultiplier
-	rewardScience = 3
-	rewardReputation = 30
-	rewardFunds = @advanceFunds
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 75000
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Landing.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Landing.cfg
@@ -28,12 +28,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.625 * 25000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 50
-	rewardFunds = @advanceFunds
-	failureReputation = 25
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 75000
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Orbiter.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Orbiter.cfg
@@ -28,12 +28,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.625 * 30000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 60
-	rewardFunds = @advanceFunds
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 90000
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Rover.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Rover.cfg
@@ -28,12 +28,7 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.625 * 35000 * @RP0:globalHardContractMultiplier
-	rewardScience = 4.2
-	rewardReputation = 20
-	rewardFunds = 0.625 * 20000 * @RP0:globalHardContractMultiplier
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 82500
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Sample Return.cfg
@@ -28,12 +28,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.625 * 40000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 75
-	rewardFunds = 0.625 * 50000 * @RP0:globalHardContractMultiplier
-	failureReputation = 25
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 135000
+	genericAdvanceMultiplier = 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Nav Sats/Early Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Early Nav Sats.cfg
@@ -27,12 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = 10000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 10
-	rewardFunds = 5000 * @RP0:globalHardContractMultiplier
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 36000
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Nav Sats/GLONASS Network.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/GLONASS Network.cfg
@@ -25,12 +25,7 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 	
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 666666.6667 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 15
-	rewardFunds = 160000 * @RP0:globalHardContractMultiplier
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 2000000
 	
 	
 	// ************ REQUIREMENTS ************

--- a/GameData/RP-0/Contracts/Nav Sats/GPS Network.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/GPS Network.cfg
@@ -25,13 +25,8 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 	
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 160000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 15
-	rewardFunds = 666666.6667 * @RP0:globalHardContractMultiplier
-	failureReputation = 30
-	failureFunds = @advanceFunds * 0.5
-	
+    genericReward = 2000000
+    genericAdvanceMultiplier = 0.2
 	
 	// ************ REQUIREMENTS ************
 	

--- a/GameData/RP-0/Contracts/Nav Sats/Operational Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Operational Nav Sats.cfg
@@ -27,11 +27,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 20000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 30
-	rewardFunds = 64000 * @RP0:globalHardContractMultiplier
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 201600
+	genericAdvanceMultiplier = 1.0 / 3.0
 
 
 	// ************ REQUIREMENTS ************

--- a/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = 12000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 10
-	rewardFunds = (16000 + @SecondGenNavSat/HasComSatPayload/minQuantity * 4) * @RP0:globalHardContractMultiplier
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 28800
+	genericBonus = 38400 + @SecondGenNavSat/HasComSatPayload/minQuantity * 9.6
+	genericAdvanceMultiplier = 1.0
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Orbits/Jupiter Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Jupiter Orbit.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	genericReward = 15000
+	genericAdvanceMultiplier =  0.2
 	rewardScience = 0.15
-	rewardReputation = 30
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 40
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Orbits/Mars Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Mars Orbit.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	genericReward = 15000
+	genericAdvanceMultiplier =  0.2
 	rewardScience = 0.15
-	rewardReputation = 30
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 40
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Orbits/Mercury Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Mercury Orbit.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	genericReward = 15000
+	genericAdvanceMultiplier =  0.2
 	rewardScience = 0.15
-	rewardReputation = 30
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 40
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Orbits/Neptune Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Neptune Orbit.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	genericReward = 15000
+	genericAdvanceMultiplier =  0.2
 	rewardScience = 0.15
-	rewardReputation = 30
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 40
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Orbits/Pluto Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Pluto Orbit.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	genericReward = 15000
+	genericAdvanceMultiplier =  0.2
 	rewardScience = 0.15
-	rewardReputation = 30
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 40
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Orbits/Saturn Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Saturn Orbit.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000 * @RP0:globalHardContractMultiplier
+	genericReward = 15000
+	genericAdvanceMultiplier =  0.2
 	rewardScience = 0.15
-	rewardReputation = 30
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 40
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Orbits/Uranus Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Uranus Orbit.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	genericReward = 15000
+	genericAdvanceMultiplier =  0.2
 	rewardScience = 0.15
-	rewardReputation = 30
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 40
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Orbits/Venus Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Venus Orbit.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	genericReward = 15000
+	genericAdvanceMultiplier =  0.2
 	rewardScience = 0.15
-	rewardReputation = 30
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 40
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Records/AltRecord.cfg
+++ b/GameData/RP-0/Contracts/Records/AltRecord.cfg
@@ -24,8 +24,9 @@ CONTRACT_TYPE
   maxSimultaneous = 1
 
   // Contract rewards
-  rewardFunds = @rewardFundsInternal * @RP0:globalHardContractMultiplier
-	rewardReputation = @rewardReputationInternal
+  genericReward = @rewardFundsInternal * 2.4
+  genericAdvanceMultiplier = 0.0
+  genericFailureMultiplier = 0.0
     
   DATA
   {

--- a/GameData/RP-0/Contracts/Records/SpeedRecord.cfg
+++ b/GameData/RP-0/Contracts/Records/SpeedRecord.cfg
@@ -24,8 +24,9 @@ CONTRACT_TYPE
     maxSimultaneous = 1
 
     // Contract rewards
-    rewardFunds = (500.0 + @uncrewedTargetSpeed*0.5) * @RP0:globalHardContractMultiplier
-	rewardReputation = 4.0 + @uncrewedTargetSpeed*0.01
+    genericReward = 2.4 * (500.0 + @uncrewedTargetSpeed*0.5) 
+    genericAdvanceMultiplier = 0.0
+    genericFailureMultiplier = 0.0
 
     DATA
     {

--- a/GameData/RP-0/Contracts/Rovers/Callisto Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Callisto Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Charon Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Charon Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Dione Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Dione Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Enceladus Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Enceladus Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Europa Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Europa Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Ganymede Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Ganymede Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Iapetus Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Iapetus Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Io Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Io Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Mars Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Mars Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Mercury Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Mercury Rover.cfg
@@ -27,13 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
-
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/Rovers/Mimas Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Mimas Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Pluto Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Pluto Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Rhea Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Rhea Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Tethys Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Tethys Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Titan Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Titan Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Triton Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Triton Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Rovers/Venus Rover.cfg
+++ b/GameData/RP-0/Contracts/Rovers/Venus Rover.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 25000 * @RP0:globalHardContractMultiplier
+    genericReward = 60000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.45
-	rewardReputation = 50
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 60
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Asteroid Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Asteroid Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 120000 * @RP0:globalHardContractMultiplier
-	rewardScience = 2.4
-	rewardReputation = 120
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 140
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
+	rewardScience = 0.6
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Callisto Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Callisto Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Charon Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Charon Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Dione Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Dione Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Enceladus Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Enceladus Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Europa Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Europa Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Ganymede Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Ganymede Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Iapetus Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Iapetus Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Io Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Io Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Mars Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Mars Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Mercury Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Mercury Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Mimas Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Mimas Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Phobos Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Phobos Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Pluto Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Pluto Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Rhea Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Rhea Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Tethys Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Tethys Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Titan Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Titan Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 60000 * @RP0:globalHardContractMultiplier
+    genericReward = 2 * 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Sample Return/Triton Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Triton Sample Return.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 30000 * @RP0:globalHardContractMultiplier
+    genericReward = 72000
+    genericAdvanceMultiplier =  0.2
 	rewardScience = 0.6
-	rewardReputation = 60
-	rewardFunds = @advanceFunds * 4
-	failureReputation = 70
-	failureFunds = @advanceFunds * 0.5
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_Biome.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_Biome.cfg
@@ -30,12 +30,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 1250 * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds * 6
-	rewardScience = 0
-	rewardReputation = 10
-	failureReputation = 20
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 21000
+    genericAdvanceMultiplier = 1.0 / 7.0
 
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_HiRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_HiRes.cfg
@@ -30,12 +30,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 1500 * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds * 6
-	rewardScience = 0
-	rewardReputation = 10
-	failureReputation = 20
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 25200
+    genericAdvanceMultiplier = 1.0 / 7.0
 
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_LoRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_LoRes.cfg
@@ -30,12 +30,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 1000 * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds * 6
-	rewardScience = 0
-	rewardReputation = 10
-	failureReputation = 20
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 168000
+    genericAdvanceMultiplier = 1.0 / 7.0
 
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Earth.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Earth.cfg
@@ -28,12 +28,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Significant   // 1.25x
-	advanceFunds = 5000 * @RP0:globalHardContractMultiplier	// $15,000
-	rewardFunds = @advanceFunds * 3.333333333333			// $50,000
-	rewardScience = 0
-	rewardReputation = 5
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 52000
+    genericAdvanceMultiplier = 1.0 / 4.333333333333
 
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_GasGiant_Biome.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_GasGiant_Biome.cfg
@@ -30,12 +30,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 2000 * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds * 6
-	rewardScience = 0
-	rewardReputation = 10
-	failureReputation = 20
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 33600
+    genericAdvanceMultiplier = 1.0 / 7.0
 
 	// ************ DATA BLOCKS ************
 	

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_Biome.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_Biome.cfg
@@ -30,12 +30,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 1500 * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds * 6
-	rewardScience = 0
-	rewardReputation = 10
-	failureReputation = 20
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 25200
+    genericAdvanceMultiplier = 1.0 / 7.0
 
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_HiRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_HiRes.cfg
@@ -30,12 +30,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 1750 * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds * 6
-	rewardScience = 0
-	rewardReputation = 10
-	failureReputation = 20
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 29400
+    genericAdvanceMultiplier = 1.0 / 7.0
 
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_LoRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_LoRes.cfg
@@ -30,12 +30,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 1250 * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds * 6
-	rewardScience = 0
-	rewardReputation = 10
-	failureReputation = 20
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 21000
+    genericAdvanceMultiplier = 1.0 / 7.0
 
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_JupiterMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_JupiterMoons.cfg
@@ -28,12 +28,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.25x
-	advanceFunds = 2500 * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds * 3
-	rewardScience = 0
-	rewardReputation = 5
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 24000
+    genericAdvanceMultiplier = 0.25
 
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Moon.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Moon.cfg
@@ -27,13 +27,9 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 
 	// ************ REWARDS ************
-	prestige = Significant   // 1.25x						Moon is 4x
-	advanceFunds = 2500 * @RP0:globalHardContractMultiplier	// $48,000
-	rewardFunds = @advanceFunds * 3.333333333333			// $160,000
-	rewardScience = 0
-	rewardReputation = 10
-	failureReputation = 20
-	failureFunds = @advanceFunds * 0.5
+	prestige = Significant   // 1.25x
+    genericReward = 26000
+    genericAdvanceMultiplier = 1.0 / 4.33333333333
 
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_NeptuneMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_NeptuneMoons.cfg
@@ -28,12 +28,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.25x
-	advanceFunds = 2500 * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds * 3
-	rewardScience = 0
-	rewardReputation = 5
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 24000
+    genericAdvanceMultiplier = 0.25
 
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_SaturnMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_SaturnMoons.cfg
@@ -28,13 +28,9 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.25x
-	advanceFunds = 2500 * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds * 3
-	rewardScience = 0
-	rewardReputation = 5
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
-
+    genericReward = 24000
+    genericAdvanceMultiplier = 0.25
+    
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND
 	{

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_UranusMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_UranusMoons.cfg
@@ -28,12 +28,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.25x
-	advanceFunds = 2500 * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds * 3
-	rewardScience = 0
-	rewardReputation = 5
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 24000
+    genericAdvanceMultiplier = 0.25
 
 	// ************ DATA BLOCKS ************
 	DATA_EXPAND

--- a/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingDifficult.cfg
@@ -78,7 +78,7 @@ CONTRACT_TYPE
     title = Generate the actual payment amount for this specific mission
     type = float
     newPayout = Random( @currentMinPayment, @currentMaxPayment )
-    calcPayout = @newPayout / @RP0:globalHardContractMultiplier
+    calcPayout = @newPayout / 2.4
   }
   
   DATA

--- a/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingDifficult.cfg
@@ -25,13 +25,9 @@ CONTRACT_TYPE
 	maxCompletions = 0
 	maxSimultaneous = 1
 	prestige = Trivial
-	
-	// reward block
-	advanceFunds = Max(( @halfPayout * @RP0:globalHardContractMultiplier ) + ( 500 * ( 4 / @/soundingDifficultyLevel ) ), 4200)
-	rewardFunds = @advanceFunds * 1.2
-	failureFunds = @advanceFunds * 0.5
-  
-  
+    genericReward = 2.2 * Max(( @halfPayout * 2.4 ) + ( 500 * ( 4 / @/soundingDifficultyLevel ) ), 4200)
+    genericAdvanceMultiplier = 1.0 / 2.2
+    
   // The global modifiers for all sounding rockets are stored in the main Groups.cfg file in the root Contracts folder
   DATA
   {

--- a/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingIntermediate.cfg
@@ -79,7 +79,7 @@ CONTRACT_TYPE
     title = Generate the actual payment amount for this specific mission
     type = float
     newPayout = Random( @currentMinPayment, @currentMaxPayment )
-    calcPayout = @newPayout / @RP0:globalHardContractMultiplier
+    calcPayout = @newPayout / 2.4
   }
   
   DATA

--- a/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingIntermediate.cfg
@@ -25,12 +25,8 @@ CONTRACT_TYPE
 	maxCompletions = 0
 	maxSimultaneous = 1
 	prestige = Trivial
-	
-	// reward block
-	advanceFunds = Max(( @halfPayout * @RP0:globalHardContractMultiplier ) + ( 500 * ( 4 / @/soundingDifficultyLevel ) ), 3925)
-	rewardFunds = @advanceFunds * 1.2
-	failureFunds = @advanceFunds * 0.5
-  
+    genericReward = 2.2 * Max(( @halfPayout * 2.4 ) + ( 500 * ( 4 / @/soundingDifficultyLevel ) ), 3925)
+    genericAdvanceMultiplier = 1.0 / 2.2  
   
   // The global modifiers for all sounding rockets are stored in the main Groups.cfg file in the root Contracts folder
   DATA

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingBio.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingBio.cfg
@@ -20,11 +20,9 @@ CONTRACT_TYPE
 
 	// Contract rewards
 	prestige = Trivial
-	advanceFunds = 1300 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardFunds = @/reward * @RP0:globalHardContractMultiplier
-	rewardReputation = 5
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 3120
+    genericBonus = @/reward * 2.4
+    genericAdvanceMultiplier = 1.0
 
 	REQUIREMENT 
 	{

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingDifficult.cfg
@@ -76,7 +76,7 @@ CONTRACT_TYPE
     title = Generate the actual payment amount for this specifc mission
     type = float
     newPayout = Random( @currentMinPayment, @currentMaxPayment )
-    calcPayout = @newPayout / @RP0:globalHardContractMultiplier
+    calcPayout = @newPayout / 2.4
   }
   
   DATA

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingDifficult.cfg
@@ -25,12 +25,8 @@ CONTRACT_TYPE
 	maxCompletions = 0
 	maxSimultaneous = 1
 	prestige = Trivial
-	
-	// reward block
-	advanceFunds = Max(( @halfPayout * @RP0:globalHardContractMultiplier ) + ( 500 * ( 4 / @/soundingDifficultyLevel ) ), 3925)
-	rewardFunds = @advanceFunds * 1.2
-	failureFunds = @advanceFunds * 0.5
-  
+    genericReward = 2.2 * Max(( @halfPayout * 2.4 ) + ( 500 * ( 4 / @/soundingDifficultyLevel ) ), 3925)
+    genericAdvanceMultiplier = 1.0 / 2.2  
   
   // The global modifiers for all sounding rockets are stored in the main Groups.cfg file in the root Contracts folder
   DATA

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingFilm.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingFilm.cfg
@@ -21,11 +21,9 @@ CONTRACT_TYPE
 
 	// Contract rewards
 	prestige = Trivial
-	advanceFunds = 1300 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardFunds = @/reward * @RP0:globalHardContractMultiplier
-	rewardReputation = 5
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 3120
+    genericBonus = @/reward * 2.4
+    genericAdvanceMultiplier = 1.0
 
 	REQUIREMENT 
 	{

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingIntermediate.cfg
@@ -25,12 +25,8 @@ CONTRACT_TYPE
 	maxCompletions = 0
 	maxSimultaneous = 1
 	prestige = Trivial
-	
-	// reward block
-	advanceFunds = Max(( @halfPayout * @RP0:globalHardContractMultiplier ) + ( 500 * ( 4 / @/soundingDifficultyLevel ) ), 3444)
-	rewardFunds = @advanceFunds * 1.2
-	failureFunds = @advanceFunds * 0.5
-  
+    genericReward = 2.2 * Max(( @halfPayout * 2.4 ) + ( 500 * ( 4 / @/soundingDifficultyLevel ) ), 3444)
+    genericAdvanceMultiplier = 1.0 / 2.2
   
   // The global modifiers for all sounding rockets are stored in the main Groups.cfg file in the root Contracts folder
   DATA

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingIntermediate.cfg
@@ -77,7 +77,7 @@ CONTRACT_TYPE
     title = Generate the actual payment amount for this specifc mission
     type = float
     newPayout = Random( @currentMinPayment, @currentMaxPayment )
-    calcPayout = @newPayout / @RP0:globalHardContractMultiplier
+    calcPayout = @newPayout / 2.4
   }
   
   DATA

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingLow.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingLow.cfg
@@ -23,12 +23,8 @@ CONTRACT_TYPE
 	maxCompletions = 0
 	maxSimultaneous = 1
 	prestige = Trivial
-	
-	// reward block
-	// 400 to 600
-	advanceFunds = (200.0 + @VesselGroup/ReachAlt/minAltitude*0.005) * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds + 250.0
-	failureFunds = @advanceFunds * 0.5
+    genericReward = 1056.0 + @VesselGroup/ReachAlt/minAltitude * 0.264
+    genericAdvanceMultiplier = 1.0 / 2.2
 
 	DATA
 	{

--- a/GameData/RP-0/Contracts/Space Stations/Add Crew Module Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Add Crew Module Station.cfg
@@ -26,12 +26,9 @@ CONTRACT_TYPE
 	targetBody = @/targetBody1
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = (Round(Random(20000, 30000))) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = Round(Random(1,5))
-	rewardFunds = (Round(Random(5000, 10000))) * @RP0:globalHardContractMultiplier
-	failureReputation = @rewardReputation
-	failureFunds = @advanceFunds * 0.5
+	genericReward = (Round(Random(20000, 30000))) * 2.4
+	genericBonus = (Round(Random(5000, 10000))) * 2.4
+	genericAdvanceMultiplier = 1.0
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Space Stations/Crew Rotation Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Crew Rotation Station.cfg
@@ -27,12 +27,9 @@ CONTRACT_TYPE
 	targetBody = @/targetBody1
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = (Round(Random(5000, 10000))) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = Round(Random(1,5))
-	rewardFunds = (@/targetVessel1.CrewCount() >4 ? @/targetVessel1.CrewCount()*10000 : Random(40000, 60000.0)) * @RP0:globalHardContractMultiplier
-	failureReputation = @rewardReputation
-	failureFunds = @advanceFunds * 0.5
+	genericReward = (Round(Random(5000, 10000))) * 2.4
+	genericBonus = (@/targetVessel1.CrewCount() >4 ? @/targetVessel1.CrewCount()*10000 : Random(40000, 60000.0)) * 2.4
+	genericAdvanceMultiplier = 1.0
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 575000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 500
-	rewardFunds = 250000 * @RP0:globalHardContractMultiplier
-	failureReputation = 750
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 1980000
+	genericAdvanceMultiplier = 0.7
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Space Stations/Life Support Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Life Support Station.cfg
@@ -26,12 +26,9 @@ CONTRACT_TYPE:NEEDS[TACLifeSupport]
 	targetBody = @/targetBody1
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = (Round(Random(5000, 10000))) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = Round(Random(1,5))
-	rewardFunds = (@/targetVessel1.CrewCount() >4 ? @/targetVessel1.CrewCount()*10000 : Random(40000, 60000.0)) * @RP0:globalHardContractMultiplier
-	failureReputation = @rewardReputation
-	failureFunds = @advanceFunds * 0.5
+	genericReward = (Round(Random(5000, 10000))) * 2.4
+	genericBonus = (@/targetVessel1.CrewCount() >4 ? @/targetVessel1.CrewCount()*10000 : Random(40000, 60000.0)) * 2.4
+	genericAdvanceMultiplier = 1.0
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Space Stations/Lunar Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Lunar Space Station.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.625 * 200000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 500
-	rewardFunds = 0.625 * 85000 * @RP0:globalHardContractMultiplier
-	failureReputation = 750
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 427500
+	genericAdvanceMultiplier = 0.7
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Space Stations/Martian Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Martian Space Station.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 250000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 500
-	rewardFunds = 100000 * @RP0:globalHardContractMultiplier
-	failureReputation = 750
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 360000
+	genericAdvanceMultiplier = 1.0 / 3.0
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Space Stations/New Crew Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/New Crew Station.cfg
@@ -28,12 +28,9 @@ CONTRACT_TYPE
 
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = (Round(Random(5000, 10000))) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = Round(Random(1,5))
-	rewardFunds = (@/targetVessel1.CrewCount() >4 ? @/targetVessel1.CrewCount()*10000 : Random(40000, 60000.0)) * @RP0:globalHardContractMultiplier
-	failureReputation = @rewardReputation
-	failureFunds = @advanceFunds * 0.5
+	genericReward = (Round(Random(5000, 10000))) * 2.4
+	genericBonus = (@/targetVessel1.CrewCount() >4 ? @/targetVessel1.CrewCount()*10000 : Random(40000, 60000.0)) * 2.4
+	genericAdvanceMultiplier = 1.0
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Space Stations/Power Module Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Power Module Station.cfg
@@ -28,12 +28,9 @@ CONTRACT_TYPE
 
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = (Round(Random(20000, 30000))) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = Round(Random(1,5))
-	rewardFunds = (Round(Random(5000, 10000))) * @RP0:globalHardContractMultiplier
-	failureReputation = @rewardReputation
-	failureFunds = @advanceFunds * 0.5
+	genericReward = (Round(Random(20000, 30000))) * 2.4
+	genericBonus = (Round(Random(5000, 10000))) * 2.4
+	genericAdvanceMultiplier = 1.0
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Surface Outposts/MarsOutpost.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MarsOutpost.cfg
@@ -27,13 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 750000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 500
-	rewardFunds = 500000 * @RP0:globalHardContractMultiplier
-	failureReputation = 750
-	failureFunds = @advanceFunds * 0.5
-
+	genericReward = 600000
+	genericAdvanceMultiplier = 0.6
+	
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/Surface Outposts/MarsOutpostWithLab.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MarsOutpostWithLab.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.2 * 750000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 500
-	rewardFunds = 500000 * @RP0:globalHardContractMultiplier
-	failureReputation = 750
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 600000
+	genericAdvanceMultiplier = 0.6
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Surface Outposts/MoonOutpost.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MoonOutpost.cfg
@@ -27,13 +27,9 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.625 * 300000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 500
-	rewardFunds = 0.625 * 100000 * @RP0:globalHardContractMultiplier
-	failureReputation = 750
-	failureFunds = @advanceFunds * 0.5
-
+	genericReward = 600000
+	genericAdvanceMultiplier = 0.75
+	
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/Surface Outposts/MoonOutpostWithLab.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MoonOutpostWithLab.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 0.625 * 750000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 500
-	rewardFunds = 0.625 * 500000 * @RP0:globalHardContractMultiplier
-	failureReputation = 750
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 1875000
+	genericAdvanceMultiplier = 0.6
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/SwitchContractRewardType.cfg
+++ b/GameData/RP-0/Contracts/SwitchContractRewardType.cfg
@@ -30,11 +30,11 @@
 // Reputation rewards
 @CONTRACT_TYPE[*]:NEEDS[RP1DoUseBudgets]
 {
-	@advanceFunds = @genericReward * @genericAdvanceMultiplier*0.015
+	@advanceFunds = @genericReward * @genericAdvanceMultiplier*0.15
 	@rewardFunds = 0
-	@rewardReputation = (@genericReward * (1.1 - @genericAdvanceMultiplier*0.015) + @genericBonus) / 1000
+	@rewardReputation = (@genericReward * (1.1 - @genericAdvanceMultiplier*0.15) + @genericBonus) / 1000
 	@failureFunds = 0
-	@failureReputation = Max(0, @rewardReputation * (@genericFailureMultiplier - 1))
+	@failureReputation = Max(0, @advanceFunds * (@genericFailureMultiplier - 1) / 1000)
 }
 
 // Convert it to CC speak...

--- a/GameData/RP-0/Contracts/SwitchContractRewardType.cfg
+++ b/GameData/RP-0/Contracts/SwitchContractRewardType.cfg
@@ -1,0 +1,68 @@
+// Make sure all contracts have all fields
+@CONTRACT_TYPE[*]:HAS[~genericReward[*]]
+{
+	genericReward = 0
+}
+@CONTRACT_TYPE[*]:HAS[~genericBonus[*]]
+{
+	genericBonus = 0
+}
+@CONTRACT_TYPE[*]:HAS[~genericAdvanceMultiplier[*]]
+{
+	genericAdvanceMultiplier = 2.0/3.0
+}
+@CONTRACT_TYPE[*]:HAS[~genericFailureMultiplier[*]]
+{
+	genericFailureMultiplier = 1.5
+}
+
+
+// Normal rewards
+@CONTRACT_TYPE[*] 
+{
+	%advanceFunds = @genericReward * @genericAdvanceMultiplier	
+	%rewardFunds = @genericReward * (1 - @genericAdvanceMultiplier) + @genericBonus
+	%rewardReputation = Pow(@rewardFunds/1000, 0.5)
+	%failureFunds = Max(0, @advanceFunds * (@genericFailureMultiplier - 1))
+	%failureReputation = Max(0, @rewardReputation * @genericFailureMultiplier)
+}
+
+// Reputation rewards
+@CONTRACT_TYPE[*]:NEEDS[RP1DoUseBudgets]
+{
+	@advanceFunds = @genericReward * @genericAdvanceMultiplier*0.015
+	@rewardFunds = 0
+	@rewardReputation = (@genericReward * (1.1 - @genericAdvanceMultiplier*0.015) + @genericBonus) / 1000
+	@failureFunds = 0
+	@failureReputation = Max(0, @rewardReputation * (@genericFailureMultiplier - 1))
+}
+
+// Convert it to CC speak...
+@CONTRACT_TYPE[*] 
+{
+	DATA {
+		type = float
+		genericReward = #$../genericReward$
+	}
+	DATA {
+		type = float
+		genericBonus = #$../genericBonus$
+	}
+	DATA {
+		type = float
+		genericAdvanceMultiplier = #$../genericAdvanceMultiplier$
+	}
+	DATA {
+		type = float
+		genericFailureMultiplier = #$../genericFailureMultiplier$
+	}
+}
+
+// Remove the unneeded values
+@CONTRACT_TYPE[*] 
+{
+	-genericReward,0=remove
+	-genericBonus,0=remove
+	-genericAdvanceMultiplier,0=remove
+	-genericFailureMultiplier,0=remove
+}

--- a/GameData/RP-0/Contracts/Weather Sats/Early Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Early Weather Sats.cfg
@@ -28,12 +28,9 @@ CONTRACT_TYPE
 
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = 15000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 10
-	rewardFunds = (5000 + @EarlyWeatherSat/HasWeatherSatPayload/minQuantity * 4) * @RP0:globalHardContractMultiplier
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 48000	
+	genericBonus = @EarlyWeatherSat/HasWeatherSatPayload/minQuantity * 9.6
+	genericAdvanceMultiplier = 0.75
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Weather Sats/First Weather Sat.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/First Weather Sat.cfg
@@ -27,12 +27,8 @@ CONTRACT_TYPE
 
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = 10000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 10
-	rewardFunds = (5000 + @FirstWeatherSat/HasWeatherSatPayload/minQuantity * 4) * @RP0:globalHardContractMultiplier
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 36000
+	genericBonus = @FirstWeatherSat/HasWeatherSatPayload/minQuantity * 9.6
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
@@ -25,12 +25,8 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Significant   // 1.25x
-	advanceFunds = ((12500 * Pow(1 + ((@GEOWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.25)) / 2) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 15
-	rewardFunds = (12500 * Pow(1 + ((@GEOWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.25)) * @RP0:globalHardContractMultiplier
-	failureReputation = 15
-	failureFunds = @advanceFunds * 0.5
+	genericReward = (12500 * Pow(1 + ((@SunSyncWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.25)) * 3.6
+	genericAdvanceMultiplier = 1.0 / 3.0 
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
@@ -25,7 +25,7 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Significant   // 1.25x
-	genericReward = (12500 * Pow(1 + ((@SunSyncWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.25)) * 3.6
+	genericReward = (12500 * Pow(1 + ((@GEOWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.25)) * 3.6
 	genericAdvanceMultiplier = 1.0 / 3.0 
 
 	// ************ REQUIREMENTS ************

--- a/GameData/RP-0/Contracts/Weather Sats/Second Gen Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Second Gen Weather Sats.cfg
@@ -28,12 +28,9 @@ CONTRACT_TYPE
 
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = 15000 * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 10
-	rewardFunds = (10000 + @SecondGenWeather/HasWeatherSatPayload/minQuantity * 4) * @RP0:globalHardContractMultiplier
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
+	genericReward = 60000	
+	genericBonus = @SecondGenWeather/HasWeatherSatPayload/minQuantity * 9.6
+	genericAdvanceMultiplier = 0.6
 
 	// ************ REQUIREMENTS ************
 

--- a/GameData/RP-0/Contracts/Weather Sats/Sun Sync Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Sun Sync Weather Sats.cfg
@@ -28,13 +28,9 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = ((7000 * Pow(1 + ((@SunSyncWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.25)) / 2) * @RP0:globalHardContractMultiplier
-	rewardScience = 0
-	rewardReputation = 10
-	rewardFunds = (7000 * Pow(1 + ((@SunSyncWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.25)) * @RP0:globalHardContractMultiplier
-	failureReputation = 10
-	failureFunds = @advanceFunds * 0.5
-
+	genericReward = (7000 * Pow(1 + ((@SunSyncWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.25)) * 3.6
+	genericAdvanceMultiplier = 1.0 / 3.0 
+	
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT

--- a/GameData/RP-0/Contracts/X-Planes/CrewedFlight.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedFlight.cfg
@@ -28,11 +28,8 @@ CONTRACT_TYPE
 	prestige = Trivial
 
 	// reward block
-	advanceFunds = (250.0 + @VesselGroup/ReachAlt/minAltitude*0.1) * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds
-	failureFunds = @advanceFunds * 0.5
-	rewardReputation = 0.5
-	failureReputation = 0.5
+	genericReward = (250.0 + @VesselGroup/ReachAlt/minAltitude*0.1) * 4.8
+	genericAdvanceMultiplier = 0.5
 
 	REQUIREMENT
 	{

--- a/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmo.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmo.cfg
@@ -25,11 +25,8 @@ CONTRACT_TYPE
 	prestige = Trivial
 	
 	// reward block
-	advanceFunds = (2050 + @VesselGroup/ReachAlt/minAltitude*0.035) * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds
-	failureFunds = @advanceFunds * 0.5
-	rewardReputation = 2
-	failureReputation = 2
+	genericReward = (2050 + @VesselGroup/ReachAlt/minAltitude*0.035) * 4.8
+	genericAdvanceMultiplier = 0.5
 	
 	DATA
 	{

--- a/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoDifficult.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoDifficult.cfg
@@ -25,11 +25,8 @@ CONTRACT_TYPE
 	prestige = Trivial
 	
 	// reward block
-	advanceFunds = (2050 + @VesselGroup/ReachAlt/minAltitude*0.035) * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds
-	failureFunds = @advanceFunds * 0.5
-	rewardReputation = 2
-	failureReputation = 2
+	genericReward = (2050 + @VesselGroup/ReachAlt/minAltitude*0.035) * 4.8
+	genericAdvanceMultiplier = 0.5
 	
 	DATA
 	{

--- a/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
@@ -26,11 +26,8 @@ CONTRACT_TYPE
 	prestige = Trivial
 
 	// reward block
-	advanceFunds = Round((700.0 + 2.5 * @VesselGroup/HoldSituation/minSpeed) * @RP0:globalHardContractMultiplier * @rewardFactor, 100)
-	rewardFunds = Round(@advanceFunds + 1200.0 * @rewardFactor, 100)
-	failureFunds = @advanceFunds * 0.5
-	rewardReputation = 1
-	failureReputation = 1
+	genericReward = 2 * Round((700.0 + 2.5 * @VesselGroup/HoldSituation/minSpeed) * 2.4 * @rewardFactor, 100) + 1200.0 * @rewardFactor
+	genericAdvanceMultiplier = 0.25
 	
 	DATA
 	{

--- a/GameData/RP-0/Contracts/X-Planes/RocketPlaneDevelopment.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/RocketPlaneDevelopment.cfg
@@ -26,11 +26,8 @@ CONTRACT_TYPE
 	prestige = Trivial
 	
 	// reward block
-	advanceFunds = (1750.0 + @VesselGroup/ReachAlt/minAltitude*0.04) * @RP0:globalHardContractMultiplier
-	rewardFunds = @advanceFunds
-	failureFunds = @advanceFunds * 0.5
-	rewardReputation = 2
-	failureReputation = 2
+	genericReward = (1750.0 + @VesselGroup/ReachAlt/minAltitude*0.04) * 4.8
+	genericAdvanceMultiplier = 0.5
 	
 	REQUIREMENT
 	{


### PR DESCRIPTION
This pull request removes explicit reference to `rewardFunds`, `advanceFunds`, and similar nodes in all contract definitions. A MM patch catches references to a new field, `genericValue`, which abstracts the total reward offered by a contract, and patches it before ContractConfigurator sees it. 

Besides making contract value much more human-readable (I've taken the occasion to simplify what had become layers and layers of modifications to some original contract reward) and reducing the number of lines by a lot, it lays the groundwork for making quarterly budgets a toggle in the difficulty settings. Currently, adding the empty folder `RP1DoUseBudgets` toggles reward paradigm between cash and reputation. The details of this switch over are highly tweakable.

As the MM patch provides a much cleaner way to mass-edit contract value, I have removed the myriad references to `RP0:globalHardContractMultiplier`. Instead of having this lengthy reference be present in every single line of reward definition, it can be a simple `* 2.4` addition to a single line in the MM patch. 

The current 2.4x multiplier has been incorporated into `genericValue`. I've gone over my changes twice making sure I didn't change the value of any contracts (except for one series in which there is a 0.8% difference in value). Some advance/reward splits may have been *slightly* altered, but the total value is still the same.

This PR will be form the base upon which I'll develop the new sounding rocket contracts as directed by Siimav.