### PR TITLE
Fix payload contracts to show rounded amounts in the requirements

### DIFF
--- a/GameData/RP-0/Contracts/Advanced Satellites/Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Communications Satellites.cfg
@@ -93,6 +93,12 @@ CONTRACT_TYPE
             RepeatComSats_Count = $RepeatComSats_Count + 1
         }
 	}
+	
+	DATA 
+	{
+		type = float
+		payload = Round((Pow(Random(0.5,1.5) * (0.3 + UnlockedTech().Count() / 100),2)*2500)/2,1)
+	}
 
 	// ************ PARAMETERS ************
 
@@ -125,8 +131,8 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round((Pow(Random(0.5,1.5) * (0.3 + UnlockedTech().Count() / 100),2)*2500)/2,1)-0.01
-			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Advanced Satellites/Geostationary Communications Network.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Geostationary Communications Network.cfg
@@ -164,8 +164,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 315
+			minQuantity = 314.99
 			title = Have a ComSatPayload of at least 315 units on the craft
+			hideChildren = true
 		}
         PARAMETER
         {
@@ -221,8 +222,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 315
+			minQuantity = 314.99
 			title = Have a ComSatPayload of at least 315 units on the craft
+			hideChildren = true
 		}
         PARAMETER
         {
@@ -278,8 +280,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 315
+			minQuantity = 314.99
 			title = Have a ComSatPayload of at least 315 units on the craft
+			hideChildren = true
 		}
         PARAMETER
         {

--- a/GameData/RP-0/Contracts/Advanced Satellites/IridiumNEXT.cfg.disabled
+++ b/GameData/RP-0/Contracts/Advanced Satellites/IridiumNEXT.cfg.disabled
@@ -227,7 +227,8 @@ CONTRACT_TYPE
 			type = HasResource
 			resource = ComSatPayload
 			minQuantity = 1249.99
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -326,8 +327,8 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
 			hideChildren = true
 		}
 		PARAMETER
@@ -427,8 +428,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -527,8 +529,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -627,8 +630,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -727,8 +731,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -827,8 +832,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -927,8 +933,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1027,8 +1034,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1127,8 +1135,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1227,8 +1236,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1328,8 +1338,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1428,8 +1439,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1528,8 +1540,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1628,8 +1641,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1728,8 +1742,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1828,8 +1843,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1928,8 +1944,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2028,8 +2045,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2128,8 +2146,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2228,8 +2247,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2328,8 +2348,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2429,8 +2450,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2529,8 +2551,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2629,8 +2652,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2729,8 +2753,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2829,8 +2854,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2929,8 +2955,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3029,8 +3056,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3129,8 +3157,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3229,8 +3258,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3329,8 +3359,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3429,8 +3460,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3530,8 +3562,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3630,8 +3663,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3730,8 +3764,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3830,8 +3865,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3930,8 +3966,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4030,8 +4067,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4130,8 +4168,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4230,8 +4269,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4330,8 +4370,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4430,8 +4471,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4530,8 +4572,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4631,8 +4674,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4731,8 +4775,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4831,8 +4876,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4931,8 +4977,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5031,8 +5078,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5131,8 +5179,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5231,8 +5280,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5331,8 +5381,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5431,8 +5482,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5531,8 +5583,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5631,8 +5684,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5732,8 +5786,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5832,8 +5887,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5932,8 +5988,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6032,8 +6089,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6132,8 +6190,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6232,8 +6291,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6332,8 +6392,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6432,8 +6493,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6532,8 +6594,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6632,8 +6695,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6732,8 +6796,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1250
-			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg)
+			minQuantity = 1249.99
+			title = Have a ComSatPayload of at least 1250 units on the craft (500 kg) 
+             hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
@@ -63,6 +63,12 @@ CONTRACT_TYPE
             EarlyComSat_Count = $EarlyComSat_Count + 1
         }
 	}
+	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(150,500),1)
+	}
 
 	// ************ PARAMETERS ************
 	
@@ -95,8 +101,8 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(150,500),1)-0.01
-			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
@@ -61,6 +61,12 @@ CONTRACT_TYPE
             ComTestSat_Count = $ComTestSat_Count + 1
         }
 	}
+	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(75,125),1)
+	}
 
 	// ************ PARAMETERS ************
 	
@@ -93,8 +99,8 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(75,125),1)-0.01
-			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Early Satellites/Early CommNet (3 Sat).cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Early CommNet (3 Sat).cfg
@@ -147,8 +147,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 125
+			minQuantity = 124.99
 			title = Have a ComSatPayload of at least 125 units on the craft
+			hideChildren = true
 		}
 
         PARAMETER
@@ -199,8 +200,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 125
+			minQuantity = 124.99
 			title = Have a ComSatPayload of at least 125 units on the craft
+			hideChildren = true
 		}
 
         PARAMETER

