### PR TITLE
Change upgrade costs and tiers of R&D and Mission Control

### DIFF
--- a/GameData/RP-0/CustomBarnKit.cfg
+++ b/GameData/RP-0/CustomBarnKit.cfg
@@ -62,9 +62,11 @@
 	}
 	@MISSION
 	{
-		@upgrades = 100000, 200000, 800000 // dunno what to do here
-		
-		@activeContractsLimit = 3, 7, -1
+		@levels = 5
+		@upgradesVisual = 1, 1, 2, 2, 3
+		@unlockedFlightPlanning = 3
+		@upgrades = 25000, 60000, 120000, 200000, 300000 // dunno what to do here
+		@activeContractsLimit = 2, 3, 5, 7, 10, -1
 		@reputationKerbalDeath = 200
 	    @reputationKerbalRecovery = 1
 	}
@@ -98,7 +100,7 @@
 		@upgradesVisual = 1, 1, 2, 2, 3, 3, 3
 		@upgrades = 250000, 500000, 1000000, 2000000, 4000000, 6000000, 10000000
 		@dataToScienceRatio = 1, 1, 1, 1, 1, 1, 1 // this isn't actually used.
-		@scienceCostLimit = 25.4, 50.4, 75.4, 100.4, 150.4, 200.4, -1
+		@scienceCostLimit = 25.4, 50.4, 80.4, 116.4, 150.4, 200.4, -1
 		@unlockedFuelTransfer = 1
 	}
 }

--- a/GameData/RP-0/CustomBarnKit.cfg
+++ b/GameData/RP-0/CustomBarnKit.cfg
@@ -66,7 +66,7 @@
 		@upgradesVisual = 1, 1, 2, 2, 3
 		@unlockedFlightPlanning = 3
 		@upgrades = 25000, 60000, 120000, 200000, 300000 // dunno what to do here
-		@activeContractsLimit = 2, 3, 5, 7, 10, -1
+		@activeContractsLimit = 2, 3, 6, 10, -1
 		@reputationKerbalDeath = 200
 	    @reputationKerbalRecovery = 1
 	}

--- a/GameData/RP-0/Tree/RP0TechTree.cfg
+++ b/GameData/RP-0/Tree/RP0TechTree.cfg
@@ -4483,7 +4483,7 @@
 		id = materialsScienceLunar
 		title = Lunar Exploration Era Materials Science
 		description = Blue Sky Research into Lunar Exploration Era Materials Science (1967-1971)
-		cost = 75
+		cost = 80
 		hideEmpty = False
 		nodeName = materialsScienceLunar
 		anyToUnlock = False
@@ -4502,7 +4502,7 @@
 		id = materialsScienceSpaceStation
 		title = Space Station Era Materials Science
 		description = Blue Sky Research into Space Station Era Materials Science (1972-1980)
-		cost = 100
+		cost = 116
 		hideEmpty = False
 		nodeName = materialsScienceSpaceStation
 		anyToUnlock = False
@@ -4692,7 +4692,7 @@
 		id = electronicsLunar
 		title = Lunar Exploration Era Electronics Research
 		description = Blue Sky Research into Lunar Exploration Era Electronics Research (1967-1971)
-		cost = 75
+		cost = 80
 		hideEmpty = False
 		nodeName = electronicsLunar
 		anyToUnlock = False
@@ -4711,7 +4711,7 @@
 		id = electronicsSpaceStation
 		title = Space Station Era Electronics Research
 		description = Blue Sky Research into Space Station and Deep Space Probe Era Materials Science ()
-		cost = 100
+		cost = 116
 		hideEmpty = False
 		nodeName = electronicsSpaceStation
 		anyToUnlock = False


### PR DESCRIPTION
In the R&D building, upgrade costs are pushed back 1 tier,
so that maximum cost is 6M instead of 10M, and every tier has lower cost
Additionally, levels 3 and 4 now have higher node cost limits.

In the Mission Control, more levels are added, with 5 instead of 3,
and upgrade costs are overall reduced.