### PR TITLE
Add link to forum thread

### DIFF
--- a/RP-0.netkan
+++ b/RP-0.netkan
@@ -9,6 +9,9 @@
 	"$vref"      : "#/ckan/ksp-avc",
 	"x_netkan_force_v": true,
 	"release_status" : "stable",
+	"resources": {
+		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/190040-*"
+	},
 	"depends" : [
 		{ "name" : "ModuleManager" },
 		{ "name" : "RealismOverhaul" },


### PR DESCRIPTION
## Problem

RP-0/1 has a forum thread, but CKAN doesn't know about it.

## Changes

Now the forum thread is added to the metanetkan.

(Should have included this in #1303, but I didn't notice it at the time.)

Tagging @siimav to ensure notifications.