### PR TITLE
Add VesselModule for tracking vessels built in KCT

### DIFF
--- a/Source/KerbalConstructionTime/GUI/GUI_BuildList.cs
+++ b/Source/KerbalConstructionTime/GUI/GUI_BuildList.cs
@@ -607,7 +607,8 @@ namespace KerbalConstructionTime
             GUILayout.Label(_rocketTexture, GUILayout.ExpandWidth(false));
             GUILayout.Label("VAB Storage");
             GUILayout.EndHorizontal();
-            if (Utilities.IsVabRecoveryAvailable() && GUILayout.Button("Recover Active Vessel To VAB"))
+            if (HighLogic.LoadedSceneIsFlight && Utilities.IsVabRecoveryAvailable(FlightGlobals.ActiveVessel) &&
+                GUILayout.Button("Recover Active Vessel To VAB"))
             {
                 if (!Utilities.RecoverActiveVesselToStorage(BuildListVessel.ListType.VAB))
                 {
@@ -868,7 +869,8 @@ namespace KerbalConstructionTime
             GUILayout.Label(_planeTexture, GUILayout.ExpandWidth(false));
             GUILayout.Label("SPH Storage");
             GUILayout.EndHorizontal();
-            if (Utilities.IsSphRecoveryAvailable() && GUILayout.Button("Recover Active Vessel To SPH"))
+            if (HighLogic.LoadedSceneIsFlight && Utilities.IsSphRecoveryAvailable(FlightGlobals.ActiveVessel) &&
+                GUILayout.Button("Recover Active Vessel To SPH"))
             {
                 if (!Utilities.RecoverActiveVesselToStorage(BuildListVessel.ListType.SPH))
                 {

--- a/Source/KerbalConstructionTime/KCTVesselTracker.cs
+++ b/Source/KerbalConstructionTime/KCTVesselTracker.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace KerbalConstructionTime
+{
+    /// <summary>
+    /// A VesselModule for keeping persistent vessel data across decouplings, dockings, recoveries and edits inside the VAB/SPH.
+    /// </summary>
+    public class KCTVesselTracker : VesselModule
+    {
+        private static bool _isBoundToEvents = false;
+        private static bool _isDockingInProgress = false;
+        private static bool _isUnDockingInProgress = false;
+
+        public KCTVesselData Data = new KCTVesselData();
+        public Dictionary<uint, KCTVesselData> DockedVesselData;
+
+        protected override void OnAwake()
+        {
+            base.OnAwake();
+
+            if (!_isBoundToEvents)
+            {
+                GameEvents.onPartDeCoupleNewVesselComplete.Add(OnPartDeCoupleNewVesselComplete);
+                GameEvents.onPartCouple.Add(OnPartCouple);
+                GameEvents.onPartUndock.Add(OnPartUndock);
+                GameEvents.onVesselDocking.Add(OnVesselDocking);
+                GameEvents.onVesselsUndocking.Add(OnVesselsUndocking);
+                _isBoundToEvents = true;
+            }
+        }
+
+        protected override void OnStart()
+        {
+            base.OnStart();
+
+            if (Data.VesselID == string.Empty)
+            {
+                Data.VesselID = Guid.NewGuid().ToString("N");
+            }
+        }
+
+        protected override void OnLoad(ConfigNode node)
+        {
+            base.OnLoad(node);
+
+            foreach (ConfigNode n in node.GetNodes("DATA"))
+            {
+                Data.Load(n);
+            }
+
+            foreach (ConfigNode n in node.GetNodes("DOCKED_DATA"))
+            {
+                uint launchID = default;
+                if (!n.TryGetValue("launchID", ref launchID)) continue;
+
+                DockedVesselData = DockedVesselData ?? new Dictionary<uint, KCTVesselData>();
+                DockedVesselData[launchID] = new KCTVesselData(n);
+            }
+        }
+
+        protected override void OnSave(ConfigNode node)
+        {
+            base.OnSave(node);
+
+            var n = node.AddNode("DATA");
+            Data.Save(n);
+
+            if (DockedVesselData != null)
+            {
+                foreach (KeyValuePair<uint, KCTVesselData> kvp in DockedVesselData)
+                {
+                    var dn = node.AddNode("DOCKED_DATA");
+                    kvp.Value.Save(dn);
+                    dn.AddValue("launchID", kvp.Key);
+                }
+            }
+        }
+
+        private void OnPartUndock(Part data)
+        {
+            _isUnDockingInProgress = true;
+            KerbalConstructionTime.Instance.StartCoroutine(ResetUnDockingInProgress());
+        }
+
+        private void OnVesselDocking(uint persistentId1, uint persistentId2)
+        {
+            _isDockingInProgress = true;
+            KerbalConstructionTime.Instance.StartCoroutine(ResetDockingInProgress());
+        }
+
+        private IEnumerator ResetUnDockingInProgress()
+        {
+            yield return new WaitForEndOfFrame();
+            _isUnDockingInProgress = false;
+        }
+
+        private IEnumerator ResetDockingInProgress()
+        {
+            yield return new WaitForEndOfFrame();
+            _isDockingInProgress = false;
+        }
+
+        private void OnPartCouple(GameEvents.FromToAction<Part, Part> data)
+        {
+            if (_isDockingInProgress)
+            {
+                var vm1 = (KCTVesselTracker)data.from.vessel.vesselModules.Find(vm => vm is KCTVesselTracker);
+                var vm2 = (KCTVesselTracker)data.to.vessel.vesselModules.Find(vm => vm is KCTVesselTracker);
+
+                uint id1 = data.from.vessel.rootPart.launchID;
+                uint id2 = data.to.vessel.rootPart.launchID;
+
+                var dict1 = vm1.DockedVesselData ?? new Dictionary<uint, KCTVesselData>() { { id1, KCTVesselData.Parse(vm1) } };
+                var dict2 = vm2.DockedVesselData ?? new Dictionary<uint, KCTVesselData>() { { id2, KCTVesselData.Parse(vm2) } };
+                var combinedDict = new[] { dict1, dict2 }.SelectMany(dict => dict)
+                         .ToLookup(pair => pair.Key, pair => pair.Value)
+                         .ToDictionary(group => group.Key, group => group.First());
+
+                vm1.DockedVesselData = vm2.DockedVesselData = combinedDict;
+            }
+        }
+
+        private void OnVesselsUndocking(Vessel oldVessel, Vessel newVessel)
+        {
+            if (_isUnDockingInProgress)
+            {
+                var vm1 = (KCTVesselTracker)oldVessel.vesselModules.Find(vm => vm is KCTVesselTracker);
+                if (!vm1?.DockedVesselData?.Any() ?? false) return;
+
+                var vm2 = (KCTVesselTracker)newVessel.vesselModules.Find(vm => vm is KCTVesselTracker);
+                var dict1 = vm1.DockedVesselData;
+                var dict2 = new Dictionary<uint, KCTVesselData>(dict1);
+
+                CleanAndAssignDockedVesselData(vm1, dict1);
+                CleanAndAssignDockedVesselData(vm2, dict2);
+            }
+        }
+
+        /// <summary>
+        /// Removes all entries from the dictionary where no corresponding part with the same launchId is found on the vessel.
+        /// After the cleaning process, dictionary will be assigned to vesselModule.
+        /// </summary>
+        /// <param name="vm">Tracking VesselModule</param>
+        /// <param name="dict">Docking history dictionary to clean and assign to vm</param>
+        private void CleanAndAssignDockedVesselData(KCTVesselTracker vm, Dictionary<uint, KCTVesselData> dict)
+        {
+            uint rootPartLaunchId = vm.Vessel.rootPart.launchID;
+            uint[] keys = dict.Keys.ToArray();
+            foreach (uint launchId in keys)
+            {
+                if (launchId == rootPartLaunchId) continue;
+                if (!vm.Vessel.Parts.Any(p => p.launchID == launchId))
+                {
+                    dict.Remove(launchId);
+                }
+            }
+
+            if (dict.Count == 1) dict = null;    // Only has data for the current vessel so no need to keep history
+            vm.DockedVesselData = dict;
+        }
+
+        private void OnPartDeCoupleNewVesselComplete(Vessel v1, Vessel v2)
+        {
+            var vm1 = (KCTVesselTracker)v1.vesselModules.Find(vm => vm is KCTVesselTracker);
+            var vm2 = (KCTVesselTracker)v2.vesselModules.Find(vm => vm is KCTVesselTracker);
+
+            if (vm1 != null && vm2 != null)
+            {
+                vm2.Data.VesselID = vm1.Data.VesselID;
+                vm2.Data.FacilityBuiltIn = vm1.Data.FacilityBuiltIn;
+            }
+         }
+    }
+}

--- a/Source/KerbalConstructionTime/KerbalConstructionTime.cs
+++ b/Source/KerbalConstructionTime/KerbalConstructionTime.cs
@@ -211,87 +211,104 @@ namespace KerbalConstructionTime
                     KCTGameStates.ClearVesselEditMode();
                     break;
                 case GameScenes.FLIGHT:
-                    if (!KCTGameStates.IsSimulatedFlight &&
-                        FlightGlobals.ActiveVessel.situation == Vessel.Situations.PRELAUNCH &&
-                        FlightGlobals.ActiveVessel.GetCrewCount() == 0 && KCTGameStates.LaunchedCrew.Count > 0)
-                    {
-                        KerbalRoster roster = HighLogic.CurrentGame.CrewRoster;
-                        foreach (Part p in FlightGlobals.ActiveVessel.parts)
-                        {
-                            KCTDebug.Log("Part being tested: " + p.partInfo.title);
-                            if (!(KCTGameStates.LaunchedCrew.Find(part => part.PartID == p.craftID) is CrewedPart cp))
-                                continue;
-                            List<ProtoCrewMember> crewList = cp.CrewList;
-                            KCTDebug.Log("cP.crewList.Count: " + cp.CrewList.Count);
-                            foreach (ProtoCrewMember crewMember in crewList)
-                            {
-                                if (crewMember != null)     // Can this list can have null ProtoCrewMembers?
-                                {
-                                    ProtoCrewMember finalCrewMember = crewMember;
-                                    if (crewMember.type == ProtoCrewMember.KerbalType.Crew)
-                                    {
-                                        finalCrewMember = roster.Crew.FirstOrDefault(c => c.name == crewMember.name);
-                                    }
-                                    else if (crewMember.type == ProtoCrewMember.KerbalType.Tourist)
-                                    {
-                                        finalCrewMember = roster.Tourist.FirstOrDefault(c => c.name == crewMember.name);
-                                    }
-                                    try
-                                    {
-                                        if (finalCrewMember is ProtoCrewMember && p.AddCrewmember(finalCrewMember))
-                                        {
-                                            KCTDebug.Log($"Assigned {finalCrewMember.name } to {p.partInfo.name}");
-                                            finalCrewMember.rosterStatus = ProtoCrewMember.RosterStatus.Assigned;
-                                            finalCrewMember.seat?.SpawnCrew();
-                                        } else
-                                        {
-                                            KCTDebug.LogError($"Error when assigning {crewMember.name} to {p.partInfo.name}");
-                                            finalCrewMember.rosterStatus = ProtoCrewMember.RosterStatus.Available;
-                                        }
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        KCTDebug.LogError($"Error when assigning {crewMember.name} to {p.partInfo.name}: {ex}");
-                                        finalCrewMember.rosterStatus = ProtoCrewMember.RosterStatus.Available;
-                                    }
-                                }
-                            }
-                        }
-                        KCTGameStates.LaunchedCrew.Clear();
-                    }
-
                     KCT_GUI.HideAll();
-                    if (!KCTGameStates.IsSimulatedFlight && KCTGameStates.LaunchedVessel != null && FlightGlobals.ActiveVessel?.situation == Vessel.Situations.PRELAUNCH)
-                    {
-                        KCTGameStates.LaunchedVessel.KSC = null; //it's invalid now
-                        KCTDebug.Log("Attempting to remove launched vessel from build list");
-                        if (KCTGameStates.LaunchedVessel.RemoveFromBuildList()) //Only do these when the vessel is first removed from the list
-                        {
-                            //Add the cost of the ship to the funds so it can be removed again by KSP
-                            Utilities.AddFunds(KCTGameStates.LaunchedVessel.Cost, TransactionReasons.VesselRollout);
-                            FlightGlobals.ActiveVessel.vesselName = KCTGameStates.LaunchedVessel.ShipName;
-                        }
-
-                        if (KCTGameStates.ActiveKSC.Recon_Rollout.FirstOrDefault(r => r.AssociatedID == KCTGameStates.LaunchedVessel.Id.ToString()) is ReconRollout rollout)
-                            KCTGameStates.ActiveKSC.Recon_Rollout.Remove(rollout);
-
-                        if (KCTGameStates.ActiveKSC.AirlaunchPrep.FirstOrDefault(r => r.AssociatedID == KCTGameStates.LaunchedVessel.Id.ToString()) is AirlaunchPrep alPrep)
-                            KCTGameStates.ActiveKSC.AirlaunchPrep.Remove(alPrep);
-
-                        if (KCTGameStates.AirlaunchParams is AirlaunchParams alParams && alParams.KCTVesselId == KCTGameStates.LaunchedVessel.Id &&
-                            (!alParams.KSPVesselId.HasValue || alParams.KSPVesselId == FlightGlobals.ActiveVessel.id))
-                        {
-                            if (!alParams.KSPVesselId.HasValue) alParams.KSPVesselId = FlightGlobals.ActiveVessel.id;
-                            StartCoroutine(AirlaunchRoutine(alParams, FlightGlobals.ActiveVessel.id));
-                        }
-                    }
+                    ProcessFlightStart();
                     break;
             }
             KCTDebug.Log("Start finished");
 
             DelayedStart();
 
+            UpdateTechlistIconColor();
             StartCoroutine(HandleEditorButton_Coroutine());
+        }
+
+        private void ProcessFlightStart()
+        {
+            if (FlightGlobals.ActiveVessel == null || FlightGlobals.ActiveVessel.situation != Vessel.Situations.PRELAUNCH || KCT_GUI.IsPrimarilyDisabled) return;
+
+            if (!KCTGameStates.IsSimulatedFlight &&
+                FlightGlobals.ActiveVessel.GetCrewCount() == 0 && KCTGameStates.LaunchedCrew.Count > 0)
+            {
+                KerbalRoster roster = HighLogic.CurrentGame.CrewRoster;
+                foreach (Part p in FlightGlobals.ActiveVessel.parts)
+                {
+                    KCTDebug.Log("Part being tested: " + p.partInfo.title);
+                    if (!(KCTGameStates.LaunchedCrew.Find(part => part.PartID == p.craftID) is CrewedPart cp))
+                        continue;
+                    List<ProtoCrewMember> crewList = cp.CrewList;
+                    KCTDebug.Log("cP.crewList.Count: " + cp.CrewList.Count);
+                    foreach (ProtoCrewMember crewMember in crewList)
+                    {
+                        if (crewMember != null)     // Can this list can have null ProtoCrewMembers?
+                        {
+                            ProtoCrewMember finalCrewMember = crewMember;
+                            if (crewMember.type == ProtoCrewMember.KerbalType.Crew)
+                            {
+                                finalCrewMember = roster.Crew.FirstOrDefault(c => c.name == crewMember.name);
+                            }
+                            else if (crewMember.type == ProtoCrewMember.KerbalType.Tourist)
+                            {
+                                finalCrewMember = roster.Tourist.FirstOrDefault(c => c.name == crewMember.name);
+                            }
+                            try
+                            {
+                                if (finalCrewMember is ProtoCrewMember && p.AddCrewmember(finalCrewMember))
+                                {
+                                    KCTDebug.Log($"Assigned {finalCrewMember.name } to {p.partInfo.name}");
+                                    finalCrewMember.rosterStatus = ProtoCrewMember.RosterStatus.Assigned;
+                                    finalCrewMember.seat?.SpawnCrew();
+                                }
+                                else
+                                {
+                                    KCTDebug.LogError($"Error when assigning {crewMember.name} to {p.partInfo.name}");
+                                    finalCrewMember.rosterStatus = ProtoCrewMember.RosterStatus.Available;
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                KCTDebug.LogError($"Error when assigning {crewMember.name} to {p.partInfo.name}: {ex}");
+                                finalCrewMember.rosterStatus = ProtoCrewMember.RosterStatus.Available;
+                            }
+                        }
+                    }
+                }
+                KCTGameStates.LaunchedCrew.Clear();
+            }
+
+            if (KCTGameStates.LaunchedVessel == null) return;
+
+            var dataModule = (KCTVesselTracker)FlightGlobals.ActiveVessel.vesselModules.Find(vm => vm is KCTVesselTracker);
+            if (dataModule != null)
+            {
+                dataModule.Data.FacilityBuiltIn = KCTGameStates.LaunchedVessel.FacilityBuiltIn;
+                dataModule.Data.VesselID = KCTGameStates.LaunchedVessel.KCTPersistentID;
+            }
+
+            if (!KCTGameStates.IsSimulatedFlight)
+            {
+                KCTGameStates.LaunchedVessel.KSC = null; //it's invalid now
+                KCTDebug.Log("Attempting to remove launched vessel from build list");
+                if (KCTGameStates.LaunchedVessel.RemoveFromBuildList()) //Only do these when the vessel is first removed from the list
+                {
+                    //Add the cost of the ship to the funds so it can be removed again by KSP
+                    Utilities.AddFunds(KCTGameStates.LaunchedVessel.Cost, TransactionReasons.VesselRollout);
+                    FlightGlobals.ActiveVessel.vesselName = KCTGameStates.LaunchedVessel.ShipName;
+                }
+
+                if (KCTGameStates.ActiveKSC.Recon_Rollout.FirstOrDefault(r => r.AssociatedID == KCTGameStates.LaunchedVessel.Id.ToString()) is ReconRollout rollout)
+                    KCTGameStates.ActiveKSC.Recon_Rollout.Remove(rollout);
+
+                if (KCTGameStates.ActiveKSC.AirlaunchPrep.FirstOrDefault(r => r.AssociatedID == KCTGameStates.LaunchedVessel.Id.ToString()) is AirlaunchPrep alPrep)
+                    KCTGameStates.ActiveKSC.AirlaunchPrep.Remove(alPrep);
+
+                if (KCTGameStates.AirlaunchParams is AirlaunchParams alParams && alParams.KCTVesselId == KCTGameStates.LaunchedVessel.Id &&
+                    (!alParams.KSPVesselId.HasValue || alParams.KSPVesselId == FlightGlobals.ActiveVessel.id))
+                {
+                    if (!alParams.KSPVesselId.HasValue) alParams.KSPVesselId = FlightGlobals.ActiveVessel.id;
+                    StartCoroutine(AirlaunchRoutine(alParams, FlightGlobals.ActiveVessel.id));
+                }
+            }
         }
 
         internal IEnumerator AirlaunchRoutine(AirlaunchParams launchParams, Guid vesselId, bool skipCountdown = false)

--- a/Source/KerbalConstructionTime/KerbalConstructionTime.csproj
+++ b/Source/KerbalConstructionTime/KerbalConstructionTime.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Persistence\ConfigNodeStorage.cs" />
     <Compile Include="Persistence\FacilityUpgradeStorageItem.cs" />
     <Compile Include="Persistence\GUIPosition.cs" />
+    <Compile Include="Persistence\KCTVesselData.cs" />
     <Compile Include="Persistence\ReconRolloutStorageItem.cs" />
     <Compile Include="KCTObservableList.cs" />
     <Compile Include="SceneAddons\MainMenuAddon.cs" />
@@ -163,6 +164,7 @@
     <Compile Include="Utilities\TextureScale.cs" />
     <Compile Include="ModIntegrations\ToolbarRegistration.cs" />
     <Compile Include="Utilities\TypeExtensions.cs" />
+    <Compile Include="KCTVesselTracker.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />

--- a/Source/KerbalConstructionTime/Persistence/BuildListStorageItem.cs
+++ b/Source/KerbalConstructionTime/Persistence/BuildListStorageItem.cs
@@ -29,6 +29,10 @@ namespace KerbalConstructionTime
         int BuildListIndex = -1;
         [Persistent]
         List<string> desiredManifest = new List<string>();
+        [Persistent]
+        string KCTPersistentID;
+        [Persistent]
+        EditorFacility FacilityBuiltIn;
 
         public BuildListVessel ToBuildListVessel()
         {
@@ -45,7 +49,9 @@ namespace KerbalConstructionTime
                 RushBuildClicks = rushBuildClicks,
                 LaunchSiteID = LaunchPadID,
                 BuildListIndex = BuildListIndex,
-                DesiredManifest = desiredManifest
+                DesiredManifest = desiredManifest,
+                KCTPersistentID = KCTPersistentID,
+                FacilityBuiltIn = FacilityBuiltIn
             };
             return ret;
         }
@@ -73,6 +79,8 @@ namespace KerbalConstructionTime
             BuildListIndex = blv.BuildListIndex;
             LaunchPadID = blv.LaunchSiteID;
             desiredManifest = blv.DesiredManifest;
+            KCTPersistentID = blv.KCTPersistentID;
+            FacilityBuiltIn = blv.FacilityBuiltIn;
             return this;
         }
     }

