### PR TITLE
Don't gate Lunar Station behind 4 Lunar Orbits

### DIFF
--- a/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Orbit 1 Repeatable.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Orbit 1 Repeatable.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = MoonExploration
 
 
-	description = Launch a spacecraft with at least one crew aboard into lunar orbit for a routine mission of the specified duration and return safely to Earth. This mission can be completed up to 2 times.&br;&br;<b>Number of Contracts Completed: $SingleCrewedLunarOrbitRepeatable_Count</b>
+	description = Launch a spacecraft with at least one crew aboard into lunar orbit for a routine mission of the specified duration and return safely to Earth. This mission can be completed up to 2 times. Completing once will unlock the Lunar Space Station contract.&br;&br;<b>Number of Contracts Completed: $SingleCrewedLunarOrbitRepeatable_Count</b>
 	genericDescription = Fly a Crewed Lunar Orbital mission with at least one crew
 
 	synopsis = Fly a Crewed Lunar Orbital mission with at least one crew

--- a/GameData/RP-0/Contracts/Space Stations/Lunar Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Lunar Space Station.cfg
@@ -47,7 +47,8 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = HSFOrbitalMoonGenRepeatable
+		contractType = SingleCrewedLunarOrbitRepeatable
+		title = Complete @contractType Contract at least once
 	}
 
 	// ************ PARAMETERS ************


### PR DESCRIPTION
Gate it behind a single 'moon orbit with at least one crew', and
spell out that unlock in the description.

Because First Lunar Orbit pays enough to be worth doing, but
the rest don't; it's too easy for someone to just stop there,
going straight to Landing and never realize the chain is
worth continuing. Putting up a station before going for a landing
should be a viable option, and shouldn't require doing the same prereq 4 times.

(per discord "discussion" https://discordapp.com/channels/319857228905447436/516431076680531978/683086297434423356 - PR submitted as much to provoke more discussion as anything else)