### PR TITLE
Set ResourceAbundance=1 for all difficulties

### DIFF
--- a/GameData/RP-0/GameParameters.cfg
+++ b/GameData/RP-0/GameParameters.cfg
@@ -10,7 +10,7 @@ GAMEPARAMETERS
 			BypassEntryPurchaseAfterResearch = False
 			AllowStockVessels = False
 			IndestructibleFacilities = True
-			ResourceAbundance = 1.2
+			ResourceAbundance = 1
 			ReentryHeatScale = 1.0
 			EnableCommNet = False
 		}
@@ -128,7 +128,7 @@ GAMEPARAMETERS
 			BypassEntryPurchaseAfterResearch = False
 			AllowStockVessels = False
 			IndestructibleFacilities = False
-			ResourceAbundance = 0.8
+			ResourceAbundance = 1
 			ReentryHeatScale = 1
 			EnableCommNet = True
 		}
@@ -187,7 +187,7 @@ GAMEPARAMETERS
 			BypassEntryPurchaseAfterResearch = False
 			AllowStockVessels = False
 			IndestructibleFacilities = False
-			ResourceAbundance = 0.5
+			ResourceAbundance = 1
 			ReentryHeatScale = 1
 			EnableCommNet = True
 		}


### PR DESCRIPTION
RO shouldn't do difficulty levels by changing physical properties.
For example, Mars 96% atmospheric CO2 shouldn't become something else
(especially not > 100%)