### PR TITLE
Change way of showing max number of completions in contracts

### DIFF
--- a/GameData/RP-0/Contracts/Advanced Satellites/GEO Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/GEO Communications Satellites.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = AdvSatellites
 	agent = Satellites
 
-	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: $GEORepeatComSats_Count</b>
+	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a new Commercial Communications Satellite
@@ -76,6 +76,12 @@ CONTRACT_TYPE
 		}
 	}
 	
+	DATA
+	{
+		type = int
+		index = $GEORepeatComSats_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Advanced Satellites/Molniya Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Molniya Communications Satellites.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = AdvSatellites
 	agent = Satellites
 
-	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: $MolniyaRepeatComSats_Count</b>
+	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a new Commercial Communications Satellite
@@ -74,6 +74,12 @@ CONTRACT_TYPE
 		{
 			type = KOLNIYA
 		}
+	}
+
+	DATA
+	{
+		type = int
+		index = $MolniyaRepeatComSats_Count + 0
 	}
 	
 	BEHAVIOUR

--- a/GameData/RP-0/Contracts/Advanced Satellites/Tundra Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Tundra Communications Satellites.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = AdvSatellites
 	agent = Satellites
 
-	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: $TundraRepeatComSats_Count</b>
+	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a new Commercial Communications Satellite
@@ -76,6 +76,12 @@ CONTRACT_TYPE
 		}
 	}
 	
+	DATA
+	{
+		type = int
+		index = $TundraRepeatComSats_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = EarlySatellites
 
 
-	description = Now that we have tested out the Communications Satellite Technology, there are many uses we have for these Satellites. We have a customer that is requesting a new satellite. Launch a new communications Satellite into the specified orbit.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b><b><color=white>Removal Condition: Completion of a Commercial Communications Satellite contract</color></b>&br;&br;<b>Number of Contracts Completed: $EarlyComSat_Count</b>
+	description = Now that we have tested out the Communications Satellite Technology, there are many uses we have for these Satellites. We have a customer that is requesting a new satellite. Launch a new communications Satellite into the specified orbit.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b><b><color=white>Removal Condition: Completion of a Commercial Communications Satellite contract</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a Communications Satellite for a customer.
@@ -67,6 +67,12 @@ CONTRACT_TYPE
 		invertRequirement = true
 	}
 	
+	DATA
+	{
+		type = int
+		index = $EarlyComSat_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = EarlySatellites
 
 
-	description = There are groups that want to understand more about communications with satellites. Launch a new communications test satellite into the proper orbit. &br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Communications Satellite (Early) contract</color></b>&br;&br;<b>Number of Contracts Completed: $ComTestSat_Count</b>
+	description = There are groups that want to understand more about communications with satellites. Launch a new communications test satellite into the proper orbit. &br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Communications Satellite (Early) contract</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a Communications Test Satellite
@@ -51,6 +51,12 @@ CONTRACT_TYPE
 		invertRequirement = true
 	}
 	
+	DATA
+	{
+		type = int
+		index = $ComTestSat_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Human Contracts/Orbit Repeatable.cfg
+++ b/GameData/RP-0/Contracts/Human Contracts/Orbit Repeatable.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = HumanContracts
 
 
-	description = Single-person orbital spacecraft are fairly rare in history but serve an important role in proving future technologies, with Mercury (1962, 1.4 tons, Atlas LV-3B) and Vostok (1961, 4.7 tons, Vostok-K) being the only examples. Design, build, and launch one that remains for @/NoOfOrbits orbits and return the crew safely back to Earth.<b><color=white>NOTE: You can not select this contract and the Orbital Flight with Maneuvers and 2+ Crew contract. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>Number of Contracts Completed: $HSFOrbitalLEO1Repeatable_Count</b>
+	description = Single-person orbital spacecraft are fairly rare in history but serve an important role in proving future technologies, with Mercury (1962, 1.4 tons, Atlas LV-3B) and Vostok (1961, 4.7 tons, Vostok-K) being the only examples. Design, build, and launch one that remains for @/NoOfOrbits orbits and return the crew safely back to Earth.<b><color=white>NOTE: You can not select this contract and the Orbital Flight with Maneuvers and 2+ Crew contract. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 	
 	genericDescription = Launch a crewed spacecraft carrying one person into orbit for a routine mission for the specified duration and return safely home.
 
@@ -72,6 +72,12 @@ CONTRACT_TYPE
 		title = Total Duration
 	}
 	
