### PR TITLE
Changed contract event name to InternalName for easier contract extraction

### DIFF
--- a/Source/CareerLog/CareerLog.cs
+++ b/Source/CareerLog/CareerLog.cs
@@ -375,7 +375,7 @@ namespace RP0
                     .ToArray(),
                 contractEvents = _contractDict.Where(c =>
                         c.Type == ContractEventType.Complete && c.UT >= logPeriod.StartUT && c.UT < logPeriod.EndUT)
-                    .Select(c => c.DisplayName)
+                    .Select(c => c.InternalName)
                     .ToArray(),
                 techEvents = _techEvents.Where(t => t.UT >= logPeriod.StartUT && t.UT < logPeriod.EndUT)
                     .Select(t => t.NodeName)


### PR DESCRIPTION
* aimed at easier extraction for RiS milestones and their corresponding CC names