--- a/Source/KerbalConstructionTime/Persistence/KCTVesselData.cs
+++ b/Source/KerbalConstructionTime/Persistence/KCTVesselData.cs
@@ -1,0 +1,39 @@
+﻿namespace KerbalConstructionTime
+{
+    public class KCTVesselData : IConfigNode
+    {
+        [Persistent]
+        public EditorFacility FacilityBuiltIn;
+
+        [Persistent]
+        public string VesselID = string.Empty;
+
+        public static KCTVesselData Parse(KCTVesselTracker d)
+        {
+            return new KCTVesselData
+            {
+                FacilityBuiltIn = d.Data.FacilityBuiltIn,
+                VesselID = d.Data.VesselID
+            };
+        }
+
+        public KCTVesselData()
+        {
+        }
+
+        public KCTVesselData(ConfigNode n)
+        {
+            Load(n);
+        }
+
+        public void Load(ConfigNode node)
+        {
+            ConfigNode.LoadObjectFromConfig(this, node);
+        }
+
+        public void Save(ConfigNode node)
+        {
+            ConfigNode.CreateConfigFromObject(this, node);
+        }
+    }
+}

--- a/Source/KerbalConstructionTime/SceneAddons/FlightAddon.cs
+++ b/Source/KerbalConstructionTime/SceneAddons/FlightAddon.cs
@@ -54,15 +54,14 @@ namespace KerbalConstructionTime
                 return;
             }
 