+	DATA
+	{
+		type = int
+		index = $HSFOrbitalLEO1Repeatable_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Human Contracts/Suborbital Crewed.cfg
+++ b/GameData/RP-0/Contracts/Human Contracts/Suborbital Crewed.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = HumanContracts
 
 
-	description = Crewed suborbital flights are used as a safer prelude to an orbital mission, for research, or to set non-orbital altitude records. Send any number of crew above @VesselGroup/ReachAlt/minAltitude meters to satisfy the requirements of this mission. Historical missions used the Mercury capsule (1961, Mercury-Redstone), the X-15 (1963, B-52), and SpaceShipOne (2004, White Knight). You may complete this mission up to 3 times.<b><color=white>NOTE: You can not select this contract and 'First Orbital Flight (Crewed') or 'X-Planes High' at the same time. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>Number of Contracts Completed: $CrewedSuborbital_Count</b>
+	description = Crewed suborbital flights are used as a safer prelude to an orbital mission, for research, or to set non-orbital altitude records. Send any number of crew above @VesselGroup/ReachAlt/minAltitude meters to satisfy the requirements of this mission. Historical missions used the Mercury capsule (1961, Mercury-Redstone), the X-15 (1963, B-52), and SpaceShipOne (2004, White Knight).<b><color=white>NOTE: You can not select this contract and 'First Orbital Flight (Crewed') or 'X-Planes High' at the same time. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	
 	genericDescription = Launch a crewed spacecraft or spaceplane with at least one person aboard into a suborbital trajectory of at least the given apogee and return safely home.
 
@@ -64,6 +64,12 @@ CONTRACT_TYPE
 		type = AcceptContract
 		contractType = CrewedReachSpaceDifficult
 		invertRequirement = True
+	}
+
+	DATA
+	{
+		type = int
+		index = $CrewedSuborbital_Count + 0
 	}
 
 	BEHAVIOUR

--- a/GameData/RP-0/Contracts/Human Contracts/Three Crew Orbit Repeatable.cfg
+++ b/GameData/RP-0/Contracts/Human Contracts/Three Crew Orbit Repeatable.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = HumanContracts
 
 
-	description = The goal and realization of putting three (or more) crew on orbit at the same time begins the era of the space taxi and ready access to LEO. Depending on the politics and economy of the originating nation these craft will either be noted predecessors to later craft or become so ubiquitous and reliable in the role that they are still flying 50 years after their first. These craft should be able to support at least three crew and prove that they can stay in orbit for @/DurationText days. The Soviet Voskhod 1 (1964, 5.3 tons, modified Molniya) and Soyuz (1967, 6.5 tons, Soyuz), and the U.S. Apollo CSM (1968, 14.7 - 21 tons for LEO, Saturn 1B) are examples of these craft.&br;&br;<b>Number of Contracts Completed: $HSFOrbitalLEO3Repeatable_Count</b>
+	description = The goal and realization of putting three (or more) crew on orbit at the same time begins the era of the space taxi and ready access to LEO. Depending on the politics and economy of the originating nation these craft will either be noted predecessors to later craft or become so ubiquitous and reliable in the role that they are still flying 50 years after their first. These craft should be able to support at least three crew and prove that they can stay in orbit for @/DurationText days. The Soviet Voskhod 1 (1964, 5.3 tons, modified Molniya) and Soyuz (1967, 6.5 tons, Soyuz), and the U.S. Apollo CSM (1968, 14.7 - 21 tons for LEO, Saturn 1B) are examples of these craft.&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 	
 	genericDescription = Launch a crewed spacecraft capable of supporting at least three people into orbit for a routine mission for the required number of days and return safely home.
 
@@ -77,6 +77,12 @@ CONTRACT_TYPE
 		title = Eccentricity
 	}
 	
