### PR TITLE
Tweak payload-rounding fix for second-gen nav sats

### DIFF
--- a/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
@@ -57,7 +57,7 @@ CONTRACT_TYPE
 	DATA 
 	{
 		type = float
-		payload = Round(Random(100,125),1)-0.01
+		payload = Round(Random(100,125),1)
 	}
 
 	// ************ PARAMETERS ************


### PR DESCRIPTION
Fix was double-applied: payload got a -0.01, then minQuantity got payload-0.01.
'payload' is also used for the user-visible text, so minQuantity is the one that should have the -0.01