-            bool isSPH = FlightGlobals.ActiveVessel?.IsRecoverable == true && 
-                         FlightGlobals.ActiveVessel.IsClearToSave() == ClearToSaveStatus.CLEAR;
-            bool isVAB = Utilities.IsVabRecoveryAvailable();
+            bool isSPHAllowed = Utilities.IsSphRecoveryAvailable(FlightGlobals.ActiveVessel);
+            bool isVABAllowed = Utilities.IsVabRecoveryAvailable(FlightGlobals.ActiveVessel);
             var options = new List<DialogGUIBase>();
             if (!FlightGlobals.ActiveVessel.isEVA)
             {
-                if (isSPH)
+                if (isSPHAllowed)
                     options.Add(new DialogGUIButton("Recover to SPH", RecoverToSPH));
-                if (isVAB)
+                if (isVABAllowed)
                     options.Add(new DialogGUIButton("Recover to VAB", RecoverToVAB));
                 options.Add(new DialogGUIButton("Normal recovery", DoNormalRecovery));
             }

--- a/Source/KerbalConstructionTime/SceneAddons/TrackingStationAddon.cs
+++ b/Source/KerbalConstructionTime/SceneAddons/TrackingStationAddon.cs
@@ -60,25 +60,16 @@ namespace KerbalConstructionTime
         public void NewRecoveryFunctionTrackingStation()
         {
             if (!(FindObjectOfType(typeof(SpaceTracking)) is SpaceTracking ts
-                && ts.SelectedVessel is Vessel _selectedVessel))
+                && ts.SelectedVessel is Vessel selectedVessel))
             {
                 Debug.LogError("[KCT] No Vessel selected.");
                 return;
             }
 