+	DATA
+	{
+		type = int
+		index = $HSFOrbitalLEO3Repeatable_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Human Contracts/Two Crew Orbit Repeatable.cfg
+++ b/GameData/RP-0/Contracts/Human Contracts/Two Crew Orbit Repeatable.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = HumanContracts
 
 
-	description = Putting two people into space in the same capsule opens the door to a range of new activities and opportunities. Such a spacecraft must remain in orbit with its crew @/DurationText days and return them safely to Earth. Only two spacecraft were ever specifically created for this task, the Soviet Voskhod 2, a refit of the 3-seat Voskhod 1 (1965, 5.7 tons, modified Molniya) and the U.S. Gemini (1965, 3.2 - 3.8 tons, Gemini-Titan II).&br;&br;<b>Number of Contracts Completed: $HSFOrbitalLEO2Repeatable_Count</b>
+	description = Putting two people into space in the same capsule opens the door to a range of new activities and opportunities. Such a spacecraft must remain in orbit with its crew @/DurationText days and return them safely to Earth. Only two spacecraft were ever specifically created for this task, the Soviet Voskhod 2, a refit of the 3-seat Voskhod 1 (1965, 5.7 tons, modified Molniya) and the U.S. Gemini (1965, 3.2 - 3.8 tons, Gemini-Titan II).&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 
 	genericDescription = Launch a crewed spacecraft capable of supporting at least two people into orbit for a routine mission for the specified number of days and return safely home.
 
@@ -90,6 +90,12 @@ CONTRACT_TYPE
 		title = Total Duration of Mission
 	}
 	
+	DATA
+	{
+		type = int
+		index = $HSFOrbitalLEO2Repeatable_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Orbit 1 Repeatable.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Orbit 1 Repeatable.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = MoonExploration
 
 
-	description = Launch a spacecraft with at least one crew aboard into lunar orbit for a routine mission of the specified duration and return safely to Earth. This mission can be completed up to 2 times. Completing once will unlock the Lunar Space Station contract.&br;&br;<b>Number of Contracts Completed: $SingleCrewedLunarOrbitRepeatable_Count</b>
+	description = Launch a spacecraft with at least one crew aboard into lunar orbit for a routine mission of the specified duration and return safely to Earth. Completing once will unlock the Lunar Space Station contract.&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	genericDescription = Fly a Crewed Lunar Orbital mission with at least one crew
 
 	synopsis = Fly a Crewed Lunar Orbital mission with at least one crew
@@ -44,6 +44,12 @@ CONTRACT_TYPE
 		contractType = FirstCrewedLunarOrbit
 	}
 	
+	DATA
+	{
+		type = int
+		index = $SingleCrewedLunarOrbitRepeatable_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Orbit Repeatable.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Crewed Lunar Orbit Repeatable.cfg
@@ -6,7 +6,7 @@ CONTRACT_TYPE
 	group = MoonExploration
 
 
-	description = Launch a spacecraft with at least @/crewNum aboard into lunar orbit for a routine mission of the specified duration and return safely to Earth.&br;&br;<b>Number of Contracts Completed: $HSFOrbitalMoonGenRepeatable_Count</b>
+	description = Launch a spacecraft with at least @/crewNum aboard into lunar orbit for a routine mission of the specified duration and return safely to Earth.&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Launch a spacecraft with at least the required number of crew aboard into lunar orbit for a routine mission of the specified duration and return safely to Earth.
 
 	synopsis = Fly a Crewed Lunar Orbital mission with @/crewNum crew
@@ -82,6 +82,12 @@ CONTRACT_TYPE
 		title = Inclination to use for orbits
 	}
 	
+	DATA
+	{
+		type = int
+		index = $HSFOrbitalMoonGenRepeatable_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Moon Exploration/Crewed Moon Landing and Rover.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Crewed Moon Landing and Rover.cfg
@@ -4,7 +4,7 @@ CONTRACT_TYPE
 	title = Crewed Moon Landing & Rover Exploration
 	group = MoonExploration
 
-	description = Design and launch a spacecraft with at least one crew member to land on the Moon. This will be a targeted landing near a randomly generated waypoint. We will also require you to take a crewed rover to explore an additional two waypoints. Once you have explored the waypoints, return safely to Earth. This mission can be completed 2 times.&br;&br;<b>Number of Contracts Completed: $MoonExtendedStayCrew_Count</b>
+	description = Design and launch a spacecraft with at least one crew member to land on the Moon. This will be a targeted landing near a randomly generated waypoint. We will also require you to take a crewed rover to explore an additional two waypoints. Once you have explored the waypoints, return safely to Earth.&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	genericDescription = Land crew on the Moon.
 
 	synopsis = Launch a craft with at least one Crew, land on the Moon, explore with a rover and return home safely
@@ -43,6 +43,12 @@ CONTRACT_TYPE
 		contractType = RepeatMoonLandingCrew
 	}
 	
