### PR TITLE
Planet orbits

### DIFF
--- a/GameData/RP-0/Contracts/Flyby Contracts/Ceres Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Ceres Flyby.cfg
@@ -37,11 +37,24 @@ CONTRACT_TYPE
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT
-	{
-		name = CompleteContract
-		type = CompleteContract
-		contractType = flybyMars
-	}
+    {
+        name = Any
+        type = Any
+        
+        REQUIREMENT
+	    {
+		    name = CompleteContract
+		    type = CompleteContract
+		    contractType = flybyMars
+	    }
+	    
+	    REQUIREMENT
+	    {
+		    name = CompleteContract
+		    type = CompleteContract
+		    contractType = flybyVenus
+	    }
+    }
 
 	// ************ PARAMETERS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Jupiter Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Jupiter Flyby.cfg
@@ -37,12 +37,25 @@ CONTRACT_TYPE
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT
-	{
-		name = CompleteContract
-		type = CompleteContract
-		contractType = flybyMars
-	}
-
+    {
+        name = Any
+        type = Any
+        
+        REQUIREMENT
+	    {
+		    name = CompleteContract
+		    type = CompleteContract
+		    contractType = flybyMars
+	    }
+	    
+	    REQUIREMENT
+	    {
+		    name = CompleteContract
+		    type = CompleteContract
+		    contractType = flybyVenus
+	    }
+    }
+    
 	// ************ PARAMETERS ************
 
 	PARAMETER

--- a/GameData/RP-0/Contracts/Flyby Contracts/Mercury Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Mercury Flyby.cfg
@@ -36,12 +36,25 @@ CONTRACT_TYPE
 
 	// ************ REQUIREMENTS ************
 
-	REQUIREMENT
-	{
-		name = CompleteContract
-		type = CompleteContract
-		contractType = flybyMars
-	}
+    REQUIREMENT
+    {
+        name = Any
+        type = Any
+
+        REQUIREMENT
+        {
+            name = CompleteContract
+            type = CompleteContract
+            contractType = flybyMars
+        }
+
+        REQUIREMENT
+        {
+            name = CompleteContract
+		    type = CompleteContract
+		    contractType = flybyVenus
+	    }
+    }
 
 	// ************ PARAMETERS ************
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Vesta Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Vesta Flyby.cfg
@@ -37,11 +37,24 @@ CONTRACT_TYPE
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT
-	{
-		name = CompleteContract
-		type = CompleteContract
-		contractType = flybyMars
-	}
+    {
+        name = Any
+        type = Any
+        
+        REQUIREMENT
+	    {
+		    name = CompleteContract
+		    type = CompleteContract
+		    contractType = flybyMars
+	    }
+	    
+	    REQUIREMENT
+	    {
+		    name = CompleteContract
+		    type = CompleteContract
+		    contractType = flybyVenus
+	    }
+    }
 
 	// ************ PARAMETERS ************
 

--- a/GameData/RP-0/Contracts/Orbits/Jupiter Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Jupiter Orbit.cfg
@@ -27,7 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	advanceFunds = 0.2 * 15000 * @RP0:globalHardContractMultiplier
 	rewardScience = 0.15
 	rewardReputation = 30
 	rewardFunds = @advanceFunds * 4

