### PR TITLE
Proc Fairings v6.0+ Support

### DIFF
--- a/GameData/RP-0/ProcCosts.cfg
+++ b/GameData/RP-0/ProcCosts.cfg
@@ -60,9 +60,9 @@
 	}
 }
 
-// ProcFairings v2.0+ for KSP 1.8+ deprecates both ProceduralFairingAdapter and KzFairingBaseResizer
+// ProcFairings v6.0+ for KSP 1.8+ deprecates both ProceduralFairingAdapter and KzFairingBaseResizer
 // Everything is contained in the ProceduralFairingBase, with a mode KSPField
-// PF v2.0 also adds decoupler mass and cost adders/multipliers.
+// PF v6.0 also adds decoupler mass and cost adders/multipliers.
 
 @PART:HAS[@MODULE[ProceduralFairingBase]:HAS[#mode]]:FOR[RP-0]
 {
@@ -101,7 +101,7 @@
 	}
 }
 
-// PF 2.0 patch for FairingBases/Adapters with no decoupler
+// PF 6.0 patch for FairingBases/Adapters with no decoupler
 @PART:HAS[@MODULE[ProceduralFairingBase],!MODULE[ModuleDecouple]]:FOR[RP-0]
 {
 	@MODULE[ModuleToolingGeneric]
@@ -157,9 +157,9 @@
 		costPerTonneNonDecoupled = 100
 	}
 }
