### PR TITLE
Change science at Earth to remove flying low

### DIFF
--- a/GameData/RP-0/Science/BodyScienceParams.cfg
+++ b/GameData/RP-0/Science/BodyScienceParams.cfg
@@ -12,8 +12,8 @@
 				
 				%landedDataValue = 0.00001
 				%splashedDataValue = 0.00001
-				%flyingLowDataValue = 0.25
-				%flyingHighDataValue = 0.5
+				%flyingLowDataValue = 0.001
+				%flyingHighDataValue = 0.75
 				%inSpaceLowDataValue = 0.75
 				%inSpaceHighDataValue = 1.0
 				%recoveryValue = 1.0

--- a/GameData/RP-0/Science/BodyScienceParams.cfg
+++ b/GameData/RP-0/Science/BodyScienceParams.cfg
@@ -7,7 +7,7 @@
 		{
 			%ScienceValues
 			{
-				%flyingAltitudeThreshold = 50000
+				%flyingAltitudeThreshold = 30000
 				%spaceAltitudeThreshold = 35786000
 				
 				%landedDataValue = 0.00001

--- a/GameData/RP-0/Science/BodyScienceParams.cfg
+++ b/GameData/RP-0/Science/BodyScienceParams.cfg
@@ -7,7 +7,7 @@
 		{
 			%ScienceValues
 			{
-				%flyingAltitudeThreshold = 30000
+				%flyingAltitudeThreshold = 40000
 				%spaceAltitudeThreshold = 35786000
 				
 				%landedDataValue = 0.00001

--- a/GameData/RP-0/Science/Experiments/BioSample.cfg
+++ b/GameData/RP-0/Science/Experiments/BioSample.cfg
@@ -10,7 +10,7 @@ EXPERIMENT_DEFINITION
     scienceCap = 10
     dataScale = 2
     requireAtmosphere = False
-    situationMask = 57
+    situationMask = 56
     biomeMask = 0
 
     RESULTS

--- a/GameData/RP-0/Science/Experiments/Photography.cfg
+++ b/GameData/RP-0/Science/Experiments/Photography.cfg
@@ -10,8 +10,8 @@ EXPERIMENT_DEFINITION
     scienceCap = 20
     dataScale = 2
     requireAtmosphere = False
-    situationMask = 16
-    biomeMask = 16
+    situationMask = 24
+    biomeMask = 24
 
     RESULTS
     {

--- a/GameData/RP-0/Science/Experiments/Photography.cfg
+++ b/GameData/RP-0/Science/Experiments/Photography.cfg
@@ -10,8 +10,8 @@ EXPERIMENT_DEFINITION
     scienceCap = 20
     dataScale = 2
     requireAtmosphere = False
-    situationMask = 29
-    biomeMask = 29
+    situationMask = 16
+    biomeMask = 16
 
     RESULTS
     {


### PR DESCRIPTION
Removes the flying low multiplier, adds a situation mask at flying high for bio and photo experiments, and lowers flying high to 40km. This depends also on a PR to ROKerbalism https://github.com/KSP-RO/ROKerbalism/pull/99 that adds a crewed supersonic series of experiments