### PR TITLE
Changed kOS tech progression to follow selected tech

### DIFF
--- a/GameData/RP-0/Tree/ProceduralAvionics.cfg
+++ b/GameData/RP-0/Tree/ProceduralAvionics.cfg
@@ -183,6 +183,12 @@ AVIONICSCONFIGS
 			interplanetary = False
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003	// 3l
+			
+    		// Still early analogue tech with high mass
+			kosDiskSpace = 500
+			kosSpaceCostFactor = 0.1            // 50F for double space
+			kosSpaceMassFactor = 0.0001         // 50 kg for double space
+			kosECPerInstruction = 0.000001      // 1kW @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -201,6 +207,12 @@ AVIONICSCONFIGS
 			interplanetary = False
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+            // Still early analogue tech with high mass
+			kosDiskSpace = 500
+			kosSpaceCostFactor = 0.1             // 50F for double space
+			kosSpaceMassFactor = 0.0001          // 50 kg for double space
+			kosECPerInstruction = 0.000004       // 400W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -219,6 +231,12 @@ AVIONICSCONFIGS
 			interplanetary = False
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			// Still early analogue tech with high mass
+			kosDiskSpace = 500
+			kosSpaceCostFactor = 0.1            // 50F for double space
+			kosSpaceMassFactor = 0.0001         // 50 kg for double space
+			kosECPerInstruction = 0.000002      // 200W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -238,6 +256,12 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			// Still early analogue tech with high mass
+			kosDiskSpace = 500
+			kosSpaceCostFactor = 0.1             // 50F for double space
+			kosSpaceMassFactor = 0.0001          // 50 kg for double space
+			kosECPerInstruction = 0.000001       // 100W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -257,6 +281,12 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			// Early digital tech ~ minuteman missile
+			kosDiskSpace = 5000
+			kosSpaceCostFactor = 0.01           // 50F for double space
+			kosSpaceMassFactor = 0.0000005      // 2.5 kg for double space
+			kosECPerInstruction = 0.0000004     // 40W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -276,6 +306,11 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			kosDiskSpace = 10000
+			kosSpaceCostFactor = 0.005          // 50F for double space
+			kosSpaceMassFactor = 0.0000002      // 2 kg for double space
+			kosECPerInstruction = 0.0000002     // 20W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -295,6 +330,12 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			// Surveyor / Gemini era
+			kosDiskSpace = 20000
+			kosSpaceCostFactor = 0.0025         // 50F for double space
+			kosSpaceMassFactor = 0.0000001      // 2 kg for double space
+			kosECPerInstruction = 0.0000001     // 10W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -314,6 +355,12 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			// Apollo era
+			kosDiskSpace = 50000
+			kosSpaceCostFactor = 0.001          // 50F for double space
+			kosSpaceMassFactor = 0.00000005     // 2.5 kg for double space
+			kosECPerInstruction = .00000008     // 8W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -334,6 +381,12 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			// Weight reducton for better integrated circuits
+			kosDiskSpace = 100000
+			kosSpaceCostFactor = 0.0005         // 50F for double space
+			kosSpaceMassFactor = 0.000000005    // 0.5 kg for double space
+			kosECPerInstruction = 0.00000004    // 4W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -354,6 +407,11 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			kosDiskSpace = 200000
+			kosSpaceCostFactor = 0.00025        // 50F for double space
+			kosSpaceMassFactor = 0.000000002    // 0.4 kg for double space
+			kosECPerInstruction = 0.00000001    // 1W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -374,6 +432,11 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			kosDiskSpace = 300000
+			kosSpaceCostFactor = 0.0001           // 30F for double space
+			kosSpaceMassFactor = 0.000000001      // 0.3 kg for double space
+			kosECPerInstruction = 0.00000001      // 1W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -394,6 +457,11 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			kosDiskSpace = 400000
+			kosSpaceCostFactor = 0.0001         // 40F for double space
+			kosSpaceMassFactor = 0.0000000005   // 0.2 kg for double space
+			kosECPerInstruction = 0.00000001    // 1W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -414,6 +482,11 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			kosDiskSpace = 500000
+			kosSpaceCostFactor = 0.0001         // 50F for double space
+			kosSpaceMassFactor = 0.0000000002   // 0.1 kg for double space
+			kosECPerInstruction = 0.00000001    // 1W @ 2000 IPU
 		}
 	}
 
