### PR TITLE
Gate Mars Station behind Mars Crewed orbit

### DIFF
--- a/GameData/RP-0/Contracts/Space Stations/Martian Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Martian Space Station.cfg
@@ -47,7 +47,7 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = orbitMars
+		contractType = MarsOrbitCrew
 	}
 
 	// ************ PARAMETERS ************


### PR DESCRIPTION
Mostly because getting offered Mars Station before moon
station doesn't make a lot of sense. A different prereq
may make even more sense, but this is at least more consistent.