### PR TITLE
Fix the TechTree Icons for Baloon tank upgrades

### DIFF
--- a/GameData/RP-0/Tree/ResourceTechs.cfg
+++ b/GameData/RP-0/Tree/ResourceTechs.cfg
@@ -370,7 +370,7 @@ PARTUPGRADE
 {
 	name = RFTech-Balloon-SteelAlCu
 	partIcon = RFTank-I
-	techRequired = materialsScienceSatellite
+	techRequired = materialsScienceSpaceplanes
 	entryCost = 0
 	cost = 0
 	title = Balloon Tank Upgrade
@@ -383,7 +383,7 @@ PARTUPGRADE
 {
 	name = RFTech-Balloon-SteelAlLi
 	partIcon = RFTank-I
-	techRequired = materialsScienceSpaceplanes
+	techRequired = materialsScienceInternational
 	entryCost = 0
 	cost = 0
 	title = Balloon Tank Upgrade


### PR DESCRIPTION
The Tech Tree Icons were not matching the tank definitions. 
Looks like there was some Copy-Paste error, the first upgrade had the technology for the base balloon tank, and the second upgrade had the technology of the first upgrade. 