### PR TITLE
Moved kOS ProcAvionics config to later pass

### DIFF
--- a/GameData/RP-0/Tree/ProceduralAvionics.cfg
+++ b/GameData/RP-0/Tree/ProceduralAvionics.cfg
@@ -808,7 +808,7 @@ AVIONICSCONFIGS
 
 // kOS processor tech level scaling
 // Note that numbers here are the base storage, rocket designers may add 2x or 4x as much for additional cost in the VAB.
-@PART[*]:HAS[@MODULE[ModuleProceduralAvionics]]:NEEDS[kOS]:AFTER[ProceduralParts]
+@PART[*]:HAS[@MODULE[ModuleProceduralAvionics]]:NEEDS[kOS]:AFTER[RP-0]
 {
 	MODULE
 	{


### PR DESCRIPTION
It seems ProceduralAvionics don't get their module patched in until `[RP-0]` now, so moving this back.