### PR TITLE
Gate Mars Station behind Mars Crewed orbit

### DIFF
--- a/GameData/RP-0/Contracts/Space Stations/Martian Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Martian Space Station.cfg
@@ -47,7 +47,7 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = orbitMars
+		contractType = MarsOrbitCrew
 	}
 
 	// ************ PARAMETERS ************


### PR DESCRIPTION
Because it makes no sense for Mars Station to only need an uncrewed Mars orbit, while Crewed Orbit only becomes available after at least 2 crewed moon landings.

There's a lot more that's dubious about the prereqs for crewed Mars missions, but this one seems like a no-brainer. Was presumably just copied from Moon Station without any real intent