-            bool canRecoverToSPH = _selectedVessel.IsRecoverable && _selectedVessel.IsClearToSave() == ClearToSaveStatus.CLEAR;
-
-            string reqTech = PresetManager.Instance.ActivePreset.GeneralSettings.VABRecoveryTech;
-            bool canRecoverToVAB = _selectedVessel.IsRecoverable &&
-                                   _selectedVessel.IsClearToSave() == ClearToSaveStatus.CLEAR &&
-                                   (_selectedVessel.situation == Vessel.Situations.PRELAUNCH ||
-                                    string.IsNullOrEmpty(reqTech) ||
-                                    ResearchAndDevelopment.GetTechnologyState(reqTech) == RDTech.State.Available);
-
             var options = new List<DialogGUIBase>();
-            if (canRecoverToSPH)
+            if (Utilities.IsSphRecoveryAvailable(selectedVessel))
                 options.Add(new DialogGUIButton("Recover to SPH", RecoverToSPH));
-            if (canRecoverToVAB)
+            if (Utilities.IsVabRecoveryAvailable(selectedVessel))
                 options.Add(new DialogGUIButton("Recover to VAB", RecoverToVAB));
             options.Add(new DialogGUIButton("Normal recovery", DoNormalRecovery));
             options.Add(new DialogGUIButton("Cancel", () => { }));

