### PR TITLE
Fix Agena A ECMs

### DIFF
--- a/GameData/RP-0/Tree/ECM-Engines.cfg
+++ b/GameData/RP-0/Tree/ECM-Engines.cfg
@@ -228,7 +228,7 @@
     Merlin1D++ = 20000,MerlinDTP
     Merlin1DVac = 23000,MerlinDTP
     Merlin1DVac+ = 30000,MerlinDTP
-    Model117 = Model117
+    Model117 = Model117ECM
     Model8096-39 = 5000, Model8096
     Model8096A = 5000, Model8096-39
     Model8096C = 5000,Model8096A

--- a/GameData/RP-0/Tree/EntryCostModifiers.cfg
+++ b/GameData/RP-0/Tree/EntryCostModifiers.cfg
@@ -83,8 +83,8 @@ ENTRYCOSTMODS
 	AJTitan-LH2-Upgrade = 40000, LR87-LH2-Vacuum
 
 	// Bell
-	Model117 = 5000, Navaho-PhaseIII-TP
-	Model8001 = 5000, Model117 //Identical to Model117 except for added gimbal
+	Model117ECM = 5000, Navaho-PhaseIII-TP
+	Model8001 = 5000, Model117ECM //Identical to Model117 except for added gimbal
 	Model8048 = 5000, Model8001, HydrazineFuel // Expensive because it switched to Hypergolic
 	Model8081 = 10000, Model8048 // Double the burn time
 	Model8096 = 5000, Model8081 // Production Variant

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -4980,7 +4980,7 @@
         "spacecraft": "",
         "engine_config": "Agena",
         "upgrade": false,
-        "entry_cost_mods": "Model117",
+        "entry_cost_mods": "Model117ECM",
         "identical_part_name": "",
         "module_tags": []
     },


### PR DESCRIPTION
Give the ECM a different name than the config. A "x = x" ECM
sends RealFuels into infinite recursion land; there aren't
separate namespaces for engine config names and ECM names