### PR TITLE
RD-8, RD-120 tweaks

### DIFF
--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -142,6 +142,7 @@
     GuidanceEarly2m = 1000,         avionicsBoosterEarly
     GuidanceEarly3m = 1500,         avionicsBoosterEarly
     GuidanceStart1m = 1
+    HA3SLRD120 = RD-120
     HeatShield0 = heatshieldsLunar
     HeatShield1 = heatshieldsLunar
     HeatShield2 = heatshieldsLunar
@@ -758,7 +759,6 @@
     ROE-RD58 = S1-5400
     ROE-RD58-RE = S1-5400
     ROE-RD8 = RD-8
-    ROE-RD8-RE = RD-8
     ROE-RL10A3 = RL10A-1
     ROE-RL10A3-SSTU = RL10A-1
     ROE-RL10A4 = RL10A-4
@@ -1367,6 +1367,7 @@
     rn-vostok-tdu = VostokSM
     rn-x405 = X-405
     rn-x405-vernier = X-405
+    rn-zenit-rd120 = RD-120
     rn-zond-sa = 25000,capsulesMature,heatshieldsLunar
     rocketNoseCone-v2 = 1
     roverWheel1 = wheelsEarly

--- a/GameData/RP-0/Tree/TREE-Engines.cfg
+++ b/GameData/RP-0/Tree/TREE-Engines.cfg
@@ -2312,7 +2312,7 @@
             @CONFIG[RD-8]
             {
                 %techRequired = stagedCombustion1981
-                %cost = 0
+                %cost = 600
             }
 
             @CONFIG[RD-805]

