### PR TITLE
Add KCT related config files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ GameData/RP-0/Tree.cfg
 Notes/Engine Stats\.xlsx
 
 Notes/Contracts/CBmultipliersAndPayoutsCalculator\.xlsx
+GameData/RP-0/PluginData/KCT_Windows.txt
+GameData/RP-0/PluginData/KCT_Config.txt


### PR DESCRIPTION
When using a symlinked repo in your KSP install, these files get added. Since they don't add anything useful to the GitHub repo, they can be ignored.