--- a/Source/KerbalConstructionTime/Utilities/Utilities.cs
+++ b/Source/KerbalConstructionTime/Utilities/Utilities.cs
@@ -1932,22 +1932,25 @@ namespace KerbalConstructionTime
             return v.GetKCTVesselData()?.VesselID;
         }
 
-        public static bool IsVabRecoveryAvailable()
+        public static EditorFacility? GetVesselBuiltAt(this Vessel v)
+        {
+            return v.GetKCTVesselData()?.FacilityBuiltIn;
+        }
+
+        public static bool IsVabRecoveryAvailable(Vessel v)
         {
             string reqTech = PresetManager.Instance.ActivePreset.GeneralSettings.VABRecoveryTech;
-            return HighLogic.LoadedSceneIsFlight && FlightGlobals.ActiveVessel != null &&
-                   FlightGlobals.ActiveVessel.IsRecoverable &&
-                   FlightGlobals.ActiveVessel.IsClearToSave() == ClearToSaveStatus.CLEAR &&
-                   (FlightGlobals.ActiveVessel.situation == Vessel.Situations.PRELAUNCH ||
+            return v != null && v.IsRecoverable && v.IsClearToSave() == ClearToSaveStatus.CLEAR &&
+                   v.GetVesselBuiltAt() != EditorFacility.SPH &&
+                   (v.situation == Vessel.Situations.PRELAUNCH ||
                     string.IsNullOrEmpty(reqTech) ||
                     ResearchAndDevelopment.GetTechnologyState(reqTech) == RDTech.State.Available);
         }
 
-        public static bool IsSphRecoveryAvailable()
+        public static bool IsSphRecoveryAvailable(Vessel v)
         {
-            return HighLogic.LoadedSceneIsFlight && FlightGlobals.ActiveVessel != null &&
-                   FlightGlobals.ActiveVessel.IsRecoverable &&
-                   FlightGlobals.ActiveVessel.IsClearToSave() == ClearToSaveStatus.CLEAR;
+            return v != null && v.IsRecoverable && v.IsClearToSave() == ClearToSaveStatus.CLEAR &&
+                   v.GetVesselBuiltAt() != EditorFacility.VAB;
         }
 
         public static void EnableSimulationLocks()

--- a/Source/KerbalConstructionTime/Utilities/Utilities.cs
+++ b/Source/KerbalConstructionTime/Utilities/Utilities.cs
@@ -953,6 +953,9 @@ namespace KerbalConstructionTime
                 return;
             }
 