--- a/GameData/RP-0/Contracts/Early Satellites/Early CommNet (4 Sat).cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Early CommNet (4 Sat).cfg
@@ -160,8 +160,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 125
+			minQuantity = 124.99
 			title = Have a ComSatPayload of at least 125 units on the craft
+			hideChildren = true
 		}
 
         PARAMETER
@@ -220,8 +221,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 125
+			minQuantity = 124.99
 			title = Have a ComSatPayload of at least 125 units on the craft
+			hideChildren = true
 		}
 
         PARAMETER
@@ -280,8 +282,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 125
+			minQuantity = 124.99
 			title = Have a ComSatPayload of at least 125 units on the craft
+			hideChildren = true
 		}
 
         PARAMETER

--- a/GameData/RP-0/Contracts/Early Satellites/First Com Sat.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/First Com Sat.cfg
@@ -42,6 +42,12 @@ CONTRACT_TYPE
 		type = CompleteContract
 		contractType = FirstSolarSat
 	}
+	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(75,85),1)
+	}
 
 	PARAMETER
 	{
@@ -80,8 +86,8 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(75,85),1)-0.01
-			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Early Satellites/First Nav Sat.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/First Nav Sat.cfg
@@ -72,7 +72,7 @@ CONTRACT_TYPE
 			type = HasResource
 			resource = NavSatPayload
 			minQuantity = 99.99
-			title = Have a NavSatPayload of at least @minQuantity+0.01 units on the craft
+			title = Have a NavSatPayload of at least 100 units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Early Satellites/Geostationary.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Geostationary.cfg
@@ -43,6 +43,12 @@ CONTRACT_TYPE
 		contractType = FirstSolarSat
 	}
 	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(5,25),1)
+	}
+	
 	PARAMETER
 	{
 		name = GeostationarySat
@@ -71,8 +77,8 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(5,25),1)-0.01
-			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Early Satellites/Molniya Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Molniya Satellite.cfg
@@ -64,6 +64,12 @@ CONTRACT_TYPE
 		}
 	}
 	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(75,125),1)
+	}
+	
 	PARAMETER
 	{
 		name = VesselGroup
@@ -92,8 +98,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(75,125),1)-0.01
-			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a ComSatPayload of at least @/payload units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Early Satellites/Tundra Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Tundra Satellite.cfg
@@ -64,6 +64,12 @@ CONTRACT_TYPE
 			}
 		}
 	}
+	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(20,63),1)
+	}
 
 	PARAMETER
 	{
@@ -93,8 +99,8 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(20,63),1)-0.01
-			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Nav Sats/Early Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Early Nav Sats.cfg
@@ -91,7 +91,7 @@ CONTRACT_TYPE
 			type = HasResource
 			resource = NavSatPayload
 			minQuantity = 59.99
-			title = Have a NavSatPayload of at least @minQuantity+0.01 units on the craft
+			title = Have a NavSatPayload of at least 60 units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Nav Sats/GLONASS Network.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/GLONASS Network.cfg
@@ -860,8 +860,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1261,8 +1262,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1662,8 +1664,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2063,8 +2066,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2464,8 +2468,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2865,8 +2870,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3266,8 +3272,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3667,8 +3674,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4068,8 +4076,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4469,8 +4478,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4870,8 +4880,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5271,8 +5282,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5672,8 +5684,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6073,8 +6086,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6474,8 +6488,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6875,8 +6890,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -7276,8 +7292,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -7677,8 +7694,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -8078,8 +8096,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -8479,8 +8498,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -8880,8 +8900,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -9281,8 +9302,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -9682,8 +9704,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Nav Sats/GPS Network.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/GPS Network.cfg
@@ -902,8 +902,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1303,8 +1304,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -1704,8 +1706,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2105,8 +2108,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2506,8 +2510,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -2907,8 +2912,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3308,8 +3314,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -3709,8 +3716,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4110,8 +4118,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4511,8 +4520,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -4912,8 +4922,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5313,8 +5324,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -5714,8 +5726,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6115,8 +6128,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6516,8 +6530,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -6917,8 +6932,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -7318,8 +7334,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -7719,8 +7736,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -8120,8 +8138,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -8521,8 +8540,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -8922,8 +8942,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -9323,8 +9344,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{
@@ -9724,8 +9746,9 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = 1750
+			minQuantity = 1750-0.01
 			title = Have a ComSatPayload of at least 1750 units on the craft
+			hideChildren = true
 		}
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/Nav Sats/Operational Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Operational Nav Sats.cfg
@@ -143,8 +143,9 @@ CONTRACT_TYPE
 			name = HasNavSatPayload
 			type = HasResource
 			resource = NavSatPayload
-			minQuantity = 120
+			minQuantity = 119.99
 			title = Have a NavSatPayload of at least 120 units on the craft
+			hideChildren = true
 		}
 
 		PARAMETER
@@ -187,8 +188,9 @@ CONTRACT_TYPE
 			name = HasNavSatPayload
 			type = HasResource
 			resource = NavSatPayload
