### PR TITLE
Add shared soft cooldowns to all repeatable sat contracts

### DIFF
--- a/GameData/RP-0/Contracts/Advanced Satellites/GEO Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/GEO Communications Satellites.cfg
@@ -26,7 +26,7 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.45) * 75)) * 18.5 * @RP0:globalHardContractMultiplier * @rewardFactor
+	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.37) * 75)) * 13 * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardFunds = @advanceFunds * 1.5
 	rewardScience = 0
 	rewardReputation = Round(1 + (@advanceFunds / 500))

--- a/GameData/RP-0/Contracts/Advanced Satellites/GEO Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/GEO Communications Satellites.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = AdvSatellites
 	agent = Satellites
 
-	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
+	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.&br;<b>Current reward is at @rewardFactorPercent % of it's nominal value. Elapsed/Expected Days: @elapsedDays / @expectedDays<br>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a new Commercial Communications Satellite
@@ -17,8 +17,8 @@ CONTRACT_TYPE
 	cancellable = true
 	declinable = true
 	autoAccept = false
-	minExpiry = 5
-	maxExpiry = 10
+	minExpiry = 1
+	maxExpiry = 1
 	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 365 * RP1DeadlineMult()  // 1 year
@@ -26,7 +26,7 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.45) * 75)) * 18.5 * @RP0:globalHardContractMultiplier
+	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.45) * 75)) * 18.5 * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardFunds = @advanceFunds * 1.5
 	rewardScience = 0
 	rewardReputation = Round(1 + (@advanceFunds / 500))
@@ -64,6 +64,41 @@ CONTRACT_TYPE
 		contractType = TundraRepeatComSats
 		invertRequirement = true
 	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = EarlyComSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = ComTestSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEOWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SecondGenWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SunSyncWeather
+		invertRequirement = true
+	}
 
 	BEHAVIOUR
 	{
@@ -86,13 +121,34 @@ CONTRACT_TYPE
 	{
 		name = IncrementTheCount
 		type = Expression
-		
+
+		CONTRACT_OFFERED
+		{
+			RepeatSat_Completion = ($RepeatSat_Completion + 0) == 0 ? (UniversalTime() - 60 * 86400) : ($RepeatSat_Completion + 0)
+		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			GEORepeatComSats_Count = $GEORepeatComSats_Count + 1
+			RepeatSat_Completion = UniversalTime()
 		}
 	}
-	
+
+	DATA
+	{
+		type = double	// No idea why this type has to be double whereas all other contracts are also happy with int, BUT IT DOES!
+		antiGrindCompletion = $RepeatSat_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $RepeatSat_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 60
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
+	}
+
 	DATA 
 	{
 		type = float

--- a/GameData/RP-0/Contracts/Advanced Satellites/Molniya Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Molniya Communications Satellites.cfg
@@ -26,7 +26,7 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.45) * 75)) * 10 * @RP0:globalHardContractMultiplier * @rewardFactor
+	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.37) * 75)) * 8 * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardFunds = @advanceFunds * 1.5
 	rewardScience = 0
 	rewardReputation = Round(1 + (@advanceFunds / 500))

--- a/GameData/RP-0/Contracts/Advanced Satellites/Molniya Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Molniya Communications Satellites.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = AdvSatellites
 	agent = Satellites
 
-	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
+	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.&br;<b>Current reward is at @rewardFactorPercent % of it's nominal value. Elapsed/Expected Days: @elapsedDays / @expectedDays<br>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a new Commercial Communications Satellite
@@ -17,8 +17,8 @@ CONTRACT_TYPE
 	cancellable = true
 	declinable = true
 	autoAccept = false
-	minExpiry = 5
-	maxExpiry = 10
+	minExpiry = 1
+	maxExpiry = 1
 	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 365 * RP1DeadlineMult()  // 1 year