@@ -442,6 +515,12 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003	// 3l
+
+			// Still early analogue tech with high mass
+			kosDiskSpace = 500
+			kosSpaceCostFactor = 0.1             // 50F for double space
+			kosSpaceMassFactor = 0.0001          // 50 kg for double space
+			kosECPerInstruction = 0.000001       // 100W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -463,6 +542,12 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			// Early digital tech ~ minuteman missile
+			kosDiskSpace = 5000
+			kosSpaceCostFactor = 0.01           // 50F for double space
+			kosSpaceMassFactor = 0.0000005      // 2.5 kg for double space
+			kosECPerInstruction = 0.0000004     // 40W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -484,6 +569,11 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			kosDiskSpace = 10000
+			kosSpaceCostFactor = 0.005          // 50F for double space
+			kosSpaceMassFactor = 0.0000002      // 2 kg for double space
+			kosECPerInstruction = 0.0000002     // 20W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -505,6 +595,12 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			// Surveyor / Gemini era
+			kosDiskSpace = 20000
+			kosSpaceCostFactor = 0.0025         // 50F for double space
+			kosSpaceMassFactor = 0.0000001      // 2 kg for double space
+			kosECPerInstruction = 0.0000001     // 10W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -526,6 +622,12 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			// Apollo era
+			kosDiskSpace = 50000
+			kosSpaceCostFactor = 0.001          // 50F for double space
+			kosSpaceMassFactor = 0.00000005     // 2.5 kg for double space
+			kosECPerInstruction = .00000008     // 8W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -547,6 +649,12 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			// Weight reducton for better integrated circuits
+			kosDiskSpace = 100000
+			kosSpaceCostFactor = 0.0005         // 50F for double space
+			kosSpaceMassFactor = 0.000000005    // 0.5 kg for double space
+			kosECPerInstruction = 0.00000004    // 4W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -568,6 +676,11 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			kosDiskSpace = 200000
+			kosSpaceCostFactor = 0.00025        // 50F for double space
+			kosSpaceMassFactor = 0.000000002    // 0.4 kg for double space
+			kosECPerInstruction = 0.00000001    // 1W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -589,6 +702,11 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			kosDiskSpace = 300000
+			kosSpaceCostFactor = 0.0001           // 30F for double space
+			kosSpaceMassFactor = 0.000000001      // 0.3 kg for double space
+			kosECPerInstruction = 0.00000001      // 1W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -610,6 +728,11 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			kosDiskSpace = 400000
+			kosSpaceCostFactor = 0.0001         // 40F for double space
+			kosSpaceMassFactor = 0.0000000005   // 0.2 kg for double space
+			kosECPerInstruction = 0.00000001    // 1W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -631,6 +754,11 @@ AVIONICSCONFIGS
 			hasScienceContainer = True
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.003
+
+			kosDiskSpace = 500000
+			kosSpaceCostFactor = 0.0001         // 50F for double space
+			kosSpaceMassFactor = 0.0000000002   // 0.1 kg for double space
+			kosECPerInstruction = 0.00000001    // 1W @ 2000 IPU
 		}
 	}
 
@@ -649,6 +777,12 @@ AVIONICSCONFIGS
 			powerFactor = 100
 			avionicsDensity = 2
 			reservedRFTankVolume = 0.0015	// 1.5l
+			
+    		// Still early analogue tech with high mass
+			kosDiskSpace = 400
+			kosSpaceCostFactor = 0.1            // 40F for double space
+			kosSpaceMassFactor = 0.0001         // 40 kg for double space
+			kosECPerInstruction = 0.000001      // 1kW @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -660,6 +794,12 @@ AVIONICSCONFIGS
 			powerFactor = 50
 			avionicsDensity = 1.5
 			reservedRFTankVolume = 0.0015
