### PR TITLE
Add Nuclear tag to NFE reactors

### DIFF
--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -27925,6 +27925,10 @@
     %entryCost = 35500
     RP0conf = false
     @description ^=:$: <b><color=green>From Near Future Electrical mod</color></b>
+
+    MODULE
+    { name = ModuleTagNuclear }
+
 }
 @PART[reactor-125]:FOR[xxxRP0]
 {
@@ -27933,6 +27937,10 @@
     %entryCost = 275000
     RP0conf = false
     @description ^=:$: <b><color=green>From Near Future Electrical mod</color></b>
+
+    MODULE
+    { name = ModuleTagNuclear }
+
 }
 @PART[reactor-25]:FOR[xxxRP0]
 {
@@ -27941,6 +27949,10 @@
     %entryCost = 1400000
     RP0conf = false
     @description ^=:$: <b><color=green>From Near Future Electrical mod</color></b>
+
+    MODULE
+    { name = ModuleTagNuclear }
+
 }
 @PART[reactor-25-2]:FOR[xxxRP0]
 {
@@ -27949,6 +27961,10 @@
     %entryCost = 1950000
     RP0conf = false
     @description ^=:$: <b><color=green>From Near Future Electrical mod</color></b>
+
+    MODULE
+    { name = ModuleTagNuclear }
+
 }
 @PART[restock-adapter-hollow-25-375-1]:FOR[xxxRP0]
 {

--- a/Source/Tech Tree/Parts Browser/data/Near_Future_Electrical.json
+++ b/Source/Tech Tree/Parts Browser/data/Near_Future_Electrical.json
@@ -112,7 +112,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Nuclear"
+        ]
     },
     {
         "name": "reactor-125",
@@ -135,7 +137,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Nuclear"
+        ]
     },
     {
         "name": "reactor-25",
@@ -158,7 +162,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Nuclear"
+        ]
     },
     {
         "name": "reactor-25-2",
@@ -181,7 +187,9 @@
         "upgrade": false,
         "entry_cost_mods": "",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "Nuclear"
+        ]
     },
     {
         "name": "rtg-0625",


### PR DESCRIPTION
They're nocost, and the topazII is practically free, but this
will at least give it some bite.