@@ -26,7 +26,7 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.45) * 75)) * 10 * @RP0:globalHardContractMultiplier
+	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.45) * 75)) * 10 * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardFunds = @advanceFunds * 1.5
 	rewardScience = 0
 	rewardReputation = Round(1 + (@advanceFunds / 500))
@@ -54,6 +54,13 @@ CONTRACT_TYPE
 	{
 		name = AcceptContract
 		type = AcceptContract
+		contractType = TundraRepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
 		contractType = GEORepeatComSats
 		invertRequirement = true
 	}
@@ -61,7 +68,35 @@ CONTRACT_TYPE
 	{
 		name = AcceptContract
 		type = AcceptContract
-		contractType = TundraRepeatComSats
+		contractType = EarlyComSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = ComTestSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEOWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SecondGenWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SunSyncWeather
 		invertRequirement = true
 	}
 
@@ -86,13 +121,34 @@ CONTRACT_TYPE
 	{
 		name = IncrementTheCount
 		type = Expression
-		
+
+		CONTRACT_OFFERED
+		{
+			RepeatSat_Completion = ($RepeatSat_Completion + 0) == 0 ? (UniversalTime() - 60 * 86400) : ($RepeatSat_Completion + 0)
+		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			MolniyaRepeatComSats_Count = $MolniyaRepeatComSats_Count + 1
+			RepeatSat_Completion = UniversalTime()
 		}
 	}
-	
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $RepeatSat_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $RepeatSat_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 60
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
+	}
+
 	DATA
 	{
 		type = float

--- a/GameData/RP-0/Contracts/Advanced Satellites/Tundra Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Tundra Communications Satellites.cfg
@@ -26,7 +26,7 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.45) * 75)) * 11.5 * @RP0:globalHardContractMultiplier * @rewardFactor
+	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.37) * 75)) * 9 * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardFunds = @advanceFunds * 1.5
 	rewardScience = 0
 	rewardReputation = Round(1 + (@advanceFunds / 500))

--- a/GameData/RP-0/Contracts/Advanced Satellites/Tundra Communications Satellites.cfg
+++ b/GameData/RP-0/Contracts/Advanced Satellites/Tundra Communications Satellites.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = AdvSatellites
 	agent = Satellites
 
-	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
+	description = We have a customer requesting a new Communications Satellite. Design a satellite within their specs and launch into an orbit with the proper orbital parameters as outlined in the contract.&br;&br;This contract can be completed as many times as you would like.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.&br;<b>Current reward is at @rewardFactorPercent % of it's nominal value. Elapsed/Expected Days: @elapsedDays / @expectedDays<br>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a new Commercial Communications Satellite
@@ -17,8 +17,8 @@ CONTRACT_TYPE
 	cancellable = true
 	declinable = true
 	autoAccept = false
-	minExpiry = 5
-	maxExpiry = 10
+	minExpiry = 1
+	maxExpiry = 1
 	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 365 * RP1DeadlineMult()  // 1 year
@@ -26,7 +26,7 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.45) * 75)) * 11.5 * @RP0:globalHardContractMultiplier
+	advanceFunds = (750 + (Pow(@AdvComSat/HasComSatPayload/minQuantity, 0.45) * 75)) * 11.5 * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardFunds = @advanceFunds * 1.5
 	rewardScience = 0
 	rewardReputation = Round(1 + (@advanceFunds / 500))
@@ -64,6 +64,41 @@ CONTRACT_TYPE
 		contractType = GEORepeatComSats
 		invertRequirement = true
 	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = EarlyComSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = ComTestSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEOWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SecondGenWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SunSyncWeather
+		invertRequirement = true
+	}
 
 	BEHAVIOUR
 	{
@@ -87,10 +122,31 @@ CONTRACT_TYPE
 		name = IncrementTheCount
 		type = Expression
 		
+		CONTRACT_OFFERED
+		{
+			RepeatSat_Completion = ($RepeatSat_Completion + 0) == 0 ? (UniversalTime() - 60 * 86400) : ($RepeatSat_Completion + 0)
+		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			TundraRepeatComSats_Count = $TundraRepeatComSats_Count + 1
+			RepeatSat_Completion = UniversalTime()
 		}
+	}
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $RepeatSat_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $RepeatSat_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 60
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
 	
 	DATA 