+			
+    		// Still early analogue tech with high mass
+			kosDiskSpace = 400
+			kosSpaceCostFactor = 0.1            // 40F for double space
+			kosSpaceMassFactor = 0.0001         // 40 kg for double space
+			kosECPerInstruction = 0.000001      // 1kW @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -671,6 +811,12 @@ AVIONICSCONFIGS
 			powerFactor = 25
 			avionicsDensity = 1
 			reservedRFTankVolume = 0.0015
+			
+    		// Still early analogue tech with high mass
+			kosDiskSpace = 400
+			kosSpaceCostFactor = 0.1            // 40F for double space
+			kosSpaceMassFactor = 0.0001         // 40 kg for double space
+			kosECPerInstruction = 0.000001      // 1kW @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -682,6 +828,12 @@ AVIONICSCONFIGS
 			powerFactor = 0.15
 			avionicsDensity = 0.5
 			reservedRFTankVolume = 0.0015
+			
+    		// Still early analogue tech with high mass
+			kosDiskSpace = 400
+			kosSpaceCostFactor = 0.1            // 40F for double space
+			kosSpaceMassFactor = 0.0001         // 40 kg for double space
+			kosECPerInstruction = 0.000001      // 1kW @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -694,6 +846,12 @@ AVIONICSCONFIGS
 			avionicsDensity = 0.5
 			hasScienceContainer = True
 			reservedRFTankVolume = 0.0015
+			
+    		// Still early analogue tech with high mass
+			kosDiskSpace = 400
+			kosSpaceCostFactor = 0.1            // 40F for double space
+			kosSpaceMassFactor = 0.0001         // 40 kg for double space
+			kosECPerInstruction = 0.000001      // 1kW @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -706,6 +864,12 @@ AVIONICSCONFIGS
 			avionicsDensity = 0.5
 			hasScienceContainer = True
 			reservedRFTankVolume = 0.0015
+
+			// Early digital tech ~ minuteman missile
+			kosDiskSpace = 3000
+			kosSpaceCostFactor = 0.02           // 60F for double space
+			kosSpaceMassFactor = 0.000001       // 3 kg for double space
+			kosECPerInstruction = 0.0000004     // 40W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -718,6 +882,11 @@ AVIONICSCONFIGS
 			avionicsDensity = 0.5
 			hasScienceContainer = True
 			reservedRFTankVolume = 0.0015
+
+			kosDiskSpace = 6000
+			kosSpaceCostFactor = 0.01           // 60F for double space
+			kosSpaceMassFactor = 0.0000004      // 2.4 kg for double space
+			kosECPerInstruction = 0.0000002     // 20W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -730,6 +899,12 @@ AVIONICSCONFIGS
 			avionicsDensity = 0.5
 			hasScienceContainer = True
 			reservedRFTankVolume = 0.0015
+
+			// Surveyor / Gemini era
+			kosDiskSpace = 12000
+			kosSpaceCostFactor = 0.005          // 60F for double space
+			kosSpaceMassFactor = 0.0000002      // 2.4 kg for double space
+			kosECPerInstruction = 0.0000001     // 10W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -742,6 +917,12 @@ AVIONICSCONFIGS
 			avionicsDensity = 0.5
 			hasScienceContainer = True
 			reservedRFTankVolume = 0.0015
+
+			// Apollo era
+			kosDiskSpace = 30000
+			kosSpaceCostFactor = 0.002          // 60F for double space
+			kosSpaceMassFactor = 0.00000008     // 4 kg for double space
+			kosECPerInstruction = .00000008     // 8W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -754,6 +935,12 @@ AVIONICSCONFIGS
 			avionicsDensity = 0.5
 			hasScienceContainer = True
 			reservedRFTankVolume = 0.0015
