### PR TITLE
Replace parent nodes for Improved RTGs

### DIFF
--- a/GameData/RP-0/Tree/RP0TechTree.cfg
+++ b/GameData/RP-0/Tree/RP0TechTree.cfg
@@ -4923,7 +4923,7 @@
 		scale = 0.6
 		Parent
 		{
-			parentID = earlyRTG
+			parentID = nuclearFissionReactors
 			lineFrom = RIGHT
 			lineTo = LEFT
 		}


### PR DESCRIPTION
Previously you could skip Small Nuclear Fusion Reactors for Improved RTGs.
![image](https://user-images.githubusercontent.com/26103772/111009340-2ebdb280-8348-11eb-9ba9-8010af0fea88.png)