--- a/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Satellite - Early.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = EarlySatellites
 
 
-	description = Now that we have tested out the Communications Satellite Technology, there are many uses we have for these Satellites. We have a customer that is requesting a new satellite. Launch a new communications Satellite into the specified orbit.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b><b><color=white>Removal Condition: Completion of a Commercial Communications Satellite contract</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
+	description = Now that we have tested out the Communications Satellite Technology, there are many uses we have for these Satellites. We have a customer that is requesting a new satellite. Launch a new communications Satellite into the specified orbit.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b><b><color=white>Removal Condition: Completion of a Commercial Communications Satellite contract</color></b>&br;&br;<b>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.&br;<b>Current reward is at @rewardFactorPercent % of it's nominal value. Elapsed/Expected Days: @elapsedDays / @expectedDays<br>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a Communications Satellite for a customer.
@@ -17,8 +17,8 @@ CONTRACT_TYPE
 	cancellable = true
 	declinable = true
 	autoAccept = false
-	minExpiry = 0
-	maxExpiry = 0
+	minExpiry = 1
+	maxExpiry = 1
 	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 180 * RP1DeadlineMult()  // 6 Months
@@ -28,8 +28,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = (5000 + (@EarlyComSat/HasComSatPayload/minQuantity * 5)) * @RP0:globalHardContractMultiplier
-	rewardFunds = (8000 + (Pow(@EarlyComSat/Orbit/minApA, 0.5) * 4) + @EarlyComSat/HasComSatPayload/minQuantity * 15) * @RP0:globalHardContractMultiplier
+	advanceFunds = (5000 + (@EarlyComSat/HasComSatPayload/minQuantity * 5)) * @RP0:globalHardContractMultiplier * @rewardFactor
+	rewardFunds = (8000 + (Pow(@EarlyComSat/Orbit/minApA, 0.5) * 4) + @EarlyComSat/HasComSatPayload/minQuantity * 15) * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardScience = 0
 	rewardReputation = 5
 	failureReputation = 2