+	DATA
+	{
+		type = int
+		index = $MoonExtendedStayCrew_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Moon Exploration/Crewed Targeted Moon Landing.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Crewed Targeted Moon Landing.cfg
@@ -4,7 +4,7 @@ CONTRACT_TYPE
 	title = Crewed Targeted Moon Landing
 	group = MoonExploration
 
-	description = Design and launch a spacecraft with at least one crew member to land on @/biome on the Moon. Explore the area for at least @/LandDur and then return safely to Earth. You can complete this contract 2 times.&br;&br;<b>Number of Contracts Completed: $RepeatMoonLandingCrew_Count</b>
+	description = Design and launch a spacecraft with at least one crew member to land on @/biome on the Moon. Explore the area for at least @/LandDur and then return safely to Earth.&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	
 	genericDescription = Launch a crewed single-person spacecraft and land it on a specific moon biome.  Explore the area for a specified amount of time.  Then return safely to Earth.
 
@@ -63,6 +63,12 @@ CONTRACT_TYPE
 		title = Biome
 	}
 	
+	DATA
+	{
+		type = int
+		index = $RepeatMoonLandingCrew_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Impactor.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Impactor.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = MoonExploration
 
 
-	description = Design and successfully launch a probe that impacts the surface of the Moon. Scientists at home will record their observations as a result of the impact. You may complete this contract up to three times. Due to the nature of the experiment, the impactor must have significant mass to it. The contract requires the impactor to have at least a 40 kg mass.&br;&br;<b>Number of Contracts Completed: $first_MoonImpact_Count</b>
+	description = Design and successfully launch a probe that impacts the surface of the Moon. Scientists at home will record their observations as a result of the impact. Due to the nature of the experiment, the impactor must have significant mass to it. The contract requires the impactor to have at least a 40 kg mass.&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	genericDescription = Impact the surface of the Moon with a probe.
 
 	synopsis = Impact the surface of the Moon with a probe
@@ -56,6 +56,12 @@ CONTRACT_TYPE
 		type = int
 		advance = @advances.ElementAt($first_MoonImpact_Count)
 		reward = @rewards.ElementAt($first_MoonImpact_Count)
+	}
+
+	DATA
+	{
+		type = int
+		index = $first_MoonImpact_Count + 0
 	}
 
 	BEHAVIOUR

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Landing.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Landing.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = MoonExploration
 
 
-	description = Design and successfully launch a craft that can achieve a soft landing on the Moon and return science data back to Earth. Completing this contract 2 times will unlock far side lunar landing. You may complete this mission up to 4 times.<b><color=white>NOTE: You can not select this contract and the First Crewed Lunar Landing contract. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>Number of Contracts Completed: $landingMoon_Count</b>
+	description = Design and successfully launch a craft that can achieve a soft landing on the Moon and return science data back to Earth. Completing this contract 2 times will unlock far side lunar landing.<b><color=white>NOTE: You can not select this contract and the First Crewed Lunar Landing contract. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	genericDescription = Achieve a soft landing on the Moon and transmit Science.
 
 	synopsis = Achieve a soft landing on the Moon and transmit Science
@@ -70,6 +70,12 @@ CONTRACT_TYPE
 		type = int
 		advance = @advances.ElementAt($landingMoon_Count)
 		reward = @rewards.ElementAt($landingMoon_Count)
+	}
+
+	DATA
+	{
+		type = int
+		index = $landingMoon_Count + 0
 	}
 
 	BEHAVIOUR

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Orbiter.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Orbiter.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = MoonExploration
 
 
-	description = Design and successfully launch a probe into lunar orbit (with a maximum apiselene of @/maxApText.Print() km) and successfully transmit or return some scientific data from the Moon's vicinity. You may complete this contract up to two times. &br;&br;<b>Note: The orbital parameters get tighter on the second contract</b> &br;&br;<b>Number of Contracts Completed: $first_MoonOrbitUncrewed_Count</b>
+	description = Design and successfully launch a probe into lunar orbit (with a maximum apiselene of @/maxApText.Print() km) and successfully transmit or return some scientific data from the Moon's vicinity. &br;&br;<b>Note: The orbital parameters get tighter on the second contract</b> &br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	genericDescription = Achieve Lunar Orbit.
 
 	synopsis = Achieve lunar orbit and receive data
