### PR TITLE
Add biome scan to cameras

### DIFF
--- a/GameData/RP-0/Parts/Science/VI02-BasicTVCamera.cfg
+++ b/GameData/RP-0/Parts/Science/VI02-BasicTVCamera.cfg
@@ -69,7 +69,7 @@ PART
 	MODULE
 	{
 		name = SCANsat
-		sensorType = 4 //2^2
+		sensorType = 12 //2^2 + 2^3
 		fov = 1.05
 		min_alt = 0
 		max_alt = 1000000

--- a/GameData/RP-0/Parts/Science/VI03-ImprovedTVCamera.cfg
+++ b/GameData/RP-0/Parts/Science/VI03-ImprovedTVCamera.cfg
@@ -94,7 +94,7 @@ PART
 	MODULE
 	{
 		name = SCANsat
-		sensorType = 4 //2^2
+		sensorType = 12 //2^2 + 2^3
 		fov = 0.5
 		min_alt = 0
 		max_alt = 20000000

--- a/GameData/RP-0/Parts/Science/VI04-AdvancedImager.cfg
+++ b/GameData/RP-0/Parts/Science/VI04-AdvancedImager.cfg
@@ -67,7 +67,7 @@ PART
 	MODULE
 	{
 		name = SCANsat
-		sensorType = 4 //2^2
+		sensorType = 12 //2^2 + 2^3
 		fov = 0.46
 		min_alt = 0
 		max_alt = 100000000

--- a/GameData/RP-0/Parts/Science/VI05-HIResImager.cfg
+++ b/GameData/RP-0/Parts/Science/VI05-HIResImager.cfg
@@ -124,8 +124,8 @@
 	MODULE
 	{
 		name = SCANsat
-		sensorType = 256 //2^8
-		fov = 0.18
+		sensorType = 264 //2^8 + 2^3
+		fov = 1.14
 		min_alt = 0
 		max_alt = 1000000
 		best_alt = 300000


### PR DESCRIPTION
Since visual scan is disabled in RSS, add biome scan to cameras instead. Most biomes in KSP are relatively simple (lowlands, mountains, craters, etc.) and should be able to be distinguished even with relatively primitive cameras, given enough data.