### PR TITLE
Add config for restockplus Viking

### DIFF
--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -426,6 +426,7 @@
     RO-NIMS = 2500,RO-UVSpectrometer
     RO-PMIRR = 2500,RO-TwoChannelIR
     RO-QuadropoleMassSpectrometer = 2500, RO-MIMS
+    RO-RD-0105 = RD-0105
     RO-RD-0124 = RD-0124
     RO-RD-0210 = RD-0210
     RO-RD-253 = RD-253
@@ -1313,7 +1314,6 @@
     liquidEngine1-2 = S-3
     liquidEngine2 = S1-5400
     liquidEngine2-2 = LMDE-H
-    liquidEngine3-v2 = RD-0105
     liquidEngineMiniRescale = Aestus-II
     liquidEngineMiniTurbo = 0, BE-4
     liquidEngineMini-v2 = LMAE
@@ -1361,6 +1361,7 @@
     reactor-125 = 75000, RO-reactor-TOPAZI
     restock-decoupler-radial-tiny-1 = 1
     restock-engine-125-pug = Aestus
+    restock-engine-125-valiant = Viking-2
     restock-engine-375-corgi = 10000,RL10C-1
     restock-engine-boar = F-1B
     restock-engine-torch = H-1-165K

--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -9060,6 +9060,18 @@
     { name = ModuleTagInstruments }
 
 }
+@PART[RO-RD-0105]:FOR[xxxRP0]
+{
+    %TechRequired = orbitalRocketry1958
+    %cost = 250
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From Stock (RO Config) mod</color></b>
+
+    MODULE
+    { name = ModuleTagEngineLiquidTurbo }
+
+}
 @PART[RO-RD-0124]:FOR[xxxRP0]
 {
     %TechRequired = stagedCombustion2004
@@ -26698,18 +26710,6 @@
     { name = ModuleTagEngineLiquidPF }
 
 }