@@ -76,6 +76,12 @@ CONTRACT_TYPE
 	{
 		type = int
 		maxApText = int(@maxAp/1000)
+	}
+
+	DATA
+	{
+		type = int
+		index = $first_MoonOrbitUncrewed_Count + 0
 	}
 
 	BEHAVIOUR

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Rover.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Rover.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = MoonExploration
 	agent = Federation Aeronautique Internationale
 
-	description = A good way to explore more of the Moon is to send a rover to visit different places. Our scientists have picked three locations to inspect with a rover. You can complete this mission 3 times.&br;&br;Design and successfully send a rover to the Moon and visit the marked waypoints.&br;&br;It is recommended to use the Waypoint Manager mod for better navigation.&br;&br;<b>Number of Contracts Completed: $MoonRover_Count</b>
+	description = A good way to explore more of the Moon is to send a rover to visit different places. Our scientists have picked three locations to inspect with a rover.&br;&br;Design and successfully send a rover to the Moon and visit the marked waypoints.&br;&br;It is recommended to use the Waypoint Manager mod for better navigation.&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	genericDescription = Launch a rover and inspect 3 locations on the Moon.
 
 	synopsis = Launch a rover and inspect 3 locations on the Moon
@@ -99,6 +99,12 @@ CONTRACT_TYPE
 		type = string
 		NorthSouthString = @/NorthSouthList.ElementAt(@/NorthSouthInt)
 		EastWestString = @/EastWestList.ElementAt(@/EastWestInt)
+	}
+
+	DATA
+	{
+		type = int
+		index = $MoonRover_Count + 0
 	}
 
 	BEHAVIOUR

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Sample Return.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = MoonExploration
 	agent = Federation Aeronautique Internationale
 
-	description = You have successfully landed on the Moon, but our scientists need to know more information about the elements that make up the surface. Send a craft to land and return to Earth with the science data. You may complete this mission up to 3 times.&br;&br;<b>Number of Contracts Completed: $MoonLandingReturn_Count</b>
+	description = You have successfully landed on the Moon, but our scientists need to know more information about the elements that make up the surface. Send a craft to land and return to Earth with the science data.&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	genericDescription = Launch a craft to achieve a soft landing on the Moon and return to Earth with the science
 
 	synopsis = Launch a craft to achieve a soft landing on the Moon and return to Earth with the science
@@ -56,6 +56,12 @@ CONTRACT_TYPE
 		type = int
 		advance = @advances.ElementAt($MoonLandingReturn_Count)
 		reward = @rewards.ElementAt($MoonLandingReturn_Count)
+	}
+
+	DATA
+	{
+		type = int
+		index = $MoonLandingReturn_Count + 0
 	}
 
 	BEHAVIOUR

--- a/GameData/RP-0/Contracts/Nav Sats/Early Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Early Nav Sats.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = NavSats
 
 
-	description = Our engineers are once again requesting a new navigational satellite test article.  Please place one into the proper orbit around Earth.  This contract can be completed up to 4 times.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Operational Navigation System contract</color></b>&br;&br;<b>Number of Contracts Completed: $EarlyNavSats_Count</b>
+	description = Our engineers are once again requesting a new navigational satellite test article.  Please place one into the proper orbit around Earth.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Operational Navigation System contract</color></b>&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a navigational satellite into the proper orbit
@@ -66,6 +66,12 @@ CONTRACT_TYPE
 		invertRequirement = true
 	}
 	
+	DATA
+	{
+		type = int
+		index = $EarlyNavSats_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
+++ b/GameData/RP-0/Contracts/Nav Sats/Second-Gen Nav Sats.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = NavSats
 
 
-	description = A more accurate technique for satellite navigation is to use Time-Difference Of Arrival of pulsed radio signals.  Please place a new test navigational satellite into the proper orbit around Earth.  This contract can be completed up to 3 times. <b><color=red>Note that these TDOA satellites use ComSatPayload rather than NavSatPayload.</color></b>&br;&br;<b>Number of Contracts Completed: $SecondGenNavSats_Count</b>
+	description = A more accurate technique for satellite navigation is to use Time-Difference Of Arrival of pulsed radio signals.  Please place a new test navigational satellite into the proper orbit around Earth.<b><color=red>Note that these TDOA satellites use ComSatPayload rather than NavSatPayload.</color></b>&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a navigational satellite into the proper orbit
@@ -51,6 +51,12 @@ CONTRACT_TYPE
 		invertRequirement = True
 	}
 	
