### PR TITLE
Remove Gemini ECM from antennas

### DIFF
--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -541,8 +541,7 @@
     ROC-CSTParachute = capsulesCST
     ROC-CSTRS88 = capsulesCST, NTOOxidizer
     ROC-CSTSM = capsulesCST
-    ROC-GeminiAntenna = 5000,GeminiSM
-    ROC-GeminiAntennaBDB = GeminiSM
+    ROC-GeminiAntenna = 5000
     ROC-GeminiBEquipmentSection = capsulesStation, capsulesGemini
     ROC-GeminiBRetrogradeSection = capsulesStation, capsulesGemini
     ROC-GeminiCM = capsulesGemini

--- a/Source/Tech Tree/Parts Browser/data/ROCapsules.json
+++ b/Source/Tech Tree/Parts Browser/data/ROCapsules.json
@@ -884,7 +884,7 @@
         "spacecraft": "Gemini",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "5000,GeminiSM",
+        "entry_cost_mods": "5000",
         "identical_part_name": "GeminiHGA",
         "module_tags": [
             "Instruments"
@@ -907,7 +907,7 @@
         "spacecraft": "Gemini",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "GeminiSM",
+        "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": []
     },


### PR DESCRIPTION
Antennas are useful on their own and shouldn't involve
paying the unlock cost of the capsule