### PR TITLE
Recommend TestLite, fix antenna conflict

### DIFF
--- a/RP-0.netkan
+++ b/RP-0.netkan
@@ -1,5 +1,5 @@
 {
-	"spec_version" : "v1.4",
+	"spec_version" : "v1.26",
 	"identifier" : "RP-0",
 	"name"       : "Realistic Progression One (RP-1)",
 	"abstract"   : "Realistic Progression One - Career for Realism Overhaul",
@@ -33,14 +33,19 @@
 		{ "name" : "ProceduralFairings" },
 		{ "name" : "ProceduralParts" },
 		{ "name" : "RCSBuildAidCont" },
-		{ "name" : "RealAntennas" },
-		{ "name" : "RemoteTech" },
+		{ "any_of": [
+			{ "name" : "RealAntennas" },
+			{ "name" : "RemoteTech" }
+		] },
 		{ "name" : "SCANsat" },
 		{ "name" : "ScienceSituationInfo" },
 		{ "name" : "ShipManifest" },
 		{ "name" : "Kerbalism-Config-RO" },
 		{ "name" : "TACLS" },
-		{ "name" : "TestFlight" },
+		{ "any_of": [
+			{ "name" : "TestFlight" },
+			{ "name" : "TestLite" }
+		] },
 		{ "name" : "TextureReplacer" },
 		{ "name" : "Toolbar" }
 	],


### PR DESCRIPTION
## Motivation

The RP-0 wiki mod recommendations page mentions TestLite as a manual install on these pages:

- https://github.com/KSP-RO/RP-0/wiki/Recommended-Extra-Mods
- https://github.com/KSP-RO/RP-0/wiki/TestLiteVsTestFlight

As of KSP-CKAN/NetKAN#8006, TestLite is now in CKAN (only updated for KSP 1.6.1 through 1.7.3, but the author is planning new releases).

## Problem

The current RP-0 metanetkan recommends both RealAntennas and RemoteTech, which conflict with one another. This causes the install to fail if the user doesn't make any manual changes.

## Changes

- `spec_version` updated to `v1.26` to allow use of `any_of` relationship (this just means the user's CKAN can't be horribly outdated)
- RealAntennas and RemoteTech recommendations placed in an `any_of` block so they won't be checked by default and the user can choose which to use
- TestLite is added to the recommendations, inside of an `any_of` block with TestFlight so CKAN doesn't try to install both by default (the user can pick which one they want, and if they try to pick both it'll highlight them red)

Tagging @siimav yadda yadda.