### PR TITLE
Tweak ROCapsules Apollo part cost

### DIFF
--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -9589,7 +9589,7 @@
 @PART[ROC-ApolloCM]:FOR[xxxRP0]
 {
     %TechRequired = matureCapsules
-    %cost = 38000
+    %cost = 35000
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From ROCapsules mod</color></b>

--- a/Source/Tech Tree/Parts Browser/data/ROCapsules.json
+++ b/Source/Tech Tree/Parts Browser/data/ROCapsules.json
@@ -4,7 +4,7 @@
         "title": "Apollo Command Module",
         "description": "Apollo Command Module. Contains three astronauts.",
         "mod": "ROCapsules",
-        "cost": "38000",
+        "cost": 35000,
         "entry_cost": "0",
         "category": "COMMAND",
         "info": "Command Module",


### PR DESCRIPTION
All the other Apollos are 35k, this one was 38k
Might still be too high; the forward heatshield is another 3k,
presumably all the variants don't have the same parts breakdown...