-@PART:HAS[@MODULE[ProceduralFairingSide]]:FOR[RP-0]
+@PART:HAS[@MODULE[ProceduralFairingSide]:HAS[#decouplerCostMult]]:FOR[RP-0]
 {
-	@MODULE[ProceduralFairingSide]
+	@MODULE[ProceduralFairingSide]:HAS[#decouplerCostMult]
 	{
 		@costPerTonne = 100
 		%decouplerCostMult = 8              // Mult to costPerTonne when decoupler is enabled

--- a/GameData/RP-0/ProcCosts.cfg
+++ b/GameData/RP-0/ProcCosts.cfg
@@ -1,5 +1,5 @@
 // Proc Fairings
-@PART[*]:HAS[@MODULE[KzFairingBaseResizer]]:FOR[RP-0]
+@PART:HAS[@MODULE[KzFairingBaseResizer]]:FOR[RP-0]
 {
 	@cost = 1
 	@MODULE[KzFairingBaseResizer]
@@ -22,7 +22,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ProceduralFairingAdapter]]:FOR[RP-0]
+@PART:HAS[@MODULE[ProceduralFairingAdapter]]:FOR[RP-0]
 {
 	@cost = 1
 	@MODULE[ProceduralFairingAdapter]
@@ -44,7 +44,9 @@
 		useLength = false
 	}
 }
-@PART[*]:HAS[@MODULE[ProceduralFairingAdapter],!MODULE[ModuleDecouple]]:FOR[RP-0]
+
+//    Adapters without decoupler cost 20% - though these don't exist in base ProcFairings
+@PART:HAS[@MODULE[ProceduralFairingAdapter],!MODULE[ModuleDecouple]]:FOR[RP-0]
 {
 	@MODULE[KzFairingBaseResizer]
 	{
@@ -58,6 +60,57 @@
 	}
 }
 
+// ProcFairings v2.0+ for KSP 1.8+ deprecates both ProceduralFairingAdapter and KzFairingBaseResizer
+// Everything is contained in the ProceduralFairingBase, with a mode KSPField
+// PF v2.0 also adds decoupler mass and cost adders/multipliers.
+
+@PART:HAS[@MODULE[ProceduralFairingBase]:HAS[#mode]]:FOR[RP-0]
+{
+	@cost = 1
+	@MODULE[ProceduralFairingBase]:HAS[#mode[Payload]]
+	{
+		@costPerTonne = 80
+		%decouplerCostMult = 5;              // Mult to costPerTonne when decoupler is enabled
+		%decouplerCostBase = 0;              // Flat additional cost when decoupler is enabled
+		%decouplerMassMult = 1;              // Mass multiplier
+		%decouplerMassBase = 0;              // Flat additional mass (0.001 = 1kg)
+	}
+	@MODULE[ProceduralFairingBase]:HAS[#mode[Adapter]]
+	{
+		@costPerTonne = 100
+		%decouplerCostMult = 5;              // Mult to costPerTonne when decoupler is enabled
+		%decouplerCostBase = 0;              // Flat additional cost when decoupler is enabled
+		%decouplerMassMult = 1;              // Mass multiplier
+		%decouplerMassBase = 0;              // Flat additional mass (0.001 = 1kg)
+	}
+
+	!MODULE[ModuleToolingGeneric],* {}
+	MODULE
+	{
+		name = ModuleToolingGeneric
+		toolingName = Tool Interstage/Payload Base
+		toolingType = IBFBBase
+		untooledMultiplier = 0.125
+		finalToolingCostMultiplier = 0.2
+
+		costReducers = Decoupler
+
+		partModuleName = ProceduralFairingBase
+		diamField = baseSize
+		useLength = false
+	}
+}
+
+// PF 2.0 patch for FairingBases/Adapters with no decoupler
+@PART:HAS[@MODULE[ProceduralFairingBase],!MODULE[ModuleDecouple]]:FOR[RP-0]
+{
+	@MODULE[ModuleToolingGeneric]
+	{
+		%toolingName = Tool Structural Base
+		%toolingType = StructuralBase
+		%finalToolingCostMultiplier = 0.08
+	}
+}
 
 @PART[*]:HAS[@MODULE[KzThrustPlateResizer]]:FOR[RP-0]
 {
@@ -79,7 +132,7 @@
 		useLength = false
 	}
 }
-@PART[*]:HAS[@MODULE[ProceduralFairingSide]]:FOR[RP-0]
+@PART:HAS[@MODULE[ProceduralFairingSide]]:FOR[RP-0]
 {
 	%RP0conf = true
 	@cost = 1
@@ -104,6 +157,15 @@
 		costPerTonneNonDecoupled = 100
 	}
 }
+@PART:HAS[@MODULE[ProceduralFairingSide]]:FOR[RP-0]
+{
+	@MODULE[ProceduralFairingSide]
+	{
+		@costPerTonne = 100
+		%decouplerCostMult = 8;              // Mult to costPerTonne when decoupler is enabled
+	}
+}
+
 
 // Proc Parts
 // FIXME remove on Proc Parts update

--- a/GameData/RP-0/ProcCosts.cfg
+++ b/GameData/RP-0/ProcCosts.cfg
@@ -70,18 +70,18 @@
 	@MODULE[ProceduralFairingBase]:HAS[#mode[Payload]]
 	{
 		@costPerTonne = 80
-		%decouplerCostMult = 5;              // Mult to costPerTonne when decoupler is enabled
-		%decouplerCostBase = 0;              // Flat additional cost when decoupler is enabled
-		%decouplerMassMult = 1;              // Mass multiplier
-		%decouplerMassBase = 0;              // Flat additional mass (0.001 = 1kg)
+		%decouplerCostMult = 5              // Mult to costPerTonne when decoupler is enabled
+		%decouplerCostBase = 0              // Flat additional cost when decoupler is enabled
+		%decouplerMassMult = 1              // Mass multiplier
+		%decouplerMassBase = 0              // Flat additional mass (0.001 = 1kg)
 	}
 	@MODULE[ProceduralFairingBase]:HAS[#mode[Adapter]]
 	{
 		@costPerTonne = 100
-		%decouplerCostMult = 5;              // Mult to costPerTonne when decoupler is enabled
-		%decouplerCostBase = 0;              // Flat additional cost when decoupler is enabled
-		%decouplerMassMult = 1;              // Mass multiplier
-		%decouplerMassBase = 0;              // Flat additional mass (0.001 = 1kg)
+		%decouplerCostMult = 5              // Mult to costPerTonne when decoupler is enabled
+		%decouplerCostBase = 0              // Flat additional cost when decoupler is enabled
+		%decouplerMassMult = 1              // Mass multiplier
+		%decouplerMassBase = 0              // Flat additional mass (0.001 = 1kg)
 	}
 
 	!MODULE[ModuleToolingGeneric],* {}
@@ -162,7 +162,7 @@
 	@MODULE[ProceduralFairingSide]
 	{
 		@costPerTonne = 100
-		%decouplerCostMult = 8;              // Mult to costPerTonne when decoupler is enabled
+		%decouplerCostMult = 8              // Mult to costPerTonne when decoupler is enabled
 	}
 }
 

--- a/Source/Tooling/ModuleToolingPFSide.cs
+++ b/Source/Tooling/ModuleToolingPFSide.cs
@@ -39,19 +39,11 @@ namespace RP0
         public override void OnStart(StartState state)
         {
             base.OnStart(state);
-            PFAssembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => string.Equals(a.assembly.GetName().Name, "ProceduralFairings", StringComparison.OrdinalIgnoreCase)).assembly;
-            System.Diagnostics.FileVersionInfo fvi = System.Diagnostics.FileVersionInfo.GetVersionInfo(PFAssembly.Location);
-            string version = fvi.FileVersion;
-            if (state == StartState.Editor && pmDecoupler != null && pmFairing != null)
+            PFAssembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => string.Equals(a.assembly.GetName().Name, "ProceduralFairings", StringComparison.OrdinalIgnoreCase))?.assembly;
+            if (state == StartState.Editor && pmDecoupler?.Fields["fairingStaged"] is BaseField bf && pmFairing is PartModule)
             {
-                var bf = pmDecoupler.Fields["fairingStaged"];
                 bf.uiControlEditor.onFieldChanged += OnFairingStagedChanged;
-
-                if (part.partInfo != null)
-                {
-                    var isDecoupled = bf.GetValue<bool>(pmDecoupler);
-                    UpdateToolingAndCosts(isDecoupled);
-                }
+                UpdateToolingAndCosts(bf.GetValue<bool>(pmDecoupler));
             }
         }
 
@@ -96,7 +88,7 @@ namespace RP0
 
         public void UpdateToolingAndCosts(bool isDecoupled)
         {
-            if (toolingTypeNonDecoupled == null || costPerTonneNonDecoupled == 0f || untooledMultiplierNonDecoupled == 0f || finalToolingCostMultiplierNonDecoupled == 0f)
+            if (toolingTypeNonDecoupled == null || part?.partInfo?.partPrefab == null || costPerTonneNonDecoupled == 0f || untooledMultiplierNonDecoupled == 0f || finalToolingCostMultiplierNonDecoupled == 0f)
                 return;
 
             var toolingPrefabModule = part.partInfo.partPrefab.FindModuleImplementing<ModuleToolingPFSide>();


### PR DESCRIPTION
Update tooling module to support ProcFairings 6.0 changes:
 * ProceduralFairingBase module now encompasses previous Base/Adapter/Resizer modules
 * Base and FairingSide modules have MM-configurable cost adjusters based on decoupler presence
Update general procedural costing patches based on those changes.  Simultaneous support of both PF 1.8.x and 6.0+