### PR TITLE
Docking port unlock cost tweaks

### DIFF
--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -513,7 +513,7 @@
     ROC-GeminiFlightPack = ROC-GeminiWing
     ROC-GeminiFlightPackContSurf = ROC-GeminiWing
     ROC-GeminiNoseCap = capsulesGemini
-    ROC-GeminiNosecone = 50000,dockingProbeDrogue
+    ROC-GeminiNosecone = 25000,dockingProbeDrogue
     ROC-GeminiNoseconeAero = capsulesGemini
     ROC-GeminiParachute = capsulesGemini
     ROC-GeminiParachuteDrogue = capsulesGemini

--- a/GameData/RP-0/Tree/EntryCostModifiers.cfg
+++ b/GameData/RP-0/Tree/EntryCostModifiers.cfg
@@ -189,10 +189,11 @@ ENTRYCOSTMODS
 //**********************************************************************************
 //	Docking
 //**********************************************************************************
-	dockingProbeDrogue = 50000
+	dockingCommon = 45000
+	dockingProbeDrogue = 5000,dockingCommon
 	dockingCrew = 40000
 	dockingApollo = 10000, dockingProbeDrogue, dockingCrew
-	dockingAndro = 80000
+	dockingAndro = 35000,dockingCommon
 	APAS8995Dock = 4000, dockingAndro
 	NASADock = 70000, APAS89Dock
 

--- a/Source/Tech Tree/Parts Browser/data/ROCapsules.json
+++ b/Source/Tech Tree/Parts Browser/data/ROCapsules.json
@@ -845,7 +845,7 @@
         "spacecraft": "Gemini",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "50000,dockingProbeDrogue",
+        "entry_cost_mods": "25000,dockingProbeDrogue",
         "identical_part_name": "GeminiDockingProbe",
         "module_tags": [
             "Instruments"


### PR DESCRIPTION
- Move 45k to an ECM shared by both andro ports and p&d ports.
  The choice between the 2 types is largely cosmetic, don't
  punish the player quite so much for wanting to use both.
- Reduce ROC Gemini docking port cost by 25k, bringing the total
  cost of probe+drogue to 1k less than Andro instead of 24k more.
  It doesn't make much sense for the more convenient, magical
  magnetic port to be significantly cheaper.

Oddity: even with this cost reduction, ROC Gemini ports are
more expensive than FASA by 28k. Don't know why, so leaving as-is