### PR TITLE
Update FSO contract

### DIFF
--- a/GameData/RP-0/Contracts/Milestones/First Science Sat.cfg
+++ b/GameData/RP-0/Contracts/Milestones/First Science Sat.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = Milestones
 	agent = Federation Aeronautique Internationale
 
-	description = Just putting an object in orbit is a stunt. Getting valuable scientific data from it is far more impressive.&br;&br;With the data returned from our sounding rockets, interesting radiation has been observed. We need you to send a scientific satellite into an eccentric orbit in order to study this data with more accuracy. Based on the best guesses of our scientists, having an apoapsis over 1,500 km with a low periapsis will help us to learn more about the radiation surrounding Earth.&br;&br;<b><color="green">Make sure your craft contains a Cosmic Ray Science experiment (Geiger-Muller Counter or Scintillation Counter) as we will need science returned.</color></b>&br;&br;Real life examples: Object D (Sputnik 3), Explorer 1.&br;&br;<b>Please note that when using the Kerbalism mod, this contract does not complete after the intended 120 min. Feel free to use Alt-F12 to complete the contract.</b>&br;&br;<b>Accepting this contract will automatically accept the First Artificial Satellite contract as well.</b>
+	description = Just putting an object in orbit is a stunt. Getting valuable scientific data from it is far more impressive.&br;&br;With the data returned from our sounding rockets, interesting radiation has been observed. We need you to send a scientific satellite into an eccentric orbit in order to study this data with more accuracy. Based on the best guesses of our scientists, having an apoapsis over 1,500 km with a low periapsis will help us to learn more about the radiation surrounding Earth.&br;&br;<b><color="green">Make sure your craft contains a Cosmic Ray Science experiment (Geiger-Muller Counter or Scintillation Counter) as we will need science returned.</color></b>&br;&br;Real life examples: Object D (Sputnik 3), Explorer 1.&br;&br;<b>Accepting this contract will automatically accept the First Artificial Satellite contract as well.</b>
 
 	synopsis = Launch a Scientific Satellite into an eccentric orbit of Earth with Cosmic Ray Science Experiments
 
@@ -78,7 +78,7 @@ CONTRACT_TYPE
 		{
 			name = OrbitSequence
 			type = Sequence
-			title = Survive in orbit for 120 minutes and transmit science
+			title = Survive in orbit for a day and transmit science
 			
 			PARAMETER
 			{
@@ -96,7 +96,7 @@ CONTRACT_TYPE
 					type = HasResource
 					resource = ElectricCharge
 					minQuantity = 1.0
-					title = Craft must have ElectricCharge at the end of the 120 minute orbit
+					title = Craft must have ElectricCharge after one day
 					disableOnStateChange = false
 				}
 				
@@ -105,7 +105,7 @@ CONTRACT_TYPE
 					name = Duration
 					type = Duration
 
-					duration = 120m
+					duration = 1d
 
 					preWaitText = Check for Stable Orbit
 					waitingText = Checking for Stable Orbit


### PR DESCRIPTION
Does 2 things: removes the (at this point obsolete) mention of the need to cheat the contract;
Increases the duration to 1 day, which, as discussed on discord, is a better duration (also coherent with the experiment itself).

Might be best to not merge this until a new ROKerbalism release with this change included