@@ -67,6 +67,56 @@ CONTRACT_TYPE
 		invertRequirement = true
 	}
 	
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = MolniyaRepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = TundraRepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEORepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = ComTestSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEOWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SecondGenWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SunSyncWeather
+		invertRequirement = true
+	}
+	
 	DATA
 	{
 		type = int
@@ -77,13 +127,34 @@ CONTRACT_TYPE
 	{
 		name = IncrementTheCount
 		type = Expression
-		
+
+		CONTRACT_OFFERED
+		{
+			RepeatSat_Completion = ($RepeatSat_Completion + 0) == 0 ? (UniversalTime() - 60 * 86400) : ($RepeatSat_Completion + 0)
+		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			EarlyComSat_Count = $EarlyComSat_Count + 1
+			RepeatSat_Completion = UniversalTime()
 		}
 	}
-	
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $RepeatSat_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $RepeatSat_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 60
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
+	}
+
 	DATA 
 	{
 		type = float

--- a/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites/Communications Test Satellite.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = EarlySatellites
 
 
-	description = There are groups that want to understand more about communications with satellites. Launch a new communications test satellite into the proper orbit. &br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Communications Satellite (Early) contract</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
+	description = There are groups that want to understand more about communications with satellites. Launch a new communications test satellite into the proper orbit. &br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Communications Satellite (Early) contract</color></b>&br;&br;<b>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.&br;<b>Current reward is at @rewardFactorPercent % of it's nominal value. Elapsed/Expected Days: @elapsedDays / @expectedDays<br>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a Communications Test Satellite
@@ -17,8 +17,8 @@ CONTRACT_TYPE
 	cancellable = true
 	declinable = true
 	autoAccept = false
-	minExpiry = 0
-	maxExpiry = 0
+	minExpiry = 1
+	maxExpiry = 1
 	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 365 * RP1DeadlineMult()  // 1 year
@@ -28,8 +28,8 @@ CONTRACT_TYPE
 
 	// ************ REWARDS ************
 	prestige = Trivial       // 1.0x
-	advanceFunds = 5000 * @RP0:globalHardContractMultiplier
-	rewardFunds = (5000 + @TestComSat/Orbit/minPeA * 0.006 + @TestComSat/HasComSatPayload/minQuantity * 60) * @RP0:globalHardContractMultiplier
+	advanceFunds = 5000 * @RP0:globalHardContractMultiplier * @rewardFactor
+	rewardFunds = (5000 + @TestComSat/Orbit/minPeA * 0.006 + @TestComSat/HasComSatPayload/minQuantity * 60) * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardScience = 0
 	rewardReputation = 5
 	failureReputation = 2
@@ -51,6 +51,56 @@ CONTRACT_TYPE
 		invertRequirement = true
 	}
 	
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = MolniyaRepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = TundraRepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEORepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = EarlyComSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEOWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SecondGenWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SunSyncWeather
+		invertRequirement = true
+	}
+	
 	DATA
 	{
 		type = int
@@ -61,13 +111,34 @@ CONTRACT_TYPE
 	{
 		name = IncrementTheCount
 		type = Expression
-		
+
+		CONTRACT_OFFERED
+		{
+			RepeatSat_Completion = ($RepeatSat_Completion + 0) == 0 ? (UniversalTime() - 60 * 86400) : ($RepeatSat_Completion + 0)
+		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			ComTestSat_Count = $ComTestSat_Count + 1
+			RepeatSat_Completion = UniversalTime()
 		}
 	}
-	
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $RepeatSat_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $RepeatSat_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 60
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
+	}
+
 	DATA
 	{
 		type = float

--- a/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
@@ -25,7 +25,7 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Significant   // 1.25x
-	advanceFunds = (850 + (Pow(@GEOWeather/HasWeatherSatPayload/minQuantity, 0.45) * 75)) * 14.8 * @RP0:globalHardContractMultiplier * @rewardFactor
+	advanceFunds = (850 + (Pow(@GEOWeather/HasWeatherSatPayload/minQuantity, 0.37) * 75)) * 14 * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardFunds = @advanceFunds * 1.5
 	rewardScience = 0
 	rewardReputation = 15

--- a/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Geostationary Weather Sat.cfg
@@ -4,7 +4,7 @@ CONTRACT_TYPE
 	title = Geostationary Weather Satellite
 	group = WeatherSats
 
-	description = Geostationary satellites provide the best views of the clouds in specific areas for our meteorologists. Place a weather satellite in geostationary orbit near the marked area.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
+	description = Geostationary satellites provide the best views of the clouds in specific areas for our meteorologists. Place a weather satellite in geostationary orbit near the marked area.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.&br;<b>Current reward is at @rewardFactorPercent % of it's nominal value. Elapsed/Expected Days: @elapsedDays / @expectedDays<br>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a geostationary weather satellite to the marked area
@@ -16,8 +16,8 @@ CONTRACT_TYPE
 	cancellable = true
 	declinable = true
 	autoAccept = false
-	minExpiry = 0
-	maxExpiry = 0
+	minExpiry = 1
+	maxExpiry = 1
 	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 365 * RP1DeadlineMult()  // 1 year
@@ -25,7 +25,7 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Significant   // 1.25x
-	advanceFunds = (850 + (Pow(@GEOWeather/HasWeatherSatPayload/minQuantity, 0.45) * 75)) * 14.8 * @RP0:globalHardContractMultiplier
+	advanceFunds = (850 + (Pow(@GEOWeather/HasWeatherSatPayload/minQuantity, 0.45) * 75)) * 14.8 * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardFunds = @advanceFunds * 1.5
 	rewardScience = 0
 	rewardReputation = 15
@@ -48,6 +48,57 @@ CONTRACT_TYPE
 		type = CompleteContract
 		contractType = first_GEOUncrewed
 	}
