### PR TITLE
Minor experimental parts fixes

### DIFF
--- a/Source/KerbalConstructionTime/KCTEvents.cs
+++ b/Source/KerbalConstructionTime/KCTEvents.cs
@@ -272,12 +272,6 @@ namespace KerbalConstructionTime
                         double timeLeft = tech.BuildRate > 0 ? tech.TimeLeft : tech.EstimatedTimeLeft;
                         ScreenMessages.PostScreenMessage($"[KCT] Node will unlock in {MagiCore.Utilities.GetFormattedTime(timeLeft)}", 4f, ScreenMessageStyle.UPPER_LEFT);
 
-                        foreach (AvailablePart ap in ev.host.partsAssigned)
-                        {
-                            if (Utilities.AddExperimentalPart(ap))
-                                KCTDebug.Log($"{ap.name} added to ExpParts: {ResearchAndDevelopment.IsExperimentalPart(ap)}");
-                        }
-
                         OnTechQueued.Fire(ev.host);
                     }
                 }

--- a/Source/KerbalConstructionTime/Persistence/KerbalConstructionTimeData.cs
+++ b/Source/KerbalConstructionTime/Persistence/KerbalConstructionTimeData.cs
@@ -130,7 +130,10 @@ namespace KerbalConstructionTime
                         inDevProtoTechNodes.Add(techItem.ProtoNode.techID, techItem.ProtoNode);
                     }
                 }
-                // get the nodes that have been researched from ResearchAndDevelopment
+
+                if (!HighLogic.LoadedSceneIsEditor)
+                    return;
+
                 protoTechNodes = Utilities.GetUnlockedProtoTechNodes();
                 // iterate through all loaded parts to check if any of them should be experimental
                 foreach (AvailablePart ap in PartLoader.LoadedPartsList)

--- a/Source/KerbalConstructionTime/Utilities/Utilities.cs
+++ b/Source/KerbalConstructionTime/Utilities/Utilities.cs
@@ -137,7 +137,7 @@ namespace KerbalConstructionTime
             if (InvEff != 0)
                 inventorySample.Remove(partRef);
 
-            if (effectiveCost < 0) 
+            if (effectiveCost < 0)
                 effectiveCost = 0;
             return effectiveCost;
         }
@@ -193,7 +193,7 @@ namespace KerbalConstructionTime
 
         public static double ApplyGlobalCostModifiers(HashSet<string> modifiers)
         {
-            double res = PresetManager.Instance.ActivePreset.PartVariables.GetGlobalVariable(modifiers.ToList()); 
+            double res = PresetManager.Instance.ActivePreset.PartVariables.GetGlobalVariable(modifiers.ToList());
             foreach (var x in modifiers)
                 if (KerbalConstructionTime.KCTCostModifiers.TryGetValue(x, out var mod))
                     res *= mod.globalMult;
@@ -1003,7 +1003,7 @@ namespace KerbalConstructionTime
 
             foreach (var name in partInfo.identicalParts.Split(','))
             {
-                if (PartLoader.getPartInfoByName(name.Replace('_', '.').Trim()) is AvailablePart info 
+                if (PartLoader.getPartInfoByName(name.Replace('_', '.').Trim()) is AvailablePart info
                     && info.TechRequired == partInfo.TechRequired)
                 {
                     info.costsFunds = false;


### PR DESCRIPTION
Makes it so that parts aren't marked as experimental unless in the editor, as that's the only time when you'd care about experimental parts.
Should also allow you to buy parts directly in the R&D screen, which was previously impossible. 