--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -3905,10 +3905,14 @@
 @PART[HA3SLRD120]:FOR[xxxRP0]
 {
     %TechRequired = stagedCombustion1981
-    %cost = 13000
-    %entryCost = 38000
+    %cost = 750
+    %entryCost = 3500
     RP0conf = false
     @description ^=:$: <b><color=green>From Horizon Aeronautics Zenit mod</color></b>
+
+    MODULE
+    { name = ModuleTagEngineLiquidTurbo }
+
 }
 @PART[HA3SLRD171]:FOR[xxxRP0]
 {
@@ -9425,10 +9429,14 @@
 @PART[RO-RealEngines-RD-120]:FOR[xxxRP0]
 {
     %TechRequired = stagedCombustion1981
-    %cost = 1000
+    %cost = 750
     %entryCost = 3500
     RP0conf = false
     @description ^=:$: <b><color=green>From RealEngines mod</color></b>
+
+    MODULE
+    { name = ModuleTagEngineLiquidTurbo }
+
 }
 @PART[RO-RealEngines-RD-170]:FOR[xxxRP0]
 {
@@ -9493,10 +9501,14 @@
 @PART[RO-RealEngines-RD-8]:FOR[xxxRP0]
 {
     %TechRequired = stagedCombustion1981
-    %cost = 1000
+    %cost = 0
     %entryCost = 3500
     RP0conf = false
     @description ^=:$: <b><color=green>From RealEngines mod</color></b>
+
+    MODULE
+    { name = ModuleTagEngineLiquidTurbo }
+
 }
 @PART[RO-RealEngines-RD-805]:FOR[xxxRP0]
 {
@@ -13527,18 +13539,14 @@
 @PART[ROE-RD8]:FOR[xxxRP0]
 {
     %TechRequired = stagedCombustion1981
-    %cost = 1000
+    %cost = 0
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From ROEngines mod</color></b>
-}
-@PART[ROE-RD8-RE]:FOR[xxxRP0]
-{
-    %TechRequired = stagedCombustion1981
-    %cost = 1000
-    %entryCost = 0
-    RP0conf = true
-    @description ^=:$: <b><color=green>From ROEngines mod</color></b>
+
+    MODULE
+    { name = ModuleTagEngineLiquidTurbo }
+
 }
 @PART[ROE-RL10A3]:FOR[xxxRP0]
 {
@@ -31326,9 +31334,13 @@
 {
     %TechRequired = stagedCombustion1981
     %cost = 750
-    %entryCost = 4200
+    %entryCost = 3500
     RP0conf = false
     @description ^=:$: <b><color=green>From RN Soviet Rockets mod</color></b>
+
+    MODULE
+    { name = ModuleTagEngineLiquidTurbo }
+
 }
 @PART[rn_zenit_rd171]:FOR[xxxRP0]
 {
@@ -31345,10 +31357,14 @@
 @PART[rn_zenit_rd8]:FOR[xxxRP0]
 {
     %TechRequired = stagedCombustion1981
-    %cost = 750
+    %cost = 0
     %entryCost = 4200
     RP0conf = false
     @description ^=:$: <b><color=green>From RN Soviet Rockets mod</color></b>
+
+    MODULE
+    { name = ModuleTagEngineLiquidTurbo }
+
 }
 @PART[rn_zenit_stg1]:FOR[xxxRP0]
 {

--- a/GameData/RP-0/Tree/identicalParts.cfg
+++ b/GameData/RP-0/Tree/identicalParts.cfg
@@ -560,8 +560,10 @@
 @PART[ROE-RD108-SSTU]:FOR[xxxRP0] { %identicalParts = LiquidEngineRK-7,R7_Core_Engine,R7_SECOND_STAGE,RO-RealEngines-RD-108,ROE-RD108,ROE-RD108-SSTU,SSTU-SC-ENG-RD-108A,Size2MedEngine }
 @PART[Size2MedEngine]:FOR[xxxRP0] { %identicalParts = LiquidEngineRK-7,R7_Core_Engine,R7_SECOND_STAGE,RO-RealEngines-RD-108,ROE-RD108,ROE-RD108-SSTU,SSTU-SC-ENG-RD-108A,Size2MedEngine }
 @PART[SSTU-SC-ENG-RD-108A]:FOR[xxxRP0] { %identicalParts = LiquidEngineRK-7,R7_Core_Engine,R7_SECOND_STAGE,RO-RealEngines-RD-108,ROE-RD108,ROE-RD108-SSTU,SSTU-SC-ENG-RD-108A,Size2MedEngine }
-@PART[HA3SLRD120]:FOR[xxxRP0] { %identicalParts = HA3SLRD120,RO-RealEngines-RD-120 }
-@PART[RO-RealEngines-RD-120]:FOR[xxxRP0] { %identicalParts = HA3SLRD120,RO-RealEngines-RD-120 }
+@PART[HA3SLRD120]:FOR[xxxRP0] { %identicalParts = HA3SLRD120,RO-RealEngines-RD-120,ROE-RD120,rn_zenit_rd120 }
+@PART[rn_zenit_rd120]:FOR[xxxRP0] { %identicalParts = HA3SLRD120,RO-RealEngines-RD-120,ROE-RD120,rn_zenit_rd120 }
+@PART[RO-RealEngines-RD-120]:FOR[xxxRP0] { %identicalParts = HA3SLRD120,RO-RealEngines-RD-120,ROE-RD120,rn_zenit_rd120 }
+@PART[ROE-RD120]:FOR[xxxRP0] { %identicalParts = HA3SLRD120,RO-RealEngines-RD-120,ROE-RD120,rn_zenit_rd120 }
 @PART[liquidEnginemogulmp1500]:FOR[xxxRP0] { %identicalParts = RD171_StockVersion,RO-RealEngines-RD-170,ROE-RD170,ROE-RD170-SSTU,SXTKD170,liquidEnginemogulmp1500 }
 @PART[RD171_StockVersion]:FOR[xxxRP0] { %identicalParts = RD171_StockVersion,RO-RealEngines-RD-170,ROE-RD170,ROE-RD170-SSTU,SXTKD170,liquidEnginemogulmp1500 }
 @PART[RO-RealEngines-RD-170]:FOR[xxxRP0] { %identicalParts = RD171_StockVersion,RO-RealEngines-RD-170,ROE-RD170,ROE-RD170-SSTU,SXTKD170,liquidEnginemogulmp1500 }

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -7888,7 +7888,7 @@
         "title": "RD-8",
         "description": "",
         "mod": "Engine_Config",
-        "cost": "0",
+        "cost": "600",
         "entry_cost": "0",
         "category": "STAGED",
         "info": "",

--- a/Source/Tech Tree/Parts Browser/data/Horizon_Aeronautics_Zenit.json
+++ b/Source/Tech Tree/Parts Browser/data/Horizon_Aeronautics_Zenit.json
@@ -96,8 +96,8 @@
         "title": "RD-120",
         "description": "High altitude engine used in the Zenit second stage. First production Russian engine to be test fired in the United States (3 test burns were made).",
         "mod": "Horizon Aeronautics Zenit",
-        "cost": "13000",
-        "entry_cost": "38000",
+        "cost": 750,
+        "entry_cost": 3500,
         "category": "STAGED",
         "info": "",
         "year": "1985",
@@ -108,11 +108,13 @@
         "orphan": false,
         "rp0_conf": false,
         "spacecraft": "Zenit",
-        "engine_config": "",
+        "engine_config": "RD120",
         "upgrade": false,
-        "entry_cost_mods": "",
+        "entry_cost_mods": "RD-120",
         "identical_part_name": "RD-120",
-        "module_tags": []
+        "module_tags": [
+            "EngineLiquidTurbo"
+        ]
     },
     {
         "name": "HA3SLRD171",

--- a/Source/Tech Tree/Parts Browser/data/RN_Soviet_Rockets.json
+++ b/Source/Tech Tree/Parts Browser/data/RN_Soviet_Rockets.json
@@ -3499,7 +3499,7 @@
         "description": "RD-120 second stage engine for Zenit-2 rocket. Plume configured by RealPlume.",
         "mod": "RN Soviet Rockets",
         "cost": "750",
-        "entry_cost": "4200",
+        "entry_cost": 3500,
         "category": "STAGED",
         "info": "",
         "year": "1985",
@@ -3510,11 +3510,13 @@
         "orphan": false,
         "rp0_conf": false,
         "spacecraft": "Zenit-2",
-        "engine_config": "",
+        "engine_config": "RD120",
         "upgrade": false,
-        "entry_cost_mods": "",
-        "identical_part_name": "",
-        "module_tags": []
+        "entry_cost_mods": "RD-120",
+        "identical_part_name": "RD-120",
+        "module_tags": [
+            "EngineLiquidTurbo"
+        ]
     },
     {
         "name": "rn_zenit_rd171",
@@ -3546,7 +3548,7 @@
         "title": "Zenit-2 RD-8",
         "description": "RD-8 second stage vernier engine for Zenit-2 rocket. Four of these nozzles make up one RD-8 engine. Plume configured by RealPlume.",
         "mod": "RN Soviet Rockets",
-        "cost": "750",
+        "cost": 0,
         "entry_cost": "4200",
         "category": "STAGED",
         "info": "",
@@ -3562,7 +3564,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "EngineLiquidTurbo"
+        ]
     },
     {
         "name": "rn_zenit_stg1",

--- a/Source/Tech Tree/Parts Browser/data/ROEngines.json
+++ b/Source/Tech Tree/Parts Browser/data/ROEngines.json
@@ -4624,7 +4624,7 @@
         "engine_config": "RD120",
         "upgrade": false,
         "entry_cost_mods": "RD-120",
-        "identical_part_name": "",
+        "identical_part_name": "RD-120",
         "module_tags": [
             "EngineLiquidTurbo"
         ]
@@ -4907,7 +4907,7 @@
         "title": "RD-8",
         "description": "A single-chamber derivative of the RD-8 engine used on the Zenit second stage. Yuzhnoye Design Office concept, featuring dual-axis gimbal control and restart capability for use in upper stages. Diameter: 0.5 m. Plume configured by RealPlume.",
         "mod": "ROEngines",
-        "cost": "1000",
+        "cost": 0,
         "entry_cost": "0",
         "category": "STAGED",
         "info": "",
@@ -4923,30 +4923,9 @@
         "upgrade": false,
         "entry_cost_mods": "RD-8",
         "identical_part_name": "",
-        "module_tags": []
-    },
-    {
-        "name": "ROE-RD8-RE",
-        "title": "RD-8",
-        "description": "A single-chamber derivative of the RD-8 engine used on the Zenit second stage. Yuzhnoye Design Office concept, featuring dual-axis gimbal control and restart capability for use in upper stages. Diameter: 0.5 m. Plume configured by RealPlume.",
-        "mod": "ROEngines",
-        "cost": "1000",
-        "entry_cost": "0",
-        "category": "STAGED",
-        "info": "",
-        "year": "1985",
-        "technology": "stagedCombustion1981",
-        "era": "07-SPCPLANES",
-        "ro": true,
-        "rp0": false,
-        "orphan": false,
-        "rp0_conf": true,
-        "spacecraft": "Zenit",
-        "engine_config": "RD8",
-        "upgrade": false,
-        "entry_cost_mods": "RD-8",
-        "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "EngineLiquidTurbo"
+        ]
     },
     {
         "name": "ROE-RL10A3",

--- a/Source/Tech Tree/Parts Browser/data/RealEngines.json
+++ b/Source/Tech Tree/Parts Browser/data/RealEngines.json
@@ -703,7 +703,7 @@
         "title": "RD-120 Series",
         "description": "The RD-120 is a staged combustion vacuum kerolox engine, used as the main power plant on the Zenit launch vehicle family second stage. Diameter: 2.0 m Plume configured by RealPlume. (PART NOT COSTED BY RP-0 BUT IN CORRECT NODE)",
         "mod": "RealEngines",
-        "cost": "1000",
+        "cost": 750,
         "entry_cost": "3500",
         "category": "STAGED",
         "info": "",
@@ -719,7 +719,9 @@
         "upgrade": false,
         "entry_cost_mods": "RD-120",
         "identical_part_name": "RD-120",
-        "module_tags": []
+        "module_tags": [
+            "EngineLiquidTurbo"
+        ]
     },
     {
         "name": "RO-RealEngines-RD-170",
@@ -851,7 +853,7 @@
         "title": "RD-8",
         "description": "A single-chamber derivative of the RD-8 engine used on the Zenit second stage. Yuzhnoye Design Office concept, featuring dual-axis gimbal control and restart capability for use in upper stages. Diameter: 0.5 m. Plume configured by RealPlume. (PART NOT COSTED BY RP-0 BUT IN CORRECT NODE)",
         "mod": "RealEngines",
-        "cost": "1000",
+        "cost": 0,
         "entry_cost": "3500",
         "category": "STAGED",
         "info": "",
@@ -867,7 +869,9 @@
         "upgrade": false,
         "entry_cost_mods": "RD-8",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "EngineLiquidTurbo"
+        ]
     },
     {
         "name": "RO-RealEngines-RD-805",


### PR DESCRIPTION
- make all RD-8 and RD-120 variants have the same settings (cost, tags,
  ECMs, etc)
- make the RD-8 cost 150 per vernier, instead of a crazy 1000
  (600 on the config, divided by engineTypeMult=0.25)

rd-8 cost isn't based on anything, pure balance. 4x 1000 to give
verniers to a rd-120 that costs 750 is just insane. 4x 150 is probably
still high (esp. with the turbopump tag); didn't want to accidentally
create a new king of small engines

Also removed the dead ROE-RD8-RE config block; that part name lived for all of 1 month