### PR TITLE
Fix hiring Hero kerbals after they would have retired.

### DIFF
--- a/Source/Crew/CrewHandler.cs
+++ b/Source/Crew/CrewHandler.cs
@@ -692,6 +692,7 @@ namespace RP0.Crew
                             _toRemove.Add(kvp.Key);
                             _retirees.Add(kvp.Key);
                             pcm.rosterStatus = ProtoCrewMember.RosterStatus.Dead;
+                            pcm.type = ProtoCrewMember.KerbalType.Crew;
                         }
                     }
                 }

--- a/Source/Crew/CrewHandler.cs
+++ b/Source/Crew/CrewHandler.cs
@@ -580,17 +580,16 @@ namespace RP0.Crew
 
         private void OnCrewHired(ProtoCrewMember pcm, int idx)
         {
-            double currentTime = Planetarium.GetUniversalTime();
             double retireTime;
-            // Skip updating the retirement time if this is an existing kerbal who has not yet retired.
-            if (KerbalRetireTimes.ContainsKey(pcm.name) == false || KerbalRetireTimes[pcm.name] < currentTime)
-            {
-                retireTime = currentTime + GetServiceTime(pcm);
-                KerbalRetireTimes[pcm.name] = retireTime;
-            }
-            else
+            // Skip updating the retirement time if this is an existing kerbal.
+            if (KerbalRetireTimes.ContainsKey(pcm.name))
             {
                 retireTime = KerbalRetireTimes[pcm.name];
+            }
+            else
+            { 
+                retireTime = Planetarium.GetUniversalTime() + GetServiceTime(pcm);
+                KerbalRetireTimes[pcm.name] = retireTime;
             }
 
             if (RetirementEnabled && idx != int.MinValue)

--- a/Source/Crew/CrewHandler.cs
+++ b/Source/Crew/CrewHandler.cs
@@ -580,8 +580,18 @@ namespace RP0.Crew
 
         private void OnCrewHired(ProtoCrewMember pcm, int idx)
         {
-            double retireTime = Planetarium.GetUniversalTime() + GetServiceTime(pcm);
-            KerbalRetireTimes[pcm.name] = retireTime;
+            double currentTime = Planetarium.GetUniversalTime();
+            double retireTime;
+            // Skip updating the retirement time if this is an existing kerbal who has not yet retired.
+            if (KerbalRetireTimes.ContainsKey(pcm.name) == false || KerbalRetireTimes[pcm.name] < currentTime)
+            {
+                retireTime = currentTime + GetServiceTime(pcm);
+                KerbalRetireTimes[pcm.name] = retireTime;
+            }
+            else
+            {
+                retireTime = KerbalRetireTimes[pcm.name];
+            }
 
             if (RetirementEnabled && idx != int.MinValue)
             {


### PR DESCRIPTION
KSP 1.10 introduced a change which causes the hero kerbals to return to the applicant list when fired. If they are then re-hired after their retirement date, they immediately retire.

In order to prevent re-hiring once they've retired, we can force kerbals to become "crew" when their retirement date hits. This will properly move them out of the applicant pool and into the "lost" list.

Additionally, only update retirement date if  a kerbal is brand new, or past its retirement date (which would be a duplicate name). This prevents firing a hero kerbal and re-hiring it to push back the retirement date.

Fixes #1409 