### PR TITLE
Disable tooling for Proc Fairing/Interstage bases.

### DIFF
--- a/GameData/RP-0/ProcCosts.cfg
+++ b/GameData/RP-0/ProcCosts.cfg
@@ -6,20 +6,6 @@
 	{
 		@costPerTonne = 400
 	}
-//	MODULE
-//	{
-//		name = ModuleToolingGeneric
-//		toolingName = Tool Fairing Base
-//		toolingType = IBFBBase
-//		untooledMultiplier = 0.125
-//		finalToolingCostMultiplier = 0.2
-		
-//		costReducers = Decoupler
-		
-//		partModuleName = KzFairingBaseResizer
-//		diamField = size
-//		useLength = false
-//	}
 }
 
 @PART:HAS[@MODULE[ProceduralFairingAdapter]]:FOR[RP-0]
@@ -29,20 +15,6 @@
 	{
 		@costPerTonne = 500
 	}
-//	MODULE
-//	{
-//		name = ModuleToolingGeneric
-//		toolingName = Tool Interstage Base
-//		toolingType = IBFBBase
-//		untooledMultiplier = 0.125
-//		finalToolingCostMultiplier = 0.2
-		
-//		costReducers = Decoupler
-		
-//		partModuleName = ProceduralFairingAdapter
-//		diamField = baseSize
-//		useLength = false
-//	}
 }
 
 //    Adapters without decoupler cost 20% - though these don't exist in base ProcFairings
@@ -52,12 +24,6 @@
 	{
 		@costPerTonne *= 0.2
 	}
-//	@MODULE[ModuleToolingGeneric]
-//	{
-//		%toolingName = Tool Structural Base
-//		%toolingType = StructuralBase
-//		%finalToolingCostMultiplier = 0.08
-//	}
 }
 
 // ProcFairings v6.0+ for KSP 1.8+ deprecates both ProceduralFairingAdapter and KzFairingBaseResizer
@@ -83,34 +49,7 @@
 		%decouplerMassMult = 1              // Mass multiplier
 		%decouplerMassBase = 0              // Flat additional mass (0.001 = 1kg)
 	}
-
-	!MODULE[ModuleToolingGeneric],* {}
-//	MODULE
-//	{
-//		name = ModuleToolingGeneric
-//		toolingName = Tool Interstage/Payload Base
-//		toolingType = IBFBBase
-//		untooledMultiplier = 0.125
-//		finalToolingCostMultiplier = 0.2
-
-//		costReducers = Decoupler
-
-//		partModuleName = ProceduralFairingBase
-//		diamField = baseSize
-//		useLength = false
-//	}
 }
-
-// PF 6.0 patch for FairingBases/Adapters with no decoupler
-//@PART:HAS[@MODULE[ProceduralFairingBase],!MODULE[ModuleDecouple]]:FOR[RP-0]
-//{
-//	@MODULE[ModuleToolingGeneric]
-//	{
-//		%toolingName = Tool Structural Base
-//		%toolingType = StructuralBase
-//		%finalToolingCostMultiplier = 0.08
-//	}
-//}
 
 @PART[*]:HAS[@MODULE[KzThrustPlateResizer]]:FOR[RP-0]
 {
@@ -194,20 +133,6 @@
 	{
 		%costPerkL = 500
 	}
-}
-
-@PART[proceduralStackDecoupler|ROT-RingDecoupler]:FOR[RP-0]
-{
-//	MODULE
-//	{
-//		name = ModuleToolingPTank
-//		toolingName = Tool Decoupler Base
-//		toolingType = Decoupler
-//		untooledMultiplier = 0.125
-//		finalToolingCostMultiplier = 0.2
-		
-//		costReducers = IBFBBase
-//	}
 }
 
 @PART[proceduralBattery]:FOR[RP-0]

--- a/GameData/RP-0/ProcCosts.cfg
+++ b/GameData/RP-0/ProcCosts.cfg
@@ -6,20 +6,20 @@
 	{
 		@costPerTonne = 400
 	}
-	MODULE
-	{
-		name = ModuleToolingGeneric
-		toolingName = Tool Fairing Base
-		toolingType = IBFBBase
-		untooledMultiplier = 0.125
-		finalToolingCostMultiplier = 0.2
+//	MODULE
+//	{
+//		name = ModuleToolingGeneric
+//		toolingName = Tool Fairing Base
+//		toolingType = IBFBBase
+//		untooledMultiplier = 0.125
+//		finalToolingCostMultiplier = 0.2
 		
-		costReducers = Decoupler
+//		costReducers = Decoupler
 		
-		partModuleName = KzFairingBaseResizer
-		diamField = size
-		useLength = false
-	}
+//		partModuleName = KzFairingBaseResizer
+//		diamField = size
+//		useLength = false
+//	}
 }
 
 @PART:HAS[@MODULE[ProceduralFairingAdapter]]:FOR[RP-0]
