### PR TITLE
Let space station contracts select the same station

### DIFF
--- a/GameData/RP-0/Contracts/Space Stations/Add Crew Module Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Add Crew Module Station.cfg
@@ -48,9 +48,8 @@ CONTRACT_TYPE
 	{
 		type = Vessel
 		requiredValue = true
-		hidden = true
-		uniquenessCheck = GROUP_ACTIVE
-		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station && v.EmptyCrewSpace()<3 && v.FreeDockingPorts()>0).SelectUnique()
+		hidden = false
+		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station && v.EmptyCrewSpace()<3 && v.FreeDockingPorts()>0).Random()
 		title = Must have a station with less than 3 empty seats
 	}
 	DATA

--- a/GameData/RP-0/Contracts/Space Stations/Crew Rotation Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Crew Rotation Station.cfg
@@ -48,9 +48,8 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = Vessel
-		uniquenessCheck = GROUP_ACTIVE
 		requiredValue = true
-        targetVessel1 = AllVessels().Where(v => v.VesselType() == Station && v.CrewCount()>0).SelectUnique()
+        targetVessel1 = AllVessels().Where(v => v.VesselType() == Station && v.CrewCount()>0).Random()
 		title = Must have a station with crew on board
 	}
 	DATA

--- a/GameData/RP-0/Contracts/Space Stations/Life Support Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Life Support Station.cfg
@@ -1,4 +1,4 @@
-CONTRACT_TYPE:NEEDS[TACLifeSupport]
+CONTRACT_TYPE
 {
 	name = LifeSupportStation
 	title = Resupply the Life Support Resources on @/targetVessel1
@@ -46,8 +46,7 @@ CONTRACT_TYPE:NEEDS[TACLifeSupport]
 	{
 		type = Vessel
 		requiredValue = true
-		uniquenessCheck = GROUP_ACTIVE
-		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station && v.FreeDockingPorts()>0 && (v.ResourceCapacity(Food) / v.ResourceQuantity(Food))>0.26 || (v.ResourceCapacity(Water) / v.ResourceQuantity(Water))>0.26 || (v.ResourceCapacity(Oxygen) / v.ResourceQuantity(Oxygen))>0.26).SelectUnique()
+		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station && v.FreeDockingPorts()>0 && (v.ResourceCapacity(Food) / v.ResourceQuantity(Food))>0.26 || (v.ResourceCapacity(Water) / v.ResourceQuantity(Water))>0.26 || (v.ResourceCapacity(Oxygen) / v.ResourceQuantity(Oxygen))>0.26).Random()
 		title = Must have an open Docking Port and 25% or less of Life Support Supplies
 	}
 	DATA

--- a/GameData/RP-0/Contracts/Space Stations/New Crew Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/New Crew Station.cfg
@@ -50,9 +50,7 @@ CONTRACT_TYPE
 	{
 		type = Vessel
 		requiredValue = true
-		hidden = true
-		uniquenessCheck = GROUP_ACTIVE
-		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station && v.CrewCount()==0 && v.FreeDockingPorts()>0).SelectUnique()
+		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station && v.CrewCount()==0 && v.FreeDockingPorts()>0).Random()
 		title = Must have a station with no crew on board
 	}
 	DATA

--- a/GameData/RP-0/Contracts/Space Stations/Power Module Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Power Module Station.cfg
@@ -50,9 +50,7 @@ CONTRACT_TYPE
 	{
 		type = Vessel
 		requiredValue = true
-		hidden = true
-		uniquenessCheck = GROUP_ACTIVE
-		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station &&  v.FreeDockingPorts()>0).SelectUnique()
+		targetVessel1 = AllVessels().Where(v => v.VesselType() == Station &&  v.FreeDockingPorts()>0).Random()
 		title = Must have a station 
 	}
 	DATA


### PR DESCRIPTION
Because the "randomness" we get from SelectUnique is very poor
(took ~50 Declines to get NewCrew instead of PowerModule), and
because there doesn't seem to be much harm in allowing them to
be combined