+            
+			// Weight reducton for better integrated circuits
+			kosDiskSpace = 100000
+			kosSpaceCostFactor = 0.0005         // 50F for double space
+			kosSpaceMassFactor = 0.000000005    // 0.5 kg for double space
+			kosECPerInstruction = 0.00000004    // 4W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -766,6 +953,11 @@ AVIONICSCONFIGS
 			avionicsDensity = 0.5
 			hasScienceContainer = True
 			reservedRFTankVolume = 0.0015
+
+			kosDiskSpace = 200000
+			kosSpaceCostFactor = 0.00025        // 50F for double space
+			kosSpaceMassFactor = 0.000000002    // 0.4 kg for double space
+			kosECPerInstruction = 0.00000001    // 1W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -778,6 +970,11 @@ AVIONICSCONFIGS
 			avionicsDensity = 0.5
 			hasScienceContainer = True
 			reservedRFTankVolume = 0.0015
+
+			kosDiskSpace = 300000
+			kosSpaceCostFactor = 0.0001           // 30F for double space
+			kosSpaceMassFactor = 0.000000001      // 0.3 kg for double space
+			kosECPerInstruction = 0.00000001      // 1W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -790,6 +987,11 @@ AVIONICSCONFIGS
 			avionicsDensity = 0.5
 			hasScienceContainer = True
 			reservedRFTankVolume = 0.0015
+
+			kosDiskSpace = 400000
+			kosSpaceCostFactor = 0.0001         // 40F for double space
+			kosSpaceMassFactor = 0.0000000005   // 0.2 kg for double space
+			kosECPerInstruction = 0.00000001    // 1W @ 2000 IPU
 		}
 		TECHLIMIT
 		{
@@ -802,6 +1004,11 @@ AVIONICSCONFIGS
 			avionicsDensity = 0.5
 			hasScienceContainer = True
 			reservedRFTankVolume = 0.0015
+
+			kosDiskSpace = 500000
+			kosSpaceCostFactor = 0.0001         // 50F for double space
+			kosSpaceMassFactor = 0.0000000002   // 0.1 kg for double space
+			kosECPerInstruction = 0.00000001    // 1W @ 2000 IPU
 		}
 	}
 }
@@ -819,136 +1026,6 @@ AVIONICSCONFIGS
 		diskSpaceCostFactor = 0.1       // 50F for double space
 		diskSpaceMassFactor = 0.0001    // 50 kg for double space
 		ECPerInstruction = 0.000001     // 1kW @ 2000 IPU
