### PR TITLE
Better unlock cost for ROC gemini RCS pack

### DIFF
--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -518,7 +518,7 @@
     ROC-GeminiParachute = capsulesGemini
     ROC-GeminiParachuteDrogue = capsulesGemini
     ROC-GeminiRCS = 4000,rcsMult
-    ROC-GeminiReentryControlSystem = 36000,rcsMult
+    ROC-GeminiReentryControlSystem = 1000,MMH+NTO,rcsMult
     ROC-GeminiRetrogradeSection = GeminiSM,rcsMult
     ROC-GeminiWing = 40000,capsulesGemini
     ROC-GeminiWingContSurf = ROC-GeminiWing

--- a/Source/Tech Tree/Parts Browser/data/ROCapsules.json
+++ b/Source/Tech Tree/Parts Browser/data/ROCapsules.json
@@ -952,7 +952,7 @@
         "spacecraft": "Gemini",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "36000,rcsMult",
+        "entry_cost_mods": "1000,MMH+NTO,rcsMult",
         "identical_part_name": "GeminiReentryControl",
         "module_tags": []
     },


### PR DESCRIPTION
- lower flat cost from 36k to 1k. For an rcs block and fuel tank,
  36k is silly.
- BUT add mmh-nto ECM, since that's the fuel it uses. It's possible
  to unlock the part first, shouldn't get a free pass.

The ECM is 25k, so this adds up to a 10k reduction, and lessens
the pain by making the rest a shared cost