-@PART[liquidEngine3_v2]:FOR[xxxRP0]
-{
-    %TechRequired = orbitalRocketry1958
-    %cost = 250
-    %entryCost = 0
-    RP0conf = true
-    @description ^=:$: <b><color=green>From Stock (RO Config) mod</color></b>
-
-    MODULE
-    { name = ModuleTagEngineLiquidTurbo }
-
-}
 @PART[liquidEngineMiniRescale]:FOR[xxxRP0]
 {
     %TechRequired = orbitalRocketry2014
@@ -28519,6 +28519,20 @@
     %TechRequired = orbitalRocketry1992
     %cost = 550
     %entryCost = 11000
+    RP0conf = true
+    @description ^=:$: <b><color=green>From ReStock Plus mod</color></b>
+
+    MODULE
+    { name = ModuleTagEngineLiquidTurbo }
+    MODULE
+    { name = ModuleTagToxic }
+
+}
+@PART[restock-engine-125-valiant]:FOR[xxxRP0]
+{
+    %TechRequired = orbitalRocketry1959
+    %cost = 300
+    %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From ReStock Plus mod</color></b>
 

--- a/GameData/RP-0/Tree/identicalParts.cfg
+++ b/GameData/RP-0/Tree/identicalParts.cfg
@@ -515,10 +515,10 @@
 @PART[ROE-R40B]:FOR[xxxRP0] { %identicalParts = ROE-R40B,ROE-R40B-NicheParts,R_40B_4kN,ca_lahar }
 @PART[ROE-R40B-NicheParts]:FOR[xxxRP0] { %identicalParts = ROE-R40B,ROE-R40B-NicheParts,R_40B_4kN,ca_lahar }
 @PART[bluedog_rangerCore]:FOR[xxxRP0] { %identicalParts = bluedog_rangerCore }
-@PART[liquidEngine3_v2]:FOR[xxxRP0] { %identicalParts = RO-RealEngines-RD-0105,ROE-RD0105,ROE-RD0105-RE,liquidEngine3_v2 }
-@PART[RO-RealEngines-RD-0105]:FOR[xxxRP0] { %identicalParts = RO-RealEngines-RD-0105,ROE-RD0105,ROE-RD0105-RE,liquidEngine3_v2 }
-@PART[ROE-RD0105]:FOR[xxxRP0] { %identicalParts = RO-RealEngines-RD-0105,ROE-RD0105,ROE-RD0105-RE,liquidEngine3_v2 }
-@PART[ROE-RD0105-RE]:FOR[xxxRP0] { %identicalParts = RO-RealEngines-RD-0105,ROE-RD0105,ROE-RD0105-RE,liquidEngine3_v2 }
+@PART[RO-RD-0105]:FOR[xxxRP0] { %identicalParts = RO-RD-0105,RO-RealEngines-RD-0105,ROE-RD0105,ROE-RD0105-RE }
+@PART[RO-RealEngines-RD-0105]:FOR[xxxRP0] { %identicalParts = RO-RD-0105,RO-RealEngines-RD-0105,ROE-RD0105,ROE-RD0105-RE }
+@PART[ROE-RD0105]:FOR[xxxRP0] { %identicalParts = RO-RD-0105,RO-RealEngines-RD-0105,ROE-RD0105,ROE-RD0105-RE }
+@PART[ROE-RD0105-RE]:FOR[xxxRP0] { %identicalParts = RO-RD-0105,RO-RealEngines-RD-0105,ROE-RD0105,ROE-RD0105-RE }
 @PART[RD_0110]:FOR[xxxRP0] { %identicalParts = RD_0110,RO-BobCat-RD0110,RO-RealEngines-RD-0110,ROE-RD0110,ROE-RD0110-SSTU,SSTU-SC-ENG-RD-0110 }
 @PART[RO-BobCat-RD0110]:FOR[xxxRP0] { %identicalParts = RD_0110,RO-BobCat-RD0110,RO-RealEngines-RD-0110,ROE-RD0110,ROE-RD0110-SSTU,SSTU-SC-ENG-RD-0110 }
 @PART[RO-RealEngines-RD-0110]:FOR[xxxRP0] { %identicalParts = RD_0110,RO-BobCat-RD0110,RO-RealEngines-RD-0110,ROE-RD0110,ROE-RD0110-SSTU,SSTU-SC-ENG-RD-0110 }

--- a/Source/Tech Tree/Parts Browser/data/ReStock_Plus.json
+++ b/Source/Tech Tree/Parts Browser/data/ReStock_Plus.json
@@ -443,6 +443,30 @@
         ]
     },
     {
+        "name": "restock-engine-125-valiant",
+        "title": "Viking Series engine",
+        "description": "",
+        "mod": "ReStock Plus",
+        "cost": 300,
+        "entry_cost": 0,
+        "category": "ORBITAL",
+        "info": "",
+        "year": "1959",
+        "technology": "orbitalRocketry1959",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "Ariane",
+        "engine_config": "Viking",
+        "upgrade": false,
+        "entry_cost_mods": "Viking-2",
+        "identical_part_name": "",
+        "module_tags": [
+            "EngineLiquidTurbo",
+            "Toxic"
+        ]
+    },
+    {
         "name": "restock-engine-375-corgi",
         "title": "Exploration Upper Stage Engines",
         "description": "",

--- a/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
@@ -1714,6 +1714,31 @@
         ]
     },
     {
+        "name": "RO-RD-0105",
+        "title": "RD-0105/0109 Series",
+        "description": "Kerolox gas generator vacuum engine which served in R-7 upper stages (Luna, Vostok). The RD-0105 was designed for Luna launches; it was the first upper stage for the R-7 series and was reused for uncrewed Vostok tests. An enhanced version, the RD-0109, was used for crewed Vostok launches. Diameter: [2.56 m]. Plume configured by RealPlume.",
+        "mod": "Stock (RO Config)",
+        "cost": "250",
+        "entry_cost": "0",
+        "category": "ORBITAL",
+        "info": "",
+        "year": "1958",
+        "technology": "orbitalRocketry1958",
+        "era": "02-SAT",
+        "ro": true,
+        "rp0": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "Luna, Vostok",
+        "engine_config": "RD0105",
+        "upgrade": false,
+        "entry_cost_mods": "RD-0105",
+        "identical_part_name": "RD-0105",
+        "module_tags": [
+            "EngineLiquidTurbo"
+        ]
+    },
+    {
         "name": "RO-RD-0210",
         "title": "RD-0210/0211",
         "description": "A staged combustion, hypergolic vacuum rocket engine. Used as a power plant on the second stage of the Proton launch vehicle family. Features a two-axis gimbal mechanism for attitude control. Diameter: 1.47 m. Plume configured by RealPlume.",
@@ -4545,31 +4570,6 @@
         "identical_part_name": "Apollo LMDE",
         "module_tags": [
             "EngineLiquidPF"
-        ]
-    },
-    {
-        "name": "liquidEngine3_v2",
-        "title": "RD-0105/0109 Series",
-        "description": "Kerolox gas generator vacuum engine which served in R-7 upper stages (Luna, Vostok). The RD-0105 was designed for Luna launches; it was the first upper stage for the R-7 series and was reused for uncrewed Vostok tests. An enhanced version, the RD-0109, was used for crewed Vostok launches. Diameter: [2.56 m]. Plume configured by RealPlume.",
-        "mod": "Stock (RO Config)",
-        "cost": "250",
-        "entry_cost": "0",
-        "category": "ORBITAL",
-        "info": "",
-        "year": "1958",
-        "technology": "orbitalRocketry1958",
-        "era": "02-SAT",
-        "ro": true,
-        "rp0": true,
-        "orphan": false,
-        "rp0_conf": true,
-        "spacecraft": "Luna, Vostok",
-        "engine_config": "RD0105",
-        "upgrade": false,
-        "entry_cost_mods": "RD-0105",
-        "identical_part_name": "RD-0105",
-        "module_tags": [
-            "EngineLiquidTurbo"
         ]
     },
     {


### PR DESCRIPTION
Part was configured in RO a long time ago, and apparently forgotten.

https://github.com/KSP-RO/RealismOverhaul/blob/fe5f66506ed60e27db78b62cec2894e1f95f5310/GameData/RealismOverhaul/RO_SuggestedMods/RestockPlus/RO_RestockPlus_Engine_Part_Config.cfg#L78-L83

Also fixed: the stock-engine-as-rd-0105 part got switched from using
liquidEngine3_v2 directly to using a clone of it recently, but
rp-0 wasn't updated to match.

https://github.com/KSP-RO/RealismOverhaul/blob/991ba498d8d15d09b886eb43e28b0e49223105aa/GameData/RealismOverhaul/RO_SuggestedMods/Squad/RO_Squad_Engines.cfg#L24