-
-		UPGRADES
-		{
-			UPGRADE
-			{
-				name__ = procAvionics-tltech1
-				// 52-55
-				diskSpace = 500
-				baseDiskSpace = 500
-				// Still early analogue tech with high mass
-				diskSpaceCostFactor = 0.1       // 50F for double space
-				diskSpaceMassFactor = 0.0001    // 50 kg for double space
-				ECPerInstruction = 0.000004     // 400W @ 2000 IPU
-			}
-			UPGRADE
-			{
-				name__ = procAvionics-tltech2
-				// 56-58
-				diskSpace = 500
-				baseDiskSpace = 500
-				// Still early analogue tech with high mass
-				diskSpaceCostFactor = 0.1      	// 50F for double space
-				diskSpaceMassFactor = 0.0001    // 50 kg for double space
-				ECPerInstruction = 0.000002     // 200W @ 2000 IPU
-			}
-			UPGRADE
-			{
-				name__ = procAvionics-tltech3
-				// 59-60
-				diskSpace = 500
-				baseDiskSpace = 500
-				// Still early analogue tech with high mass
-				diskSpaceCostFactor = 0.1       // 50F for double space
-				diskSpaceMassFactor = 0.0001    // 50 kg for double space
-				ECPerInstruction = 0.000001     // 100W @ 2000 IPU
-			}
-			UPGRADE
-			{
-				name__ = procAvionics-tltech4
-				// 61 - Minuteman missile onboard computer had circa 5kB
-				diskSpace = 5000
-				baseDiskSpace = 5000
-				// Early digital tech
-				diskSpaceCostFactor = 0.01       // 50F for double space
-				diskSpaceMassFactor = 0.0000005  // 2.5 kg for double space
-				ECPerInstruction = 0.0000004     // 40W @ 2000 IPU
-			}
-			UPGRADE
-			{
-				name__ = procAvionics-tltech5
-				// 62-63
-				diskSpace = 10000
-				baseDiskSpace = 10000
-				diskSpaceCostFactor = 0.005      // 50F for double space
-				diskSpaceMassFactor = 0.0000002  // 2 kg for double space
-				ECPerInstruction = 0.0000002     // 20W @ 2000 IPU
-			}
-			UPGRADE
-			{
-				name__ = procAvionics-tltech6
-				// 64-66 - Surveyor had circa 10 kB of memory.
-				//         Gemini had circa 20kB.
-				diskSpace = 20000
-				baseDiskSpace = 20000
-				diskSpaceCostFactor = 0.0025     // 50F for double space
-				diskSpaceMassFactor = 0.0000001  // 2 kg for double space
-				ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
-			}
-			UPGRADE
-			{
-				name__ = procAvionics-tltech7
-				// 67-71 - Apollo had circa 100kB of memory.
-				diskSpace = 50000
-				baseDiskSpace = 50000
-				diskSpaceCostFactor = 0.001       // 50F for double space
-				diskSpaceMassFactor = 0.00000005  // 2.5 kg for double space
-				ECPerInstruction = 0.00000008     // 8W @ 2000 IPU
-			}
-			UPGRADE
-			{
-				name__ = procAvionics-tltech8
-				// 72-80
-				diskSpace = 100000
-				baseDiskSpace = 100000
-				diskSpaceCostFactor = 0.0005       // 50F for double space
-				// Weight reducton for better integrated circuits
-				diskSpaceMassFactor = 0.000000005  // 0.5 kg for double space
-				ECPerInstruction = 0.00000004      // 4W @ 2000 IPU
-			}
-			UPGRADE
-			{
-				name__ = procAvionics-tltech9
-				// 81-85
-				diskSpace = 200000
-				baseDiskSpace = 200000
-				diskSpaceCostFactor = 0.00025      // 50F for double space
-				diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-				ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-			}
-			UPGRADE
-			{
-				name__ = procAvionics-tltech10
-				// 86-96
-				diskSpace = 300000
-				baseDiskSpace = 300000
-				diskSpaceCostFactor = 0.0001       // 30F for double space
-				diskSpaceMassFactor = 0.000000001  // 0.3 kg for double space
-				ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-			}
-			UPGRADE
-			{
-				name__ = procAvionics-tltech11
-				// 97-08
-				diskSpace = 400000
-				baseDiskSpace = 400000
-				diskSpaceCostFactor = 0.0001       // 40F for double space
-				diskSpaceMassFactor = 0.0000000005 // 0.2 kg for double space
-				ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-			}
-			UPGRADE
-			{
-				name__ = procAvionics-tltech12
-				// 09-18
-				diskSpace = 500000
-				baseDiskSpace = 500000
-				diskSpaceCostFactor = 0.0001       // 50F for double space
-				diskSpaceMassFactor = 0.0000000002 // 0.1 kg for double space
-				ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-			}
-		}
 	}
 }
 

--- a/Source/Avionics/ProceduralAvionicsTechNode.cs
+++ b/Source/Avionics/ProceduralAvionicsTechNode.cs
@@ -61,6 +61,18 @@ namespace RP0.ProceduralAvionics
         [Persistent]
         public bool interplanetary = true;
 
+        [Persistent]
+        public int kosDiskSpace = 500;
+
+        [Persistent]
+        public float kosSpaceCostFactor = 0.1f;
+
+        [Persistent]
+        public float kosSpaceMassFactor = 0.0001f;
+
+        [Persistent]
+        public float kosECPerInstruction = 0.000001f;
+
         public bool IsAvailable => ResearchAndDevelopment.GetTechnologyState(name) == RDTech.State.Available;
 
         public void Load(ConfigNode node)


### PR DESCRIPTION
kOS tech progression follows selected tech level rather than maximum unlocked.

This will require a fix in kOS in addition to this fix.