### PR TITLE
Fix First Rendezvous Contract

### DIFF
--- a/GameData/RP-0/Contracts/Milestones/Rendezvous.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Rendezvous.cfg
@@ -115,6 +115,7 @@ CONTRACT_TYPE
 			type = Rendezvous
 			distance = 100
 			vessel = RendezvousTgt // To prevent unintentional rendezvous with other debris or "probes"
+			title = Rendezvous with the Target Vessel
 			hideChildren = true
 			disableOnStateChange = true
 		}

--- a/GameData/RP-0/Contracts/Milestones/Rendezvous.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Rendezvous.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = Milestones
 	agent = Federation Aeronautique Internationale
 
-	description = The first successful rendezvous between two spacecraft was when Gemini 6 and 7 met in 1965. Wally Schirra maneuvered Gemini 6 to within 30cm of Gemini 7, close enough and precise enough to prove that docking two craft together in space was possible. Using your own knowledge of orbital mechanics bring two craft to within 100 meters of each other while in orbit around Earth. At least one of the spacecraft must be a new launch so make sure you have time to build and launch both the target and rendezvous craft before the deadline.
+	description = The first successful rendezvous between two spacecraft was when Gemini 6 and 7 met in 1965. Wally Schirra maneuvered Gemini 6 to within 30cm of Gemini 7, close enough and precise enough to prove that docking two craft together in space was possible. Using your own knowledge of orbital mechanics bring two craft to within 100 meters of each other while in orbit around Earth. Both of the spacecraft must be a new launch so make sure you have time to build and launch both the target and rendezvous craft before the deadline.
 
 	synopsis = Perform the First Rendezvous of two craft in space
 
@@ -45,11 +45,45 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
+		name = TargetVessel
+		type = VesselParameterGroup
+		title = Launch the Target Vessel
+		define = RendezvousTgt
+
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = HasCrew
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+			title = Uncrewed
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = @targetBody.AtmosphereAltitude()
+			title = Orbit @targetBody
+			disableOnStateChange = true
+			hideChildren = true
+		}
+	}
+	
+	PARAMETER
+	{
 		name = Rendezvous
 		type = VesselParameterGroup
-		title = First Rendezvous
-		define = Rendezvous
-
+		title = Rendezvous with the Target Vessel
+		define = RendezvousCrew
+		
 		PARAMETER
 		{
 			name = NewVessel
@@ -80,7 +114,7 @@ CONTRACT_TYPE
 			name = Rendezvous
 			type = Rendezvous
 			distance = 100
-			title = Rendezvous two craft in Orbit
+			vessel = RendezvousTgt // To prevent unintentional rendezvous with other debris or "probes"
 			hideChildren = true
 			disableOnStateChange = true
 		}

--- a/GameData/RP-0/Contracts/Milestones/Rendezvous.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Rendezvous.cfg
@@ -1,11 +1,103 @@
 CONTRACT_TYPE
 {
+	name = RendezvousTarget
+	title = First Rendezvous Target
+	group = Milestones
+	agent = Federation Aeronautique Internationale
+	
+	description = The first successful rendezvous between two spacecraft was when Gemini 6 and 7 met in 1965. Wally Schirra maneuvered Gemini 6 to within 30cm of Gemini 7, close enough and precise enough to prove that docking two craft together in space was possible. Using your own knowledge of orbital mechanics bring two craft to within 100 meters of each other while in orbit around Earth. Both of the spacecraft must be a new launch so make sure you have time to build and launch both the target and rendezvous craft before the deadline. <b>NOTE: This contract serves the purpose of launching a Rendezvous Target, and has no advance, reward, nor reputation.</b>
+
+	synopsis = Launch a Rendezvous Target into space.
+	
+	completedMessage = Good job! The First Rendezvous Contract is now available.
+	
+	sortKey = 104
+
+	cancellable = false
+	declinable = false
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 0 // unlimited
+	maxSimultaneous = 1
+	deadline = 365 * RP1DeadlineMult()  // 1 year
+	
+	targetBody = HomeWorld()
+	
+	// ************ REWARDS ************
+	prestige = Trivial   // 1x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardReputation = 0
+	rewardFunds = 0
+	failureReputation = 0
+	failureFunds = 0
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = first_OrbitCrewed
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = Rendezvous
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = Rendezvous
+		invertRequirement = true
+	}
+	
+	PARAMETER
+	{
+		name = TargetVessel
+		type = VesselParameterGroup
+		title = Launch the Target Vessel
+		define = RendezvousTgt
+
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = HasCrew
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 99
+			title = Can be Uncrewed or Crewed
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = @targetBody.AtmosphereAltitude()
+			title = Orbit @targetBody
+			disableOnStateChange = true
+			hideChildren = true
+		}
+	}
+	
+}
+
+CONTRACT_TYPE
+{
 	name = Rendezvous
 	title = First Rendezvous
 	group = Milestones
 	agent = Federation Aeronautique Internationale
 
-	description = The first successful rendezvous between two spacecraft was when Gemini 6 and 7 met in 1965. Wally Schirra maneuvered Gemini 6 to within 30cm of Gemini 7, close enough and precise enough to prove that docking two craft together in space was possible. Using your own knowledge of orbital mechanics bring two craft to within 100 meters of each other while in orbit around Earth. Both of the spacecraft must be a new launch so make sure you have time to build and launch both the target and rendezvous craft before the deadline.
+	description = The first successful rendezvous between two spacecraft was when Gemini 6 and 7 met in 1965. Wally Schirra maneuvered Gemini 6 to within 30cm of Gemini 7, close enough and precise enough to prove that docking two craft together in space was possible. Using your own knowledge of orbital mechanics bring two craft to within 100 meters of each other while in orbit around Earth. Both of the spacecraft must be a new launch so make sure you have time to build and launch both the target and rendezvous craft before the deadline. <b>NOTE: This contract is the one where you rendezvous with the target. If the target vessel is lost, this contract will immediately fail.</b>
 
 	synopsis = Perform the First Rendezvous of two craft in space
 
@@ -40,41 +132,20 @@ CONTRACT_TYPE
 	{
 		name = CompleteContract
 		type = CompleteContract
-		contractType = first_OrbitCrewed
+		contractType = RendezvousTarget
 	}
-
-	PARAMETER
+	REQUIREMENT
 	{
-		name = TargetVessel
-		type = VesselParameterGroup
-		title = Launch the Target Vessel
-		define = RendezvousTgt
-
-		PARAMETER
-		{
-			name = NewVessel
-			type = NewVessel
-			title = Launch a New Vessel
-			hideChildren = true
-		}
-		PARAMETER
-		{
-			name = HasCrew
-			type = HasCrew
-			minCrew = 0
-			maxCrew = 0
-			title = Uncrewed
-			hideChildren = true
-		}
-		PARAMETER
-		{
-			name = Orbit
-			type = Orbit
-			minPeA = @targetBody.AtmosphereAltitude()
-			title = Orbit @targetBody
-			disableOnStateChange = true
-			hideChildren = true
-		}
+		name = AcceptContract
+		type = AcceptContract
+		contractType = Rendezvous
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = ValidVessel
+		type = ValidVessel
+		vessel = RendezvousTgt
 	}
 	
 	PARAMETER


### PR DESCRIPTION
Previously, you could rendezvous with a spent stage which would satisfy the Rendezvous contract parameter. Fixed by adding a VesselParameterGroup that creates a specific vessel to rendezvous with, rather than rendezvousing with any object in space.