### PR TITLE
Small grammar fix in crew count record

### DIFF
--- a/GameData/RP-0/Contracts/Human Records/CrewedCountRecord.cfg
+++ b/GameData/RP-0/Contracts/Human Records/CrewedCountRecord.cfg
@@ -7,7 +7,7 @@ CONTRACT_TYPE
     description = We want you to set a new crew count record! Have at least @crewedTargetCount crew on the same spacecraft/station at the same time.
 	genericTitle = Crew Count Record
     genericDescription = We want you to set a new crew count record! Have at least the specified crew amount on the same spacecraft/station at the same time.
-    synopsis = Set a crew count record of @crewedTargetCount
+    synopsis = Set a crew count record of @crewedTargetCount crew.
     completedMessage = Congratulations! You've set a new crew count record!
 	
 	agent = Federation Aeronautique Internationale
@@ -52,7 +52,7 @@ CONTRACT_TYPE
 	{
 		name = crewCountInSpace
 		type = All
-		title = Have @/crewedTargetCount on the same vessel while in space in a stable orbit.
+		title = Have @/crewedTargetCount crew on the same vessel while in space in a stable orbit.
 		
 		disableOnStateChange = False
 		


### PR DESCRIPTION
Descriptions were missing "crew" in two places.