--- a/GameData/RP-0/Contracts/Orbits/Jupiter Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Jupiter Orbit_Rep.cfg
@@ -1,13 +1,13 @@
 CONTRACT_TYPE
 {
 	name = orbitJupiter_Rep
-	title = High inclination Jupiter Orbit
+	title = Jupiter orbital science probe
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Jupiter.
+	description = Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Jupiter. &br The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or an orbit co-planar with the moons for repeated flybys.
 
-	synopsis = Send an uncrewed probe into high inclination orbit around Jupiter
+	synopsis = Send an uncrewed probe into orbit around Jupiter
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
@@ -74,10 +74,8 @@ CONTRACT_TYPE
 			type = Orbit
 			situation = ORBITING
 			maxApA = 2000000000
-			minInclination = 60
-			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Jupiter with a maximum Apoapsis of 2,000,000 km and inclination above 60°
+			title = Orbit Jupiter with a maximum Apoapsis of 2,000,000 km
 			
 			PARAMETER
 			{

--- a/GameData/RP-0/Contracts/Orbits/Jupiter Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Jupiter Orbit_Rep.cfg
@@ -1,17 +1,17 @@
 CONTRACT_TYPE
 {
-	name = orbitMars_Rep
-	title = High inclination Mars Orbit
+	name = orbitJupiter_Rep
+	title = High inclination Jupiter Orbit
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Mars.
+	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Jupiter.
 
-	synopsis = Send an uncrewed probe into high inclination orbit around Mars
+	synopsis = Send an uncrewed probe into high inclination orbit around Jupiter
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
-	sortKey = 1101
+	sortKey = 1103
 
 	cancellable = true
 	declinable = true
@@ -20,9 +20,9 @@ CONTRACT_TYPE
 	maxExpiry = 0
 	maxCompletions = 0
 	maxSimultaneous = 1
-	deadline = 1460 * RP1DeadlineMult()  // 4 years
+	deadline = 1825 * RP1DeadlineMult()  // 5 years
 
-	targetBody = Mars
+	targetBody = Jupiter
 
 
 
@@ -39,17 +39,9 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = orbitMars
-		
+		contractType = orbitJupiter
 	}
 
-	// ************ DATA ************
-	DATA
-	{
-		type = double
-		orbitKM = Round((@targetBody.Radius() * 5) / 1000)
-		title = Get Maximum Orbit Height
-	}
 
 	// ************ PARAMETERS ************
 
@@ -57,8 +49,8 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Orbit Mars
-		define = OrbitMars
+		title = Orbit Jupiter
+		define = OrbitJupiter
 
 		PARAMETER
 		{
@@ -75,17 +67,17 @@ CONTRACT_TYPE
 			type = NewVessel
 			title = Launch a New Vessel
 			hideChildren = true
-		}
+		}		
 		PARAMETER
 		{
 			name = EnterOrbit
 			type = Orbit
 			situation = ORBITING
-			maxApA = @targetBody.Radius() * 5
+			maxApA = 2000000000
 			minInclination = 60
 			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Mars with a maximum Apoapsis of @/orbitKM km and inclination above 60°
+			title = Orbit Jupiter with a maximum Apoapsis of 2,000,000 km and inclination above 60°
 			
 			PARAMETER
 			{

--- a/GameData/RP-0/Contracts/Orbits/Mars Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Mars Orbit.cfg
@@ -27,7 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	advanceFunds = 0.2 * 15000 * @RP0:globalHardContractMultiplier
 	rewardScience = 0.15
 	rewardReputation = 30
 	rewardFunds = @advanceFunds * 4

--- a/GameData/RP-0/Contracts/Orbits/Mars Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Mars Orbit_Rep.cfg
@@ -1,0 +1,104 @@
+CONTRACT_TYPE
+{
+	name = orbitMars_Rep
+	title = High inclination Mars Orbit
+	group = Orbits
+	agent = Grand Tours
+
+	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Mars.&br;<b>This contract can only be completed once every two years.</b>
+
+	synopsis = Send an uncrewed probe into high inclination orbit around Mars
+
+	completedMessage = Congratulations! We can continue to gather data from the new satellite.
+
+	sortKey = 1001
+
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 0
+	maxSimultaneous = 1
+	deadline = 1460 * RP1DeadlineMult()  // 4 years
+
+	targetBody = Mars
+
+
+
+	prestige = Significant   // 1.25x
+	advanceFunds = 0.2 * 20000
+	rewardReputation = 30
+	rewardFunds = @advanceFunds * 4
+	failureReputation = 40
+	failureFunds = @advanceFunds * 0.5
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = orbitMars
+		cooldownDuration = 730d
+		
+	}
+
+	// ************ DATA ************
+	DATA
+	{
+		type = double
+		orbitKM = Round((@targetBody.Radius() * 5) / 1000)
+		title = Get Maximum Orbit Height
+	}
+
+	// ************ PARAMETERS ************
+
+	PARAMETER
+	{
+		name = VesselGroup
+		type = VesselParameterGroup
+		title = Orbit Mars
+		define = OrbitMars
+
+		PARAMETER
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+			title = Uncrewed
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = EnterOrbit
+			type = Orbit
+			situation = ORBITING
+			maxApA = @targetBody.Radius() * 5
+			minInclination = 60
+			maxInclination = 120
+			disableOnStateChange = true
+			title = Orbit Mars with a maximum Apoapsis of @/orbitKM km and inclination above 60°
+			
+			PARAMETER
+			{
+				name = Duration
+				type = Duration
+
+				duration = 2m
+
+				preWaitText = Check for Stable Orbit
+				waitingText = Checking for Stable Orbit
+				completionText = Stable Orbit: Confirmed
+			}
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Orbits/Mars Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Mars Orbit_Rep.cfg
@@ -1,13 +1,13 @@
 CONTRACT_TYPE
 {
 	name = orbitMars_Rep
-	title = High inclination Mars Orbit
+	title = Mars orbital science probe
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Mars.
+	description = Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Mars. &br The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or an orbit co-planar with the moons for repeated flybys.
 
-	synopsis = Send an uncrewed probe into high inclination orbit around Mars
+	synopsis = Send an uncrewed probe into orbit around Mars
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
@@ -82,10 +82,8 @@ CONTRACT_TYPE
 			type = Orbit
 			situation = ORBITING
 			maxApA = @targetBody.Radius() * 5
-			minInclination = 60
-			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Mars with a maximum Apoapsis of @/orbitKM km and inclination above 60°
+			title = Orbit Mars with a maximum Apoapsis of @/orbitKM km
 			
 			PARAMETER
 			{

--- a/GameData/RP-0/Contracts/Orbits/Mercury Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Mercury Orbit.cfg
@@ -27,7 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	advanceFunds = 0.2 * 15000 * @RP0:globalHardContractMultiplier
 	rewardScience = 0.15
 	rewardReputation = 30
 	rewardFunds = @advanceFunds * 4

--- a/GameData/RP-0/Contracts/Orbits/Mercury Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Mercury Orbit_Rep.cfg
@@ -1,11 +1,11 @@
 CONTRACT_TYPE
 {
 	name = orbitMercury_Rep
-	title = High Inclination Mercury Orbit
+	title = Mercury orbital science probe
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into an orbit of Mercury.
+	description = Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Mercury. &br The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or any other inclination that matches your scientific objectives.
 
 	synopsis = Send an uncrewed probe into high inclination orbit around Mercury
 
@@ -20,7 +20,7 @@ CONTRACT_TYPE
 	maxExpiry = 0
 	maxCompletions = 0
 	maxSimultaneous = 1
-	deadline = 1825 * RP1DeadlineMult()  // 5 years
+	deadline = 2920 * RP1DeadlineMult()  // 8 years
 
 	targetBody = Mercury
 
@@ -81,10 +81,8 @@ CONTRACT_TYPE
 			type = Orbit
 			situation = ORBITING
 			maxApA = @targetBody.Radius() * 5
-			minInclination = 60
-			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Mercury with a maximum Apoapsis of @/orbitKM km and inclination above 60°
+			title = Orbit Mercury with a maximum Apoapsis of @/orbitKM km
 			
 			PARAMETER
 			{

--- a/GameData/RP-0/Contracts/Orbits/Mercury Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Mercury Orbit_Rep.cfg
@@ -1,17 +1,17 @@
 CONTRACT_TYPE
 {
-	name = orbitMars_Rep
-	title = High inclination Mars Orbit
+	name = orbitMercury_Rep
+	title = High Inclination Mercury Orbit
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Mars.
+	description = Design and successfully launch an uncrewed probe that will enter into an orbit of Mercury.
 
-	synopsis = Send an uncrewed probe into high inclination orbit around Mars
+	synopsis = Send an uncrewed probe into high inclination orbit around Mercury
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
-	sortKey = 1101
+	sortKey = 1102
 
 	cancellable = true
 	declinable = true
@@ -20,9 +20,9 @@ CONTRACT_TYPE
 	maxExpiry = 0
 	maxCompletions = 0
 	maxSimultaneous = 1
-	deadline = 1460 * RP1DeadlineMult()  // 4 years
+	deadline = 1825 * RP1DeadlineMult()  // 5 years
 
-	targetBody = Mars
+	targetBody = Mercury
 
 
 
@@ -39,8 +39,7 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = orbitMars
-		
+		contractType = orbitMercury
 	}
 
 	// ************ DATA ************
@@ -57,9 +56,9 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Orbit Mars
-		define = OrbitMars
-
+		title = Orbit Mercury
+		define = OrbitMercury
+	
 		PARAMETER
 		{
 			name = Crewmembers
@@ -75,7 +74,7 @@ CONTRACT_TYPE
 			type = NewVessel
 			title = Launch a New Vessel
 			hideChildren = true
-		}
+		}		
 		PARAMETER
 		{
 			name = EnterOrbit
@@ -85,7 +84,7 @@ CONTRACT_TYPE
 			minInclination = 60
 			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Mars with a maximum Apoapsis of @/orbitKM km and inclination above 60°
+			title = Orbit Mercury with a maximum Apoapsis of @/orbitKM km and inclination above 60°
 			
 			PARAMETER
 			{

--- a/GameData/RP-0/Contracts/Orbits/Neptune Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Neptune Orbit.cfg
@@ -27,7 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	advanceFunds = 0.2 * 15000 * @RP0:globalHardContractMultiplier
 	rewardScience = 0.15
 	rewardReputation = 30
 	rewardFunds = @advanceFunds * 4

--- a/GameData/RP-0/Contracts/Orbits/Neptune Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Neptune Orbit_Rep.cfg
@@ -1,17 +1,17 @@
 CONTRACT_TYPE
 {
-	name = orbitMars_Rep
-	title = High inclination Mars Orbit
+	name = orbitNeptune_Rep
+	title = High Inclination Neptune Orbit
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Mars.
+	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Neptune.
 
-	synopsis = Send an uncrewed probe into high inclination orbit around Mars
+	synopsis = Send an uncrewed probe into high inclination orbit around Neptune
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
-	sortKey = 1101
+	sortKey = 1106
 
 	cancellable = true
 	declinable = true
@@ -20,9 +20,9 @@ CONTRACT_TYPE
 	maxExpiry = 0
 	maxCompletions = 0
 	maxSimultaneous = 1
-	deadline = 1460 * RP1DeadlineMult()  // 4 years
+	deadline = 7300 * RP1DeadlineMult()  // 20 years
 
-	targetBody = Mars
+	targetBody = Neptune
 
 
 
@@ -39,16 +39,15 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = orbitMars
-		
+		contractType = orbitNeptune
 	}
 
 	// ************ DATA ************
 	DATA
 	{
 		type = double
-		orbitKM = Round((@targetBody.Radius() * 5) / 1000)
-		title = Get Maximum Orbit Height
+		orbitKM = Round((@targetBody.Radius() * 2) / 1000)
+		title = Get Minimum Orbit Height
 	}
 
 	// ************ PARAMETERS ************
@@ -57,8 +56,8 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Orbit Mars
-		define = OrbitMars
+		title = Orbit Neptune
+		define = OrbitNeptune
 
 		PARAMETER
 		{
@@ -75,18 +74,18 @@ CONTRACT_TYPE
 			type = NewVessel
 			title = Launch a New Vessel
 			hideChildren = true
-		}
+		}		
 		PARAMETER
 		{
 			name = EnterOrbit
 			type = Orbit
 			situation = ORBITING
-			maxApA = @targetBody.Radius() * 5
+			maxApA = 200000
 			minInclination = 60
 			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Mars with a maximum Apoapsis of @/orbitKM km and inclination above 60°
-			
+			title = Orbit Neptune with a maximum Apoapsis of 200,000 km and inclination above 60°
+
 			PARAMETER
 			{
 				name = Duration

--- a/GameData/RP-0/Contracts/Orbits/Neptune Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Neptune Orbit_Rep.cfg
@@ -1,13 +1,13 @@
 CONTRACT_TYPE
 {
 	name = orbitNeptune_Rep
-	title = High Inclination Neptune Orbit
+	title = Neptune orbital science probe
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Neptune.
+	description = Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Neptune. &br The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or an orbit co-planar with the moons for repeated flybys.
 
-	synopsis = Send an uncrewed probe into high inclination orbit around Neptune
+	synopsis = Send an uncrewed probe into orbit around Neptune
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
@@ -42,13 +42,6 @@ CONTRACT_TYPE
 		contractType = orbitNeptune
 	}
 
-	// ************ DATA ************
-	DATA
-	{
-		type = double
-		orbitKM = Round((@targetBody.Radius() * 2) / 1000)
-		title = Get Minimum Orbit Height
-	}
 
 	// ************ PARAMETERS ************
 
@@ -81,10 +74,8 @@ CONTRACT_TYPE
 			type = Orbit
 			situation = ORBITING
 			maxApA = 200000
-			minInclination = 60
-			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Neptune with a maximum Apoapsis of 200,000 km and inclination above 60°
+			title = Orbit Neptune with a maximum Apoapsis of 200,000 km
 
 			PARAMETER
 			{

--- a/GameData/RP-0/Contracts/Orbits/Pluto Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Pluto Orbit.cfg
@@ -27,7 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	advanceFunds = 0.2 * 15000 * @RP0:globalHardContractMultiplier
 	rewardScience = 0.15
 	rewardReputation = 30
 	rewardFunds = @advanceFunds * 4

--- a/GameData/RP-0/Contracts/Orbits/Saturn Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Saturn Orbit_Rep.cfg
@@ -1,17 +1,17 @@
 CONTRACT_TYPE
 {
-	name = orbitMars_Rep
-	title = High inclination Mars Orbit
+	name = orbitSaturn_Rep
+	title = High inclination Saturn Orbit
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Mars.
+	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Saturn.
 
-	synopsis = Send an uncrewed probe into high inclination orbit around Mars
+	synopsis = Send an uncrewed probe into orbit high inclination around Saturn
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
-	sortKey = 1101
+	sortKey = 1104
 
 	cancellable = true
 	declinable = true
@@ -20,9 +20,9 @@ CONTRACT_TYPE
 	maxExpiry = 0
 	maxCompletions = 0
 	maxSimultaneous = 1
-	deadline = 1460 * RP1DeadlineMult()  // 4 years
+	deadline = 5475 * RP1DeadlineMult()  // 15 years
 
-	targetBody = Mars
+	targetBody = Saturn
 
 
 
@@ -39,17 +39,9 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = orbitMars
-		
+		contractType = orbitSaturn
 	}
 
-	// ************ DATA ************
-	DATA
-	{
-		type = double
-		orbitKM = Round((@targetBody.Radius() * 5) / 1000)
-		title = Get Maximum Orbit Height
-	}
 
 	// ************ PARAMETERS ************
 
@@ -57,8 +49,8 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Orbit Mars
-		define = OrbitMars
+		title = Orbit Saturn
+		define = OrbitSaturn
 
 		PARAMETER
 		{
@@ -75,18 +67,18 @@ CONTRACT_TYPE
 			type = NewVessel
 			title = Launch a New Vessel
 			hideChildren = true
-		}
+		}		
 		PARAMETER
 		{
 			name = EnterOrbit
 			type = Orbit
 			situation = ORBITING
-			maxApA = @targetBody.Radius() * 5
+			maxApA = 1000000000
 			minInclination = 60
 			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Mars with a maximum Apoapsis of @/orbitKM km and inclination above 60°
-			
+			title = Orbit Saturn with a maximum Apoapsis of 1,000,000 km and inclination above 60°
+					
 			PARAMETER
 			{
 				name = Duration

--- a/GameData/RP-0/Contracts/Orbits/Saturn Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Saturn Orbit_Rep.cfg
@@ -1,13 +1,13 @@
 CONTRACT_TYPE
 {
 	name = orbitSaturn_Rep
-	title = High inclination Saturn Orbit
+	title = Saturn orbital science probe
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Saturn.
+	description = Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Saturn. &br The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or an orbit co-planar with the moons for repeated flybys.
 
-	synopsis = Send an uncrewed probe into orbit high inclination around Saturn
+	synopsis = Send an uncrewed probe into orbit around Saturn
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
@@ -74,10 +74,8 @@ CONTRACT_TYPE
 			type = Orbit
 			situation = ORBITING
 			maxApA = 1000000000
-			minInclination = 60
-			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Saturn with a maximum Apoapsis of 1,000,000 km and inclination above 60°
+			title = Orbit Saturn with a maximum Apoapsis of 1,000,000 km
 					
 			PARAMETER
 			{

--- a/GameData/RP-0/Contracts/Orbits/Uranus Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Uranus Orbit.cfg
@@ -27,7 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	advanceFunds = 0.2 * 15000 * @RP0:globalHardContractMultiplier
 	rewardScience = 0.15
 	rewardReputation = 30
 	rewardFunds = @advanceFunds * 4

--- a/GameData/RP-0/Contracts/Orbits/Uranus Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Uranus Orbit_Rep.cfg
@@ -1,17 +1,17 @@
 CONTRACT_TYPE
 {
-	name = orbitMars_Rep
-	title = High inclination Mars Orbit
+	name = orbitUranus_Rep
+	title = High Inclination Uranus Orbit
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Mars.
+	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Uranus.
 
-	synopsis = Send an uncrewed probe into high inclination orbit around Mars
+	synopsis = Send an uncrewed probe into high inclination orbit around Uranus
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
-	sortKey = 1101
+	sortKey = 1105
 
 	cancellable = true
 	declinable = true
@@ -20,9 +20,9 @@ CONTRACT_TYPE
 	maxExpiry = 0
 	maxCompletions = 0
 	maxSimultaneous = 1
-	deadline = 1460 * RP1DeadlineMult()  // 4 years
+	deadline = 7300 * RP1DeadlineMult()  // 20 years
 
-	targetBody = Mars
+	targetBody = Uranus
 
 
 
@@ -39,16 +39,7 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = orbitMars
-		
-	}
-
-	// ************ DATA ************
-	DATA
-	{
-		type = double
-		orbitKM = Round((@targetBody.Radius() * 5) / 1000)
-		title = Get Maximum Orbit Height
+		contractType = orbitUranus
 	}
 
 	// ************ PARAMETERS ************
@@ -57,9 +48,9 @@ CONTRACT_TYPE
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
-		title = Orbit Mars
-		define = OrbitMars
-
+		title = Orbit Uranus
+		define = OrbitUranus
+	
 		PARAMETER
 		{
 			name = Crewmembers
@@ -81,11 +72,11 @@ CONTRACT_TYPE
 			name = EnterOrbit
 			type = Orbit
 			situation = ORBITING
-			maxApA = @targetBody.Radius() * 5
+			maxApA = 200000
 			minInclination = 60
 			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Mars with a maximum Apoapsis of @/orbitKM km and inclination above 60°
+			title = Orbit Uranus with a maximum Apoapsis of 200,000 km and inclination above 60°
 			
 			PARAMETER
 			{

--- a/GameData/RP-0/Contracts/Orbits/Uranus Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Uranus Orbit_Rep.cfg
@@ -1,13 +1,13 @@
 CONTRACT_TYPE
 {
 	name = orbitUranus_Rep
-	title = High Inclination Uranus Orbit
+	title = Uranus orbital science probe
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Uranus.
+	description = Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Uranus. &br The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or an orbit co-planar with the moons for repeated flybys.
 
-	synopsis = Send an uncrewed probe into high inclination orbit around Uranus
+	synopsis = Send an uncrewed probe into orbit around Uranus
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
@@ -73,10 +73,8 @@ CONTRACT_TYPE
 			type = Orbit
 			situation = ORBITING
 			maxApA = 200000
-			minInclination = 60
-			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Uranus with a maximum Apoapsis of 200,000 km and inclination above 60°
+			title = Orbit Uranus with a maximum Apoapsis of 200,000 km
 			
 			PARAMETER
 			{

--- a/GameData/RP-0/Contracts/Orbits/Venus Orbit.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Venus Orbit.cfg
@@ -27,7 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 15000
+	advanceFunds = 0.2 * 15000 * @RP0:globalHardContractMultiplier
 	rewardScience = 0.15
 	rewardReputation = 30
 	rewardFunds = @advanceFunds * 4

--- a/GameData/RP-0/Contracts/Orbits/Venus Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Venus Orbit_Rep.cfg
@@ -5,13 +5,13 @@ CONTRACT_TYPE
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Venus.&br;<b>This contract can only be completed once every two years.</b>
+	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Venus.
 
 	synopsis = Send an uncrewed probe into high inclination orbit around Venus
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
-	sortKey = 1000
+	sortKey = 1100
 
 	cancellable = true
 	declinable = true
@@ -27,7 +27,7 @@ CONTRACT_TYPE
 
 
 	prestige = Significant   // 1.25x
-	advanceFunds = 0.2 * 20000
+	advanceFunds = 0.2 * 12000 * @RP0:globalHardContractMultiplier
 	rewardReputation = 30
 	rewardFunds = @advanceFunds * 4
 	failureReputation = 40
@@ -40,7 +40,6 @@ CONTRACT_TYPE
 		name = CompleteContract
 		type = CompleteContract
 		contractType = orbitVenus
-		cooldownDuration = 730d
 	}
 
 	// ************ DATA ************
@@ -71,6 +70,13 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}		
+		PARAMETER
+		{
 			name = EnterOrbit
 			type = Orbit
 			situation = ORBITING
@@ -85,7 +91,7 @@ CONTRACT_TYPE
 				name = Duration
 				type = Duration
 
-				duration = 10s
+				duration = 2m
 
 				preWaitText = Check for Stable Orbit
 				waitingText = Checking for Stable Orbit

--- a/GameData/RP-0/Contracts/Orbits/Venus Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Venus Orbit_Rep.cfg
@@ -1,0 +1,96 @@
+CONTRACT_TYPE
+{
+	name = orbitVenus_Rep
+	title = High inclination Venus Orbit
+	group = Orbits
+	agent = Grand Tours
+
+	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Venus.&br;<b>This contract can only be completed once every two years.</b>
+
+	synopsis = Send an uncrewed probe into high inclination orbit around Venus
+
+	completedMessage = Congratulations! We can continue to gather data from the new satellite.
+
+	sortKey = 1000
+
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 0
+	maxSimultaneous = 1
+	deadline = 1460 * RP1DeadlineMult()  // 4 years
+
+	targetBody = Venus
+
+
+
+	prestige = Significant   // 1.25x
+	advanceFunds = 0.2 * 20000
+	rewardReputation = 30
+	rewardFunds = @advanceFunds * 4
+	failureReputation = 40
+	failureFunds = @advanceFunds * 0.5
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = orbitVenus
+		cooldownDuration = 730d
+	}
+
+	// ************ DATA ************
+	DATA
+	{
+		type = double
+		orbitKM = Round((@targetBody.Radius() * 5) / 1000)
+		title = Get Maximum Orbit Height
+	}
+
+	// ************ PARAMETERS ************
+
+	PARAMETER
+	{
+		name = VesselGroup
+		type = VesselParameterGroup
+		title = Orbit Venus
+		define = OrbitVenus
+	
+		PARAMETER
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+			title = Uncrewed
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = EnterOrbit
+			type = Orbit
+			situation = ORBITING
+			maxApA = @targetBody.Radius() * 5
+			minInclination = 60
+			maxInclination = 120
+			disableOnStateChange = true
+			title = Orbit Venus with a maximum Apoapsis of @/orbitKM km and inclination above 60°
+			
+			PARAMETER
+			{
+				name = Duration
+				type = Duration
+
+				duration = 10s
+
+				preWaitText = Check for Stable Orbit
+				waitingText = Checking for Stable Orbit
+				completionText = Stable Orbit: Confirmed
+			}
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Orbits/Venus Orbit_Rep.cfg
+++ b/GameData/RP-0/Contracts/Orbits/Venus Orbit_Rep.cfg
@@ -1,13 +1,13 @@
 CONTRACT_TYPE
 {
 	name = orbitVenus_Rep
-	title = High inclination Venus Orbit
+	title = Venus orbital science probe
 	group = Orbits
 	agent = Grand Tours
 
-	description = Design and successfully launch an uncrewed probe that will enter into a high inclination orbit of Venus.
+	description = Design and successfully launch an uncrewed probe that will enter into a scientifically useful orbit of Venus. &br The flexible parameters of this contract allow you to choose either a high inclination orbit for maximum surface coverage, or any other inclination that matches your scientific objectives.
 
-	synopsis = Send an uncrewed probe into high inclination orbit around Venus
+	synopsis = Send an uncrewed probe into orbit around Venus
 
 	completedMessage = Congratulations! We can continue to gather data from the new satellite.
 
@@ -81,10 +81,8 @@ CONTRACT_TYPE
 			type = Orbit
 			situation = ORBITING
 			maxApA = @targetBody.Radius() * 5
-			minInclination = 60
-			maxInclination = 120
 			disableOnStateChange = true
-			title = Orbit Venus with a maximum Apoapsis of @/orbitKM km and inclination above 60°
+			title = Orbit Venus with a maximum Apoapsis of @/orbitKM km
 			
 			PARAMETER
 			{


### PR DESCRIPTION
Fixes the payout from most planetary orbit contracts, which were missing the @RP0:globalHardContractMultiplier and adds a new planetary orbit contract for the 7 main planets.
Also changes the Requirement for the flybys Mercury, Ceres, Vesta and Jupiter, to be either Mars or Venus instead of only Mars.

These repeatables have slightly less payout than the first orbit "milestone" contracts, and add a high inclination and apoapsis (5 * planet radius for the rocky planets, and a higher preset "reasonable" requirement for the gas giants) requirements.
As they require a new vessel, only one of each can be launched at a time, avoiding a shotgun into each planet every window. The intention is to stimulate people to return to the planets with more advanced experiments later on after the first orbit.