### PR TITLE
Fix unlocking experimental parts creates a new vessel in edit mode

### DIFF
--- a/Source/KerbalConstructionTime/GUI/GUI_Editor.cs
+++ b/Source/KerbalConstructionTime/GUI/GUI_Editor.cs
@@ -120,9 +120,9 @@ namespace KerbalConstructionTime
                 ship.IntegrationPoints = MathParser.ParseIntegrationTimeFormula(ship);
             }
 
-            double newProgress = Utilities.GetShipProgress(ship, out double origBP, out double buildTime, out double difference, out double progress);
-            GUILayout.Label($"Original: {Math.Max(0, Math.Round(100 * (progress / origBP), 2))}%");
-            GUILayout.Label($"Edited: {Math.Round(100 * newProgress / buildTime, 2)}%");
+            Utilities.GetShipEditProgress(ship, out double newProgressBP, out double originalCompletionPercent, out double newCompletionPercent);
+            GUILayout.Label($"Original: {Math.Max(0, Math.Round(100 * originalCompletionPercent, 2))}%");
+            GUILayout.Label($"Edited: {Math.Round(100 * newCompletionPercent, 2)}%");
 
             BuildListVessel.ListType type = EditorLogic.fetch.launchSiteName == "LaunchPad" ? BuildListVessel.ListType.VAB : BuildListVessel.ListType.SPH;
             GUILayout.BeginHorizontal();
@@ -142,7 +142,7 @@ namespace KerbalConstructionTime
                     BuildRateForDisplay = bR.ToString();
                 }
                 GUILayout.EndHorizontal();
-                GUILayout.Label(MagiCore.Utilities.GetFormattedTime(Math.Abs(buildTime - newProgress) / bR));
+                GUILayout.Label(MagiCore.Utilities.GetFormattedTime(Math.Abs(KCTGameStates.EditorBuildTime + KCTGameStates.EditorIntegrationTime - newProgressBP) / bR));
             }
             else
             {

--- a/Source/KerbalConstructionTime/GUI/GUI_Editor.cs
+++ b/Source/KerbalConstructionTime/GUI/GUI_Editor.cs
@@ -120,12 +120,7 @@ namespace KerbalConstructionTime
                 ship.IntegrationPoints = MathParser.ParseIntegrationTimeFormula(ship);
             }
 
-            double origBP = (ship.IsFinished ? -1 : ship.BuildPoints) + ship.IntegrationPoints;
-            double buildTime = KCTGameStates.EditorBuildTime + KCTGameStates.EditorIntegrationTime;
-            double difference = Math.Abs(buildTime - origBP);
-            double progress = ship.IsFinished ? origBP : ship.Progress;
-            double newProgress = Math.Max(0, progress - (1.1 * difference));
-
+            double newProgress = Utilities.GetShipProgress(ship, out double origBP, out double buildTime, out double difference, out double progress);
             GUILayout.Label($"Original: {Math.Max(0, Math.Round(100 * (progress / origBP), 2))}%");
             GUILayout.Label($"Edited: {Math.Round(100 * newProgress / buildTime, 2)}%");
 

--- a/Source/KerbalConstructionTime/Utilities/Utilities.cs
+++ b/Source/KerbalConstructionTime/Utilities/Utilities.cs
@@ -895,12 +895,18 @@ namespace KerbalConstructionTime
                     var unlockableParts = devParts.Keys.Where(p => ResearchAndDevelopment.GetTechnologyState(p.TechRequired) == RDTech.State.Available).ToList();
                     int n = unlockableParts.Count();
                     int unlockCost = FindUnlockCost(unlockableParts);
-                    string mode = KCTGameStates.EditorShipEditingMode ? "Edit" : "Build";
+                    string mode = KCTGameStates.EditorShipEditingMode ? "save edits" : "build vessel";
                     if (unlockableParts.Any())
                     {
                         buttons = new DialogGUIButton[] {
                             new DialogGUIButton("Acknowledged", () => { }),
-                            new DialogGUIButton($"Unlock {n} part{(n > 1? "s":"")} for {unlockCost} Fund{(unlockCost > 1? "s":"")} and {mode}", () => { UnlockExperimentalParts(unlockableParts); if (!KCTGameStates.EditorShipEditingMode) AddVesselToBuildList(blv); else EditShip(KCTGameStates.EditedVessel); })
+                            new DialogGUIButton($"Unlock {n} part{(n > 1? "s":"")} for {unlockCost} Fund{(unlockCost > 1? "s":"")} and {mode}", () => 
+                            { 
+                                UnlockExperimentalParts(unlockableParts);
+                                if (!KCTGameStates.EditorShipEditingMode)
+                                    AddVesselToBuildList(blv); 
+                                else EditShip(KCTGameStates.EditedVessel); 
+                            })
                         };
                     }
                     else

