### PR TITLE
Create a custom Rendezvous CC parameter

### DIFF
--- a/GameData/RP-0/Contracts/Milestones/Rendezvous.cfg
+++ b/GameData/RP-0/Contracts/Milestones/Rendezvous.cfg
@@ -78,8 +78,9 @@ CONTRACT_TYPE
 		PARAMETER
 		{
 			name = Rendezvous
-			type = Rendezvous
+			type = RP1Rendezvous
 			distance = 100
+			relativeSpeed = 0.5
 			title = Rendezvous two craft in Orbit
 			hideChildren = true
 			disableOnStateChange = true

--- a/Source/CC_RP0/CC_RP0.csproj
+++ b/Source/CC_RP0/CC_RP0.csproj
@@ -62,6 +62,8 @@
     <Compile Include="CustomExpressionParserRegistrer.cs" />
     <Compile Include="DownrangeDistanceFactory.cs" />
     <Compile Include="DownrangeDistanceVesselParam.cs" />
+    <Compile Include="RP1RendezvousFactory.cs" />
+    <Compile Include="RP1RendezvousVesselParam.cs" />
     <Compile Include="ImpactCBFactory.cs" />
     <Compile Include="ImpactCBParam.cs" />
     <Compile Include="ReachMachFactory.cs" />
@@ -69,6 +71,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\KerbalConstructionTime\KerbalConstructionTime.csproj">
+      <Project>{93908b2a-0859-4dab-8873-d32a4c633308}</Project>
+      <Name>KerbalConstructionTime</Name>
+    </ProjectReference>
     <ProjectReference Include="..\RP0.csproj">
       <Project>{997854F8-4EFB-4A78-87BC-F7C8CEA64669}</Project>
       <Name>RP0</Name>

--- a/Source/CC_RP0/RP1RendezvousFactory.cs
+++ b/Source/CC_RP0/RP1RendezvousFactory.cs
@@ -1,0 +1,25 @@
+﻿using Contracts;
+
+namespace ContractConfigurator.RP0
+{
+    public class RP1RendezvousFactory : ParameterFactory
+    {
+        protected double distance;
+        protected double relativeSpeed;
+
+        public override bool Load(ConfigNode configNode)
+        {
+            bool valid = base.Load(configNode);
+
+            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "distance", x => distance = x, this, 100);
+            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "relativeSpeed", x => relativeSpeed = x, this, 0);
+
+            return valid;
+        }
+
+        public override ContractParameter Generate(Contract contract)
+        {
+            return new RP1Rendezvous(distance, relativeSpeed, title);
+        }
+    }
+}

--- a/Source/CC_RP0/RP1RendezvousVesselParam.cs
+++ b/Source/CC_RP0/RP1RendezvousVesselParam.cs
@@ -1,0 +1,106 @@
+﻿using ContractConfigurator.Parameters;
+using Contracts;
+using KerbalConstructionTime;
+using KSP.Localization;
+using UnityEngine;
+
+namespace ContractConfigurator.RP0
+{
+    public class RP1Rendezvous : VesselParameter
+    {
+        protected double distance { get; set; }
+        protected double relativeSpeed { get; set; }
+
+        private float lastUpdate = 0.0f;
+        private const float UPDATE_FREQUENCY = 0.50f;
+
+        public RP1Rendezvous()
+            : base(null)
+        {
+        }
+
+        public RP1Rendezvous(double distance, double relativeSpeed, string title)
+            : base(title)
+        {
+            this.distance = distance;
+            this.relativeSpeed = relativeSpeed;
+            this.title = title;
+            disableOnStateChange = true;
+        }
+
+        protected override string GetParameterTitle()
+        {
+            string output;
+            if (string.IsNullOrEmpty(title))
+            {
+                output = Localizer.Format("#cc.param.Rendezvous.1", Localizer.GetStringByTag("#cc.param.vessel.Any"));
+            }
+            else
+            {
+                output = title;
+            }
+            return output;
+        }
+
+        protected override void OnParameterSave(ConfigNode node)
+        {
+            base.OnParameterSave(node);
+            node.AddValue("distance", distance);
+            node.AddValue("relativeSpeed", relativeSpeed);
+        }
+
+        protected override void OnParameterLoad(ConfigNode node)
+        {
+            base.OnParameterLoad(node);
+            distance = ConfigNodeUtil.ParseValue<double>(node, "distance");
+            relativeSpeed = ConfigNodeUtil.ParseValue<double>(node, "relativeSpeed");
+        }
+
+        protected override void OnUpdate()
+        {
+            base.OnUpdate();
+
+            if (Time.fixedTime - lastUpdate < UPDATE_FREQUENCY) return;
+
+            lastUpdate = Time.fixedTime;
+
+            if (FlightGlobals.VesselsLoaded.Count < 2) return;
+
+            Vessel v1 = FlightGlobals.ActiveVessel;
+            if (!IsValidVessel(v1)) return;
+
+            string id1 = v1.GetKCTVesselId();
+            bool forceStateChange = false;
+            bool rendezvous = false;
+            foreach (Vessel v2 in FlightGlobals.VesselsLoaded)
+            {
+                if (v2 != v1 && IsValidVessel(v2) && id1 != v2.GetKCTVesselId())
+                {
+                    float distance = Vector3.Distance(v1.transform.position, v2.transform.position);
+                    double relSpeed = (v1.obt_velocity - v2.obt_velocity).magnitude;
+                    if (distance < this.distance && (this.relativeSpeed <= 0 || relSpeed < this.relativeSpeed))
+                    {
+                        rendezvous = true;
+                        forceStateChange |= SetState(v1, ParameterState.Complete);
+                        forceStateChange |= SetState(v2, ParameterState.Complete);
+                    }
+                }
+            }
+
+            if (rendezvous)
+            {
+                CheckVessel(FlightGlobals.ActiveVessel, forceStateChange);
+            }
+        }
+
+        protected override bool VesselMeetsCondition(Vessel vessel)
+        {
+            return GetState(vessel) == ParameterState.Complete;
+        }
+
+        private static bool IsValidVessel(Vessel v)
+        {
+            return v != null && !v.isEVA && v.vesselType != VesselType.Debris && v.vesselType != VesselType.Flag;
+        }
+    }
+}


### PR DESCRIPTION
Prevents 2 stages from the same vessel satisfying the contract parameter. 
Additionally has `relativeSpeed` parameter so that 2 vessels whooshing past each other wouldn't be called a *rendezvous*.