-			minQuantity = 120
+			minQuantity = 119.99
 			title = Have a NavSatPayload of at least 120 units on the craft
+			hideChildren = true
 		}
 
 		PARAMETER
@@ -223,8 +225,9 @@ CONTRACT_TYPE
 			name = HasNavSatPayload
 			type = HasResource
 			resource = NavSatPayload
-			minQuantity = 120
+			minQuantity = 119.99
 			title = Have a NavSatPayload of at least 120 units on the craft
+			hideChildren = true
 		}
 
 		PARAMETER
@@ -251,8 +254,9 @@ CONTRACT_TYPE
 			name = HasNavSatPayload
 			type = HasResource
 			resource = NavSatPayload
-			minQuantity = 120
+			minQuantity = 119.99
 			title = Have a NavSatPayload of at least 120 units on the craft
+			hideChildren = true
 		}
 
 		PARAMETER

--- a/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
@@ -53,6 +53,12 @@ CONTRACT_TYPE
             SecondGenNavSats_Count = $SecondGenNavSats_Count + 1
         }
 	}
+	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(100,125),1)-0.01
+	}
 
 	// ************ PARAMETERS ************
 
@@ -83,8 +89,8 @@ CONTRACT_TYPE
 			name = HasComSatPayload
 			type = HasResource
 			resource = ComSatPayload
-			minQuantity = Round(Random(100,125),1)-0.01
-			title = Have a ComSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a ComSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Weather Sats/Early Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Early Weather Sats.cfg
@@ -61,6 +61,12 @@ CONTRACT_TYPE
             EarlyWeatherSats_Count = $EarlyWeatherSats_Count + 1
         }
 	}
+	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(12,50),1)
+	}
 
 	// ************ PARAMETERS ************
 
@@ -93,8 +99,8 @@ CONTRACT_TYPE
 			name = HasWeatherSatPayload
 			type = HasResource
 			resource = WeatherSatPayload
-			minQuantity = Round(Random(12,50),1)-0.01
-			title = Have a WeatherSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a WeatherSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Weather Sats/First Weather Sat.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/First Weather Sat.cfg
@@ -42,6 +42,13 @@ CONTRACT_TYPE
 		type = CompleteContract
 		contractType = AtmoSat
 	}
+	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(5,25),1)
+	}
+
 
 	PARAMETER
 	{
@@ -71,8 +78,8 @@ CONTRACT_TYPE
 			name = HasWeatherSatPayload
 			type = HasResource
 			resource = WeatherSatPayload
-			minQuantity = Round(Random(5,25),1)-0.01
-			title = Have a WeatherSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a WeatherSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
@@ -60,6 +60,12 @@ CONTRACT_TYPE
         }
 	}
 	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(250,825),1)
+	}
+	
 	// ************ PARAMETERS ************
 
 	PARAMETER
@@ -92,8 +98,8 @@ CONTRACT_TYPE
 			name = HasWeatherSatPayload
 			type = HasResource
 			resource = WeatherSatPayload
-			minQuantity = Round(Random(250,825),1)-0.01
-			title = Have a WeatherSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a WeatherSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Weather Sats/Second Gen Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Second Gen Weather Sats.cfg
@@ -69,6 +69,12 @@ CONTRACT_TYPE
             SecondGenWeather_Count = $SecondGenWeather_Count + 1
         }
 	}
+	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(50,200),1)
+	}
 
 	// ************ PARAMETERS ************
 
@@ -101,8 +107,8 @@ CONTRACT_TYPE
 			name = HasWeatherSatPayload
 			type = HasResource
 			resource = WeatherSatPayload
-			minQuantity = Round(Random(50,200),1)-0.01
-			title = Have a WeatherSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a WeatherSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Weather Sats/Sun Sync Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Sun Sync Weather Sats.cfg
@@ -84,6 +84,12 @@ CONTRACT_TYPE
         }
 	}
 	
+	DATA 
+	{
+		type = float
+		payload = Round(Random(250,500),1)
+	}
+	
 	// ************ PARAMETERS ************
 
 	PARAMETER
@@ -115,8 +121,8 @@ CONTRACT_TYPE
 			name = HasWeatherSatPayload
 			type = HasResource
 			resource = WeatherSatPayload
-			minQuantity = Round(Random(250,500),1)-0.01
-			title = Have a WeatherSatPayload of at least @minQuantity+0.01 units on the craft
+			minQuantity = @/payload-0.01
+			title = Have a WeatherSatPayload of at least @/payload units on the craft
 			hideChildren = true
 		}
 		PARAMETER


### PR DESCRIPTION
As #1237 had some issues with showing the rounded amounts of payloads, I followed a different approach here. I tested it in a few of the early satellite contracts, and it seems to be working correctly now. I have also fixed the contracts that include several satellites, which I had omitted in the previous PR.