+            newShip.FacilityBuiltIn = ship.FacilityBuiltIn;
+            newShip.KCTPersistentID = ship.KCTPersistentID;
+
             ship.RemoveFromBuildList();
 
             GetShipEditProgress(ship, out double progressBP, out _, out _);
@@ -1741,6 +1744,10 @@ namespace KerbalConstructionTime
 
                 KCTGameStates.RecoveredVessel = new BuildListVessel(FlightGlobals.ActiveVessel, listType);
 
+                KCTVesselData vData = FlightGlobals.ActiveVessel.GetKCTVesselData();
+                KCTGameStates.RecoveredVessel.KCTPersistentID = vData?.VesselID;
+                KCTGameStates.RecoveredVessel.FacilityBuiltIn = vData?.FacilityBuiltIn ?? EditorFacility.None;
+
                 //KCT_GameStates.recoveredVessel.type = listType;
                 if (listType == BuildListVessel.ListType.VAB)
                     KCTGameStates.RecoveredVessel.LaunchSite = "LaunchPad";
@@ -1912,6 +1919,17 @@ namespace KerbalConstructionTime
         {
             ModuleTagList mTags = p.FindModuleImplementing<ModuleTagList>();
             return mTags?.tags.Contains(tag) ?? false;
+        }
+
+        public static KCTVesselData GetKCTVesselData(this Vessel v)
+        {
+            var kctvm = (KCTVesselTracker)v.vesselModules.FirstOrDefault(vm => vm is KCTVesselTracker);
+            return kctvm?.Data;
+        }
+
+        public static string GetKCTVesselId(this Vessel v)
+        {
+            return v.GetKCTVesselData()?.VesselID;
         }
 
         public static bool IsVabRecoveryAvailable()


### PR DESCRIPTION
Currently tracks whether the vessel was originally built in SPH or VAB and stores a unique ID for it. This data will be assigned as soon as the vessel is added to build queue and will survive multiple recoveries and KCT edits.
On staging all the subvessels will retain the same data which means that we can use it to fix the rendezvous contract. Another potential use case is assigning vessels to contracts at launch or through a custom UI instead of relying on CC to pick one dynamically.
Note that the code relies on a new event that was introduced in KSP 1.10.