+	DATA
+	{
+		type = int
+		index = $SecondGenNavSats_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Weather Sats/Early Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Early Weather Sats.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = WeatherSats
 
 
-	description = Our scientists are once again requesting a new weather satellite. Please place one into the proper orbit to observe Earth. This contract can be completed up to 6 times.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Second Generation Weather Satellite contract.&br;NOTE: You can not select this contract and the Second Generation Weather Sat contract. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>Number of Contracts Completed: $EarlyWeatherSats_Count</b>
+	description = Our scientists are once again requesting a new weather satellite. Please place one into the proper orbit to observe Earth.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Second Generation Weather Satellite contract.&br;NOTE: You can not select this contract and the Second Generation Weather Sat contract. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a weather satellite into the proper orbit
@@ -47,6 +47,12 @@ CONTRACT_TYPE
 		type = CompleteContract
 		contractType = SecondGenWeather
 		invertRequirement = true
+	}
+
+	DATA
+	{
+		type = int
+		index = $EarlyWeatherSats_Count + 0
 	}
 
 	BEHAVIOUR

--- a/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
@@ -4,7 +4,7 @@ CONTRACT_TYPE
 	title = Geostationary Weather Satellite
 	group = WeatherSats
 
-	description = Geostationary satellites provide the best views of the clouds in specific areas for our meteorologists. Place a weather satellite in geostationary orbit near the marked area.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: $GEOWeather_Count</b>
+	description = Geostationary satellites provide the best views of the clouds in specific areas for our meteorologists. Place a weather satellite in geostationary orbit near the marked area.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a geostationary weather satellite to the marked area
@@ -47,6 +47,12 @@ CONTRACT_TYPE
 		name = CompleteContract
 		type = CompleteContract
 		contractType = first_GEOUncrewed
+	}
+
+	DATA
+	{
+		type = int
+		index = $GEOWeather_Count + 0
 	}
 
 	BEHAVIOUR

--- a/GameData/RP-0/Contracts/Weather Sats/Second Gen Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Second Gen Weather Sats.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = WeatherSats
 
 
-	description = Our experience has given us a better understanding of the best orbits to use for weather satellites. Please launch a new weather satellite into the proper orbit that is sun synchronous. Remember that Sun Synchronous orbits are slightly retrograde.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Geostationary Weather Satellite contract.&br;NOTE: You can not select this contract and the Geostationary Weather contract. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>Number of Contracts Completed: $SecondGenWeather_Count</b>
+	description = Our experience has given us a better understanding of the best orbits to use for weather satellites. Please launch a new weather satellite into the proper orbit that is sun synchronous. Remember that Sun Synchronous orbits are slightly retrograde.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Geostationary Weather Satellite contract.&br;NOTE: You can not select this contract and the Geostationary Weather contract. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a new weather satellite into the proper orbit
@@ -57,6 +57,12 @@ CONTRACT_TYPE
 		invertRequirement = true
 	}
 	
+	DATA
+	{
+		type = int
+		index = $SecondGenWeather_Count + 0
+	}
+
 	BEHAVIOUR
 	{
 		name = IncrementTheCount

--- a/GameData/RP-0/Contracts/Weather Sats/Sun Sync Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Sun Sync Weather Sats.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = WeatherSats
 
 
-	description = Polar orbiting weather satellites are launched in sun-synchronous orbits that allow them to observe the same area on Earth twice a day with the same general lighting. The images they can return are of much higher resolution than geostationary satellites because their orbit is much lower. Launch a sun-synchronous weather satellite into the proper orbit. Remember that Sun Synchronous orbits are slightly retrograde.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: $SunSyncWeather_Count</b>
+	description = Polar orbiting weather satellites are launched in sun-synchronous orbits that allow them to observe the same area on Earth twice a day with the same general lighting. The images they can return are of much higher resolution than geostationary satellites because their orbit is much lower. Launch a sun-synchronous weather satellite into the proper orbit. Remember that Sun Synchronous orbits are slightly retrograde.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a sun-synchronous weather satellite
@@ -69,6 +69,12 @@ CONTRACT_TYPE
 				REF = 1
 			}
 		}
+	}
+
+	DATA
+	{
+		type = int
+		index = $SunSyncWeather_Count + 0
 	}
 
 	BEHAVIOUR


### PR DESCRIPTION
Display max completions as `Number of Contracts Completed: x / y` instead of having a separate line for that info.
Uses `x / unlimited` when there is no max, but keeping track of number of completions is still of interest.

The same change to Lunar Far side Lander is in another PR, #1501 