### PR TITLE
(text) Change text of the suborbital return contract

### DIFF
--- a/GameData/RP-0/Contracts/Milestones/Suborbital Return.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Suborbital Return.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = Milestones
 	agent = Federation Aeronautique Internationale
 		
-	description = As early as 1947, the U.S. was launching into and recovering fruit flies from space on suborbital trajectories, but it wasn't until 1951 that a monkey named Yorick and eleven mice were successfully recovered from an Aerobee flight. The Soviets preferred dogs and returned many from suborbital flights, the first two being Dezik and Tsygan in 1951 on top of an R-1. Although it is not a requirement to launch a biological capsule for this mission, it is a perfect opportunity to do so. Send a rocket out of the atmosphere (140km) and return at least some of the craft back to Earth, intact, for study.
+	description = As early as 1947 the U.S. was launching fruit flies into space on suborbital trajectories and recovering them, but it wasn't until 1951 that a monkey named Yorick and eleven mice were successfully recovered from an Aerobee flight. The Soviets preferred dogs and returned many from suborbital flights, the first two being Dezik and Tsygan in 1951 on top of an R-1. Although it is not a requirement to launch a biological capsule for this mission, it is a perfect opportunity to do so. Send a rocket out of the atmosphere (140km) and return at least some of the craft back to Earth, intact, for study.
 		
 	synopsis = Return a suborbital spacecraft safely to Earth
 		

--- a/GameData/RP-0/Contracts/Milestones/Suborbital Return.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Suborbital Return.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = Milestones
 	agent = Federation Aeronautique Internationale
 		
-	description = As early as 1947 the U.S. was launching into and recovering fruit flies from space on suborbital trajectories but it wasn't until 1951 that a monkey named Yorick and eleven mice were successfully recovered from an Aerobee flight. The Soviets preferred dogs and returned many from suborbital flights, the first two being Dezik and Tsygan in 1951 on top of an R-1. Although it is not a requirement to launch a biological capsule for this mission it is a perfect opportunity to do so. Send a rocket out of the atmosphere (140km) and return at least some of the craft back to Earth, intact, for study.
+	description = As early as 1947, the U.S. was launching into and recovering fruit flies from space on suborbital trajectories, but it wasn't until 1951 that a monkey named Yorick and eleven mice were successfully recovered from an Aerobee flight. The Soviets preferred dogs and returned many from suborbital flights, the first two being Dezik and Tsygan in 1951 on top of an R-1. Although it is not a requirement to launch a biological capsule for this mission, it is a perfect opportunity to do so. Send a rocket out of the atmosphere (140km) and return at least some of the craft back to Earth, intact, for study.
 		
 	synopsis = Return a suborbital spacecraft safely to Earth
 		


### PR DESCRIPTION
Added three commas in the suborbital return contract description. Certain about the last one ("Although ..., ... "), but not sure about the first and second ones ("As early as 1947, ...", "... trajectories, but ..."). I think it doesn't hurt, though.