### PR TITLE
Add support for 7m heatshield

### DIFF
--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -887,6 +887,7 @@
     RO-LEOHeatShield3m = heatshieldsLEO
     RO-LEOHeatShield4m = heatshieldsLEO
     RO-LEOHeatShield5m = heatshieldsLEO
+    RO-LunarHeatshield7m = heatshieldsLunar
     RO-bluedog-M1 = M-1-Spec
     RO-earlyControllableCore = 1000, avionicsProbesBasic
     RO-linearRcs-tenth = 1

--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -15210,6 +15210,18 @@
     { name = ModuleTagReentry }
 
 }
+@PART[RO_LunarHeatshield7m]:FOR[xxxRP0]
+{
+    %TechRequired = advancedUncrewedLanding
+    %cost = 5000
+    %entryCost = 37000
+    RP0conf = true
+    @description ^=:$: <b><color=green>From Realism Overhaul mod</color></b>
+
+    MODULE
+    { name = ModuleTagReentry }
+
+}
 @PART[RO_RLA_AJ260_FL]:FOR[xxxRP0]
 {
     %TechRequired = solids1981

--- a/Source/Tech Tree/Parts Browser/data/Realism_Overhaul.json
+++ b/Source/Tech Tree/Parts Browser/data/Realism_Overhaul.json
@@ -419,6 +419,31 @@
         ]
     },
     {
+        "name": "RO_LunarHeatshield7m",
+        "title": "Heat Shield (7m)",
+        "description": "Lunar-rated heat shield.",
+        "mod": "Realism Overhaul",
+        "cost": "5000",
+        "entry_cost": "37000",
+        "category": "EDL",
+        "info": "Heat Shield",
+        "year": "1972",
+        "technology": "advancedUncrewedLanding",
+        "era": "06-STATION",
+        "ro": true,
+        "rp0": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "",
+        "upgrade": false,
+        "entry_cost_mods": "heatshieldsLunar",
+        "identical_part_name": "",
+        "module_tags": [
+            "Reentry"
+        ]
+    },
+    {
         "name": "RO_linearRcs_tenth",
         "title": "Attitude Jet (28/45 N class)",
         "description": "These small thrusters are for upper stage or very small probe orientation.",


### PR DESCRIPTION
Arbitrarily placed in same node as 10m shield.

Goes with KSP-RO/RealismOverhaul#2347