+	
+	
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = MolniyaRepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = TundraRepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEORepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = EarlyComSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = ComTestSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SecondGenWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SunSyncWeather
+		invertRequirement = true
+	}
 
 	DATA
 	{
@@ -59,11 +110,32 @@ CONTRACT_TYPE
 	{
 		name = IncrementTheCount
 		type = Expression
-		
+
+		CONTRACT_OFFERED
+		{
+			RepeatSat_Completion = ($RepeatSat_Completion + 0) == 0 ? (UniversalTime() - 60 * 86400) : ($RepeatSat_Completion + 0)
+		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			GEOWeather_Count = $GEOWeather_Count + 1
+			RepeatSat_Completion = UniversalTime()
 		}
+	}
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $RepeatSat_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $RepeatSat_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 60
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
 
 	DATA

--- a/GameData/RP-0/Contracts/Weather Sats/Second Gen Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Second Gen Weather Sats.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = WeatherSats
 
 
-	description = Our experience has given us a better understanding of the best orbits to use for weather satellites. Please launch a new weather satellite into the proper orbit that is sun synchronous. Remember that Sun Synchronous orbits are slightly retrograde.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Geostationary Weather Satellite contract.&br;NOTE: You can not select this contract and the Geostationary Weather contract. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
+	description = Our experience has given us a better understanding of the best orbits to use for weather satellites. Please launch a new weather satellite into the proper orbit that is sun synchronous. Remember that Sun Synchronous orbits are slightly retrograde.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b><color=white>Removal Condition: Completion of a Geostationary Weather Satellite contract.&br;NOTE: You can not select this contract and the Geostationary Weather contract. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.&br;<b>Current reward is at @rewardFactorPercent % of it's nominal value. Elapsed/Expected Days: @elapsedDays / @expectedDays<br>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a new weather satellite into the proper orbit
@@ -17,8 +17,8 @@ CONTRACT_TYPE
 	cancellable = true
 	declinable = true
 	autoAccept = false
-	minExpiry = 0
-	maxExpiry = 0
+	minExpiry = 1
+	maxExpiry = 1
 	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 365 * RP1DeadlineMult()  // 1 year
@@ -26,8 +26,8 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Trivial       // 1.0x
-	advanceFunds = 13000 * @RP0:globalHardContractMultiplier
-	rewardFunds = (8000 + @SecondGenWeather/HasWeatherSatPayload/minQuantity * 30) * @RP0:globalHardContractMultiplier
+	advanceFunds = 13000 * @RP0:globalHardContractMultiplier * @rewardFactor
+	rewardFunds = (8000 + @SecondGenWeather/HasWeatherSatPayload/minQuantity * 30) * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardScience = 0
 	rewardReputation = 10
 	failureReputation = 10
@@ -57,6 +57,56 @@ CONTRACT_TYPE
 		invertRequirement = true
 	}
 	
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = MolniyaRepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = TundraRepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEORepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = EarlyComSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = ComTestSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEOWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SunSyncWeather
+		invertRequirement = true
+	}
+	
 	DATA
 	{
 		type = int
@@ -67,13 +117,34 @@ CONTRACT_TYPE
 	{
 		name = IncrementTheCount
 		type = Expression
-		
+
+		CONTRACT_OFFERED
+		{
+			RepeatSat_Completion = ($RepeatSat_Completion + 0) == 0 ? (UniversalTime() - 60 * 86400) : ($RepeatSat_Completion + 0)
+		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			SecondGenWeather_Count = $SecondGenWeather_Count + 1
+			RepeatSat_Completion = UniversalTime()
 		}
 	}
-	
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $RepeatSat_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $RepeatSat_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 60
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
+	}
+
 	DATA
 	{
 		type = float

--- a/GameData/RP-0/Contracts/Weather Sats/Sun Sync Weather Sats.cfg
+++ b/GameData/RP-0/Contracts/Weather Sats/Sun Sync Weather Sats.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = WeatherSats
 
 
-	description = Polar orbiting weather satellites are launched in sun-synchronous orbits that allow them to observe the same area on Earth twice a day with the same general lighting. The images they can return are of much higher resolution than geostationary satellites because their orbit is much lower. Launch a sun-synchronous weather satellite into the proper orbit. Remember that Sun Synchronous orbits are slightly retrograde.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
+	description = Polar orbiting weather satellites are launched in sun-synchronous orbits that allow them to observe the same area on Earth twice a day with the same general lighting. The images they can return are of much higher resolution than geostationary satellites because their orbit is much lower. Launch a sun-synchronous weather satellite into the proper orbit. Remember that Sun Synchronous orbits are slightly retrograde.&br;&br;<b><color=red>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color></b>&br;&br;<b>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.&br;<b>Current reward is at @rewardFactorPercent % of it's nominal value. Elapsed/Expected Days: @elapsedDays / @expectedDays<br>Number of Contracts Completed: @index / unlimited</b>
 	genericDescription = Put a satellite into the requested orbit.
 
 	synopsis = Launch a sun-synchronous weather satellite
@@ -17,8 +17,8 @@ CONTRACT_TYPE
 	cancellable = true
 	declinable = true
 	autoAccept = false
-	minExpiry = 0
-	maxExpiry = 0
+	minExpiry = 1
+	maxExpiry = 1
 	maxCompletions = 0
 	maxSimultaneous = 1
 	deadline = 365 * RP1DeadlineMult()  // 1 year
@@ -26,10 +26,10 @@ CONTRACT_TYPE
 	targetBody = HomeWorld()
 
 	prestige = Significant   // 1.25x
-	advanceFunds = ((8500 * Pow(1 + ((@SunSyncWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.2)) / 2) * @RP0:globalHardContractMultiplier
+	advanceFunds = ((8500 * Pow(1 + ((@SunSyncWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.2)) / 2) * @RP0:globalHardContractMultiplier * @rewardFactor
 	rewardScience = 0
 	rewardReputation = 10
-	rewardFunds = (8500 * Pow(1 + ((@SunSyncWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.2)) * @RP0:globalHardContractMultiplier
+	rewardFunds = (8500 * Pow(1 + ((@SunSyncWeather/HasWeatherSatPayload/minQuantity * 2) / 1000), 1.2)) * @RP0:globalHardContractMultiplier * @rewardFactor
 	failureReputation = 10
 	failureFunds = @advanceFunds * 0.5
 
@@ -48,6 +48,56 @@ CONTRACT_TYPE
 		name = CompleteContract
 		type = CompleteContract
 		contractType = FirstSunSyncSat
+	}
+	
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = MolniyaRepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = TundraRepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEORepeatComSats
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = EarlyComSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = ComTestSat
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = GEOWeather
+		invertRequirement = true
+	}
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = SecondGenWeather
+		invertRequirement = true
 	}
 	
 	BEHAVIOUR
@@ -81,11 +131,32 @@ CONTRACT_TYPE
 	{
 		name = IncrementTheCount
 		type = Expression
-		
+
+		CONTRACT_OFFERED
+		{
+			RepeatSat_Completion = ($RepeatSat_Completion + 0) == 0 ? (UniversalTime() - 60 * 86400) : ($RepeatSat_Completion + 0)
+		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			SunSyncWeather_Count = $SunSyncWeather_Count + 1
+			RepeatSat_Completion = UniversalTime()
 		}
+	}
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $RepeatSat_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $RepeatSat_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 60
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
 
 	DATA


### PR DESCRIPTION
This also allows the payload-based-rewards to scale up more slowly since completing contracts more often than every 60 days doesn't pay off.