### PR TITLE
Give soft cooldowns to 'Experimental rocketplanes' and make it unavailable after either XPH is completed

### DIFF
--- a/GameData/RP-0/Contracts/X-Planes/RocketPlaneDevelopment.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/RocketPlaneDevelopment.cfg
@@ -2,36 +2,36 @@ CONTRACT_TYPE
 {
 	name = RocketPlaneDevelopment
 	group = X-Planes
-	
+
 	title = Experimental rocketplanes
-	
-	description = Design, build and launch a crewed rocketplane to achieve an altitude of @/altitudeKm km, a velocity of @/velocity m/s and return home safely.<br>This is a series of 4 contracts, of which $RocketPlaneDevelopment_Count have been completed.<br> <color=white><b>After 2 completions, X-Planes High contract will become available</b></color>.
+
+	description = Design, build and launch a crewed rocketplane to achieve an altitude of @/altitudeKm km, a velocity of @/velocity m/s and return home safely.<br>The reward of this contract will slowly increase over time but will be reset to 0 after each completion.&br;<b>Current reward is at @rewardFactorPercent % of its nominal value. Elapsed/Expected Days: @elapsedDays / @expectedDays</b><br>This is a series of 4 contracts, of which $RocketPlaneDevelopment_Count have been completed.<br><color=white><b>After 2 completions, X-Planes High contract will become available.</b></color>&br;&br;<b><color="red">This contract will no longer be offered once you complete 'X-Planes High' or 'X-Planes High (Difficult)'!</color></b>
 	genericDescription = Design, build and launch a crewed rocketplane to achieve a combination of altitude + velocity and return home safely.
-	
+
 	synopsis = Launch a crewed vessel to @/altitudeKm km.
-	
+
 	completedMessage = Congratulations on a successful flight!
-	
+
 	minExpiry = 1.0
 	maxExpiry = 30.0
 	deadline = 365 * RP1DeadlineMult()  // 1 year
 	cancellable = true
 	declinable = true
 	autoAccept = false
-	
+
 	targetBody = HomeWorld()
-	
+
 	maxCompletions = 4
 	maxSimultaneous = 1
 	prestige = Trivial
-	
+
 	// reward block
-	advanceFunds = (1750.0 + @VesselGroup/ReachAlt/minAltitude*0.04) * @RP0:globalHardContractMultiplier
+	advanceFunds = Round((1750.0 + @VesselGroup/ReachAlt/minAltitude*0.04) * @RP0:globalHardContractMultiplier * @rewardFactor, 100)
 	rewardFunds = @advanceFunds
 	failureFunds = @advanceFunds * 0.5
 	rewardReputation = 2
 	failureReputation = 2
-	
+
 	REQUIREMENT
 	{
 		name = BreakSoundBarrier
@@ -65,24 +65,58 @@ CONTRACT_TYPE
 
 	REQUIREMENT
 	{
-		name = CompleteContract
+		name = NotCompletedXPH
+		type = CompleteContract
+		contractType = CrewedReachSpace
+		invertRequirement = true
+	}
+
+	REQUIREMENT
+	{
+		name = NotCompletedXPHD
+		type = CompleteContract
+		contractType = CrewedReachSpaceDifficult
+		invertRequirement = true
+	}
+
+	REQUIREMENT
+	{
+		name = NotCompletedCrewedFO
 		type = CompleteContract
 		contractType = first_OrbitCrewed
 		invertRequirement = true
 	}
 
-	BEHAVIOUR 
+	BEHAVIOUR
 	{
 		name = IncrementTheCount
 		type = Expression
 		CONTRACT_OFFERED
 		{
 			RocketPlaneDevelopment_Count = $RocketPlaneDevelopment_Count + 0
+			RPD_Completion = ($RPD_Completion + 0) == 0 ? (UniversalTime() - 120 * 86400) : ($RPD_Completion + 0)
 		}
 		CONTRACT_COMPLETED_SUCCESS
 		{
 			RocketPlaneDevelopment_Count = $RocketPlaneDevelopment_Count + 1
+			RPD_Completion = UniversalTime()
 		}
+	}
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $RPD_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $RPD_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 120
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 3 - 0.05, 1), 2) / 1.5607
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
 
 	DATA
@@ -96,8 +130,8 @@ CONTRACT_TYPE
 		type = List<float>
 		velocities = [ 320, 400, 550, 700 ]
 	}
-		
-	DATA 
+
+	DATA
 	{
 		type = int
 		index = $RocketPlaneDevelopment_Count
@@ -109,7 +143,7 @@ CONTRACT_TYPE
 		altitudeKm = @altitudesKm.ElementAt(@index)
 	}
 
-	DATA 
+	DATA
 	{
 		type = float
 		velocity = @velocities.ElementAt(@index)


### PR DESCRIPTION
Being able to complete all 4 in a quick succession with basically the same plane doesn't make much sense. Same goes for coming back to this contract after having done an XPH or 2. Now the player has a choice of waiting and completing all 4 or jumping to XPH after 2 have been completed. 