### PR TITLE
Change payload contracts to require 0.01 less than stated in description

### DIFF
--- a/GameData/RP-0/Contracts/Advanced Satellites/Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Communications Satellites.cfg
@@ -125,8 +125,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = RP1CommsPayload()
-			title = Have a ComSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round((Pow(Random(0.5,1.5) * (0.3 + UnlockedTech().Count() / 100),2)*2500)/2,1)-0.01
+			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Advanced Satellites/Geostationary Communications Network.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Geostationary Communications Network.cfg
@@ -106,8 +106,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 315
+			minQuantity = 314.99
 			title = Have a ComSatPayload of at least 315 units on the craft
+			hideChildren = true
 		}
         PARAMETER
         {

--- a/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
@@ -95,8 +95,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(150,500),1)
-			title = Have a ComSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(150,500),1)-0.01
+			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
@@ -93,8 +93,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(75,125),1)
-			title = Have a ComSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(75,125),1)-0.01
+			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Early Satellites/Early CommNet (3 Sat).cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Early CommNet (3 Sat).cfg
@@ -94,8 +94,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 125
+			minQuantity = 124.99
 			title = Have a ComSatPayload of at least 125 units on the craft
+			hideChildren = true
 		}
 
         PARAMETER

--- a/GameData/RP-0/Contracts/Early Satellites/Early CommNet (4 Sat).cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Early CommNet (4 Sat).cfg
@@ -99,8 +99,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 125
+			minQuantity = 124.99
 			title = Have a ComSatPayload of at least 125 units on the craft
+			hideChildren = true
 		}
 
         PARAMETER

--- a/GameData/RP-0/Contracts/Early Satellites/First Com Sat.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/First Com Sat.cfg
@@ -80,8 +80,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(75,85),1)
-			title = Have a ComSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(75,85),1)-0.01
+			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Early Satellites/First Nav Sat.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/First Nav Sat.cfg
@@ -71,8 +71,9 @@ CONTRACT_TYPE
 			name = HasNavSatPayload
 			type = HasResource
 			resource = NavSatPayload
-			minQuantity = 100
-			title = Have a NavSatPayload of at least @minQuantity units on the craft
+			minQuantity = 99.99
+			title = Have a NavSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Early Satellites/Geostationary.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Geostationary.cfg
@@ -71,8 +71,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(5,25),1)
-			title = Have a ComSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(5,25),1)-0.01
+			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Early Satellites/Molniya Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Molniya Satellite.cfg
@@ -92,8 +92,8 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(75,125),1)
-			title = Have a ComSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(75,125),1)-0.01
+			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Early Satellites/Tundra Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Tundra Satellite.cfg
@@ -93,8 +93,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(20,63),1)
-			title = Have a ComSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(20,63),1)-0.01
+			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Nav Sats/Early Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Early Nav Sats.cfg
@@ -90,8 +90,9 @@ CONTRACT_TYPE
 			name = HasNavSatPayload
 			type = HasResource
 			resource = NavSatPayload
-			minQuantity = 60
-			title = Have a NavSatPayload of at least @minQuantity units on the craft
+			minQuantity = 59.99
+			title = Have a NavSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Nav Sats/GLONASS Network.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/GLONASS Network.cfg
@@ -460,8 +460,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft (700 kg)
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Nav Sats/GPS Network.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/GPS Network.cfg
@@ -502,8 +502,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft (700 kg)
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Nav Sats/Operational Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Operational Nav Sats.cfg
@@ -90,8 +90,9 @@ CONTRACT_TYPE
 			name = HasNavSatPayload
 			type = HasResource
 			resource = NavSatPayload
-			minQuantity = 120
+			minQuantity = 119.99
 			title = Have a NavSatPayload of at least 120 units on the craft
+			hideChildren = true
 		}
 
 		PARAMETER

--- a/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
@@ -83,8 +83,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(100,125),1)
-			title = Have a ComSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(100,125),1)-0.01
+			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingDifficult.cfg
@@ -255,8 +255,9 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload
-			title = Have a SoundingPayload of at least @minQuantity units on the craft
+			minQuantity = @/missionPayload - 0.01
+			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/DistanceSoundingIntermediate.cfg
@@ -244,8 +244,9 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload
-			title = Have a SoundingPayload of at least @minQuantity units on the craft
+			minQuantity = @/missionPayload - 0.01
+			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingBio.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingBio.cfg
@@ -166,7 +166,7 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/payload
+			minQuantity = @/payload - 0.01
 			title = Have a SoundingPayload of at least @/payload units on the craft
 			hideChildren = true
 		}

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingDifficult.cfg
@@ -254,8 +254,9 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload
-			title = Have a SoundingPayload of at least @minQuantity units on the craft
+			minQuantity = @/missionPayload -0.01
+			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Sounding Rockets/SoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Sounding Rockets/SoundingIntermediate.cfg
@@ -243,8 +243,9 @@ CONTRACT_TYPE
 			name = HasSoundingPayload
 			type = HasResource
 			resource = SoundingPayload
-			minQuantity = @/missionPayload
+			minQuantity = @/missionPayload - 0.01
 			title = Have a SoundingPayload of at least @/missionPayload.Print() units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Weather Sats/Early Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Early Weather Sats.cfg
@@ -93,8 +93,9 @@ CONTRACT_TYPE
 			name = HasWeatherSatPayload
 			type = HasResource
 			resource = WeatherSatPayload
-			minQuantity = Round(Random(12,50),1)
-			title = Have a WeatherSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(12,50),1)-0.01
+			title = Have a WeatherSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Weather Sats/First Weather Sat.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/First Weather Sat.cfg
@@ -71,8 +71,9 @@ CONTRACT_TYPE
 			name = HasWeatherSatPayload
 			type = HasResource
 			resource = WeatherSatPayload
-			minQuantity = Round(Random(5,25),1)
-			title = Have a WeatherSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(5,25),1)-0.01
+			title = Have a WeatherSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
@@ -92,8 +92,9 @@ CONTRACT_TYPE
 			name = HasWeatherSatPayload
 			type = HasResource
 			resource = WeatherSatPayload
-			minQuantity = RP1WeatherPayload()
-			title = Have a WeatherSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(250,825),1)-0.01
+			title = Have a WeatherSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Weather Sats/Second Gen Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Second Gen Weather Sats.cfg
@@ -101,8 +101,9 @@ CONTRACT_TYPE
 			name = HasWeatherSatPayload
 			type = HasResource
 			resource = WeatherSatPayload
-			minQuantity = Round(Random(50,200),1)
-			title = Have a WeatherSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(50,200),1)-0.01
+			title = Have a WeatherSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Weather Sats/Sun Sync Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Sun Sync Weather Sats.cfg
@@ -115,8 +115,9 @@ CONTRACT_TYPE
 			name = HasWeatherSatPayload
 			type = HasResource
 			resource = WeatherSatPayload
-			minQuantity = Round(Random(250,500),1)
-			title = Have a WeatherSatPayload of at least @minQuantity units on the craft
+			minQuantity = Round(Random(250,500),1)-0.01
+			title = Have a WeatherSatPayload of at least @minQuantity+0.01 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{


### PR DESCRIPTION
This solves the bug where a contract might not complete if you have the exact amount required because of floating point errors