### PR TITLE
New "Add to Plans" button in build list options

### DIFF
--- a/Source/KerbalConstructionTime/GUI/GUI_BuildList.cs
+++ b/Source/KerbalConstructionTime/GUI/GUI_BuildList.cs
@@ -1217,6 +1217,11 @@ namespace KerbalConstructionTime
                 Utilities.AddVesselToBuildList(b.CreateCopy(true));
             }
 
+            if (GUILayout.Button("Add to Plans"))
+            {
+                AddVesselToPlansList(b.CreateCopy(true));
+            }
+
             if (KCTGameStates.ActiveKSC.Recon_Rollout.Find(rr => rr.RRType == ReconRollout.RolloutReconType.Rollout && rr.AssociatedID == b.Id.ToString()) != null && GUILayout.Button("Rollback"))
             {
                 KCTGameStates.ActiveKSC.Recon_Rollout.Find(rr => rr.RRType == ReconRollout.RolloutReconType.Rollout && rr.AssociatedID == b.Id.ToString()).SwapRolloutType();


### PR DESCRIPTION
I usually forget to save new vessels as KCT building plans when I'm in the VAB and only notice it back in the Space Center. Going back to the VAB only to click that button is very annoying (load times...). This adds a new button to the options menu in the KCT build list to do it from the Space Center or from Flight.