@@ -29,20 +29,20 @@
 	{
 		@costPerTonne = 500
 	}
-	MODULE
-	{
-		name = ModuleToolingGeneric
-		toolingName = Tool Interstage Base
-		toolingType = IBFBBase
-		untooledMultiplier = 0.125
-		finalToolingCostMultiplier = 0.2
+//	MODULE
+//	{
+//		name = ModuleToolingGeneric
+//		toolingName = Tool Interstage Base
+//		toolingType = IBFBBase
+//		untooledMultiplier = 0.125
+//		finalToolingCostMultiplier = 0.2
 		
-		costReducers = Decoupler
+//		costReducers = Decoupler
 		
-		partModuleName = ProceduralFairingAdapter
-		diamField = baseSize
-		useLength = false
-	}
+//		partModuleName = ProceduralFairingAdapter
+//		diamField = baseSize
+//		useLength = false
+//	}
 }
 
 //    Adapters without decoupler cost 20% - though these don't exist in base ProcFairings
@@ -52,12 +52,12 @@
 	{
 		@costPerTonne *= 0.2
 	}
-	@MODULE[ModuleToolingGeneric]
-	{
-		%toolingName = Tool Structural Base
-		%toolingType = StructuralBase
-		%finalToolingCostMultiplier = 0.08
-	}
+//	@MODULE[ModuleToolingGeneric]
+//	{
+//		%toolingName = Tool Structural Base
+//		%toolingType = StructuralBase
+//		%finalToolingCostMultiplier = 0.08
+//	}
 }
 
 // ProcFairings v6.0+ for KSP 1.8+ deprecates both ProceduralFairingAdapter and KzFairingBaseResizer
@@ -85,32 +85,32 @@
 	}
 
 	!MODULE[ModuleToolingGeneric],* {}
-	MODULE
-	{
-		name = ModuleToolingGeneric
-		toolingName = Tool Interstage/Payload Base
-		toolingType = IBFBBase
-		untooledMultiplier = 0.125
-		finalToolingCostMultiplier = 0.2
+//	MODULE
+//	{
+//		name = ModuleToolingGeneric
+//		toolingName = Tool Interstage/Payload Base
+//		toolingType = IBFBBase
+//		untooledMultiplier = 0.125
+//		finalToolingCostMultiplier = 0.2
 
-		costReducers = Decoupler
+//		costReducers = Decoupler
 
-		partModuleName = ProceduralFairingBase
-		diamField = baseSize
-		useLength = false
-	}
+//		partModuleName = ProceduralFairingBase
+//		diamField = baseSize
+//		useLength = false
+//	}
 }
 
 // PF 6.0 patch for FairingBases/Adapters with no decoupler
-@PART:HAS[@MODULE[ProceduralFairingBase],!MODULE[ModuleDecouple]]:FOR[RP-0]
-{
-	@MODULE[ModuleToolingGeneric]
-	{
-		%toolingName = Tool Structural Base
-		%toolingType = StructuralBase
-		%finalToolingCostMultiplier = 0.08
-	}
-}
+//@PART:HAS[@MODULE[ProceduralFairingBase],!MODULE[ModuleDecouple]]:FOR[RP-0]
+//{
+//	@MODULE[ModuleToolingGeneric]
+//	{
+//		%toolingName = Tool Structural Base
+//		%toolingType = StructuralBase
+//		%finalToolingCostMultiplier = 0.08
+//	}
+//}
 
 @PART[*]:HAS[@MODULE[KzThrustPlateResizer]]:FOR[RP-0]
 {
@@ -198,16 +198,16 @@
 
 @PART[proceduralStackDecoupler|ROT-RingDecoupler]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleToolingPTank
-		toolingName = Tool Decoupler Base
-		toolingType = Decoupler
-		untooledMultiplier = 0.125
-		finalToolingCostMultiplier = 0.2
+//	MODULE
+//	{
+//		name = ModuleToolingPTank
+//		toolingName = Tool Decoupler Base
+//		toolingType = Decoupler
+//		untooledMultiplier = 0.125
+//		finalToolingCostMultiplier = 0.2
 		
-		costReducers = IBFBBase
-	}
+//		costReducers = IBFBBase
+//	}
 }
 
 @PART[proceduralBattery]:FOR[RP-0]

--- a/GameData/RP-0/ProcCosts.cfg
+++ b/GameData/RP-0/ProcCosts.cfg
@@ -91,7 +91,7 @@
 		toolingTypeNonDecoupled = Stringers
 		untooledMultiplier = 0.125
 		untooledMultiplierNonDecoupled = 0.0625
-		finalToolingCostMultiplier = 0.25
+		finalToolingCostMultiplier = 0.35
 		finalToolingCostMultiplierNonDecoupled = 0.0625
 		costPerTonneNonDecoupled = 100
 	}


### PR DESCRIPTION
You're already tooling the tank, and tooling the fairing sides/stringers, as we discussed an extra cost for tooling the base doesn't make much sense.