--- a/Source/KerbalConstructionTime/Utilities/Utilities.cs
+++ b/Source/KerbalConstructionTime/Utilities/Utilities.cs
@@ -967,17 +967,18 @@ namespace KerbalConstructionTime
 
         public static void EditShip(BuildListVessel ship)
         {
-            Utilities.AddFunds(ship.GetTotalCost(), TransactionReasons.VesselRollout);
-            BuildListVessel newShip = Utilities.AddVesselToBuildList();
+            AddFunds(ship.GetTotalCost(), TransactionReasons.VesselRollout);
+            BuildListVessel newShip = AddVesselToBuildList();
             if (newShip == null)
             {
-                Utilities.SpendFunds(ship.GetTotalCost(), TransactionReasons.VesselRollout);
+                SpendFunds(ship.GetTotalCost(), TransactionReasons.VesselRollout);
                 return;
             }
 
             ship.RemoveFromBuildList();
 
-            newShip.Progress = GetShipProgress(ship, out _, out _, out _, out _);
+            GetShipEditProgress(ship, out double progressBP, out _, out _);
+            newShip.Progress = progressBP;
             newShip.RushBuildClicks = ship.RushBuildClicks;
             KCTDebug.Log($"Finished? {ship.IsFinished}");
             if (ship.IsFinished)
@@ -1011,14 +1012,15 @@ namespace KerbalConstructionTime
             return protoTechNodes;
         }
 
-        public static double GetShipProgress(BuildListVessel ship, out double origBP, out double buildTime, out double difference, out double progress)
+        public static void GetShipEditProgress(BuildListVessel ship, out double newProgressBP, out double originalCompletionPercent, out double newCompletionPercent)
         {
-            origBP = (ship.IsFinished ? -1 : ship.BuildPoints) + ship.IntegrationPoints;
-            buildTime = KCTGameStates.EditorBuildTime + KCTGameStates.EditorIntegrationTime;
-            difference = Math.Abs(buildTime - origBP);
-            progress = ship.IsFinished ? origBP : ship.Progress;
-            double newProgress = Math.Max(0, progress - (1.1 * difference));
-            return newProgress;
+            double origTotalBP = ship.BuildPoints + ship.IntegrationPoints;
+            double newTotalBP = KCTGameStates.EditorBuildTime + KCTGameStates.EditorIntegrationTime;
+            double totalBPDiff = Math.Abs(newTotalBP - origTotalBP);
+            double oldProgressBP = ship.IsFinished ? origTotalBP : ship.Progress;
+            newProgressBP = Math.Max(0, oldProgressBP - (1.1 * totalBPDiff));
+            originalCompletionPercent = oldProgressBP / origTotalBP;
+            newCompletionPercent = newProgressBP / newTotalBP;
         }
 
         public static int FindUnlockCost(List<AvailablePart> availableParts)

--- a/Source/KerbalConstructionTime/Utilities/Utilities.cs
+++ b/Source/KerbalConstructionTime/Utilities/Utilities.cs
@@ -977,12 +977,7 @@ namespace KerbalConstructionTime
 
             ship.RemoveFromBuildList();
 
-            double origBP = (ship.IsFinished ? -1 : ship.BuildPoints) + ship.IntegrationPoints;
-            double buildTime = KCTGameStates.EditorBuildTime + KCTGameStates.EditorIntegrationTime;
-            double difference = Math.Abs(buildTime - origBP);
-            double progress = ship.IsFinished ? origBP : ship.Progress;
-
-            newShip.Progress = Math.Max(0, progress - (1.1 * difference));
+            newShip.Progress = GetShipProgress(ship, out _, out _, out _, out _);
             newShip.RushBuildClicks = ship.RushBuildClicks;
             KCTDebug.Log($"Finished? {ship.IsFinished}");
             if (ship.IsFinished)
@@ -1014,6 +1009,16 @@ namespace KerbalConstructionTime
             }
 
             return protoTechNodes;
+        }
+
+        public static double GetShipProgress(BuildListVessel ship, out double origBP, out double buildTime, out double difference, out double progress)
+        {
+            origBP = (ship.IsFinished ? -1 : ship.BuildPoints) + ship.IntegrationPoints;
+            buildTime = KCTGameStates.EditorBuildTime + KCTGameStates.EditorIntegrationTime;
+            difference = Math.Abs(buildTime - origBP);
+            progress = ship.IsFinished ? origBP : ship.Progress;
+            double newProgress = Math.Max(0, progress - (1.1 * difference));
+            return newProgress;
         }
 
         public static int FindUnlockCost(List<AvailablePart> availableParts)


### PR DESCRIPTION
Currently, when editing ships with KCT and the prompt shows to unlock all experimental parts it will create a new entry in the build list

Fixes #1395

### Changes
* When prompt shows to unlock experimental parts, only add vessel to build list if `EditorShipEditingMode` is false, else edit the current ship
* Move KCT *"Save Edit"* to a method, so it can be called from everywhere not only the IMGUI button
* Plural/Singular switching: Fund**s** (the same thing that already existed for part**s**)