### PR TITLE
Move ROCapsules Apollo drogue to docking port node

### DIFF
--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -10146,7 +10146,7 @@
 }
 @PART[ROC-ApolloDrogueDockPort]:FOR[xxxRP0]
 {
-    %TechRequired = matureCapsules
+    %TechRequired = dockingCrewTransfer
     %cost = 500
     %entryCost = 0
     RP0conf = true

--- a/Source/Tech Tree/Parts Browser/data/ROCapsules.json
+++ b/Source/Tech Tree/Parts Browser/data/ROCapsules.json
@@ -166,7 +166,7 @@
         "category": "COMMAND",
         "info": "",
         "year": "1968",
-        "technology": "matureCapsules",
+        "technology": "dockingCrewTransfer",
         "era": "05-LUNAR",
         "ro": true,
         "rp0": true,


### PR DESCRIPTION
because the probe is there, and is completely useless
without the drogue