### PR TITLE
Add CI to RP-0

### DIFF
--- a/.github/workflows/attachReleaseArtifacts.yml
+++ b/.github/workflows/attachReleaseArtifacts.yml
@@ -33,7 +33,7 @@ jobs:
                     
       - name: Build mod solution
         run: |
-          rm -f -r ${GITHUB_WORKSPACE}/GameData/RP-0/
+          rm -f ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/*.dll
           msbuild /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${GITHUB_WORKSPACE}/Source/RP0.sln
           cp -v ${GITHUB_WORKSPACE}/Source/ClearInputLocks/obj/x64/Release/ClearInputLocks.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/ClearInputLocks.dll
           cp -v ${GITHUB_WORKSPACE}/Source/CC_RP0/obj/x64/Release/CC_RP0.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/CC_RP0.dll

--- a/.github/workflows/attachReleaseArtifacts.yml
+++ b/.github/workflows/attachReleaseArtifacts.yml
@@ -1,0 +1,73 @@
+name: "Attach Release Artifacts"
+
+# Controls when the action will run. 
+on:
+  release:
+    types: [published]
+    
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  attach-release-artifacts:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
+        
+      - name: Download required assemblies
+        id: download-assemblies
+        shell: bash
+        env: 
+          KSP_ZIP_PASSWORD: ${{ secrets.KSP_ZIP_PASSWORD }}
+        run: |
+          curl https://ksp-ro.s3-us-west-2.amazonaws.com/KSPAssemblies-1.10.zip --output /tmp/bins.zip
+          KSP_DLL_PATH="/opt/ksp/assembly"
+          echo "::set-output name=ksp-dll-path::${KSP_DLL_PATH}"
+          mkdir -p "${KSP_DLL_PATH}"
+          unzip -P "${KSP_ZIP_PASSWORD}" '/tmp/bins.zip' -d "${KSP_DLL_PATH}"
+          rm '/tmp/bins.zip'          
+                    
+      - name: Build mod solution
+        run: |
+          rm -f -r ${GITHUB_WORKSPACE}/GameData/RP-0/
+          msbuild /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${GITHUB_WORKSPACE}/Source/RP0.sln
+          cp -v ${GITHUB_WORKSPACE}/Source/ClearInputLocks/obj/x64/Release/ClearInputLocks.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/ClearInputLocks.dll
+          cp -v ${GITHUB_WORKSPACE}/Source/CC_RP0/obj/x64/Release/CC_RP0.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/CC_RP0.dll
+          cp -v ${GITHUB_WORKSPACE}/Source/KerbalConstructionTime/obj/Release/RP0KCT.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/RP0KCT.dll
+          cp -v ${GITHUB_WORKSPACE}/Source/obj/x64/Release/RP0.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/RP0.dll
+        
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.0
+          
+      - name: Make metadata
+        run: |
+          python ${GITHUB_WORKSPACE}/makeMeta.py ${{ github.event.release.tag_name }}
+          
+      - name: Assemble release
+        id: assemble-release
+        run: |
+          RELEASE_DIR="${RUNNER_TEMP}/release"
+          echo "Release dir: ${RELEASE_DIR}"
+          echo "Release zip: ${RELEASE_DIR}/RP-1-${{ github.event.release.tag_name }}.zip"
+          mkdir -v "${RELEASE_DIR}"
+          echo "::set-output name=release-dir::${RELEASE_DIR}"
+          cp -v -R "${GITHUB_WORKSPACE}/GameData" "${RELEASE_DIR}"
+          cp -v -R "${GITHUB_WORKSPACE}/RP-1.version" "${RELEASE_DIR}/GameData/RP-0/RP-1.version"
+          cd ${RELEASE_DIR}
+          zip -r RP-1-${{ github.event.release.tag_name }}.zip GameData
+        
+      - name: Upload package to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.assemble-release.outputs.release-dir }}/RP-1-${{ github.event.release.tag_name }}.zip
+          asset_name: RP-1-${{ github.event.release.tag_name }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,76 @@
+# This is a basic workflow to help you get started with Actions
+
+name: build
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master, dev ]
+  pull_request:
+    branches: [ master, dev ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
+          
+      - name: Download required assemblies
+        id: download-assemblies
+        shell: bash
+        env: 
+          KSP_ZIP_PASSWORD: ${{ secrets.KSP_ZIP_PASSWORD }}
+        run: |
+          curl https://ksp-ro.s3-us-west-2.amazonaws.com/KSPAssemblies-1.10.zip --output /tmp/bins.zip
+          KSP_DLL_PATH="/opt/ksp/assembly"
+          echo "::set-output name=ksp-dll-path::${KSP_DLL_PATH}"
+          mkdir -p "${KSP_DLL_PATH}"
+          unzip -P "${KSP_ZIP_PASSWORD}" '/tmp/bins.zip' -d "${KSP_DLL_PATH}"
+          rm '/tmp/bins.zip'          
+                    
+      - name: Build mod solution
+        run: |
+          rm -f -r ${GITHUB_WORKSPACE}/GameData/RP-0/
+          msbuild /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${GITHUB_WORKSPACE}/Source/RP0.sln
+          cp -v ${GITHUB_WORKSPACE}/Source/ClearInputLocks/obj/x64/Release/ClearInputLocks.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/ClearInputLocks.dll
+          cp -v ${GITHUB_WORKSPACE}/Source/CC_RP0/obj/x64/Release/CC_RP0.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/CC_RP0.dll
+          cp -v ${GITHUB_WORKSPACE}/Source/KerbalConstructionTime/obj/Release/RP0KCT.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/RP0KCT.dll
+          cp -v ${GITHUB_WORKSPACE}/Source/obj/x64/Release/RP0.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/RP0.dll
+        
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.0
+        
+      - name: Build metadata
+        shell: bash
+        run: |
+          python ${GITHUB_WORKSPACE}/makeMeta.py 2.0.0.0
+          
+      - name: Assemble release
+        id: assemble-release
+        run: |
+          RELEASE_DIR="${RUNNER_TEMP}/release"
+          echo "Release dir: ${RELEASE_DIR}"
+          mkdir -v "${RELEASE_DIR}"
+          echo "::set-output name=release-dir::${RELEASE_DIR}"
+          cp -v -R "${GITHUB_WORKSPACE}/GameData" "${RELEASE_DIR}"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: RP-1
+          path: ${{ steps.assemble-release.outputs.release-dir }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
                     
       - name: Build mod solution
         run: |
-          rm -f -r ${GITHUB_WORKSPACE}/GameData/RP-0/
+          rm -f ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/*.dll
           msbuild /p:Configuration=Release /p:ReferencePath="${{ steps.download-assemblies.outputs.ksp-dll-path }}" ${GITHUB_WORKSPACE}/Source/RP0.sln
           cp -v ${GITHUB_WORKSPACE}/Source/ClearInputLocks/obj/x64/Release/ClearInputLocks.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/ClearInputLocks.dll
           cp -v ${GITHUB_WORKSPACE}/Source/CC_RP0/obj/x64/Release/CC_RP0.dll ${GITHUB_WORKSPACE}/GameData/RP-0/Plugins/CC_RP0.dll

--- a/Source/KerbalConstructionTime/KerbalConstructionTime.csproj
+++ b/Source/KerbalConstructionTime/KerbalConstructionTime.csproj
@@ -169,9 +169,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>del "System.Core.dll"</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>

--- a/Source/RP0.csproj
+++ b/Source/RP0.csproj
@@ -165,9 +165,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
   </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>del "System.Core.dll"</PostBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/makeMeta.py
+++ b/makeMeta.py
@@ -1,0 +1,59 @@
+import os, argparse, sys, json, glob
+
+class DefaultHelpParser(argparse.ArgumentParser):
+    def error(self, message):
+        sys.stderr.write('error: %s\n' % message)
+        self.print_help()
+        sys.exit(2)
+
+HELP_DESC = "Creates neccesary metadata files"
+parser = DefaultHelpParser(description=HELP_DESC)
+parser.add_argument('tag', metavar='tag', type=str, nargs=1,
+                   help='tag of release (e.g. 0.4.6.0')
+
+args = parser.parse_args()
+
+if not args.tag or len(args.tag) < 1:
+    print("ERROR: git tag must be specified and must be in the format major.minor.patch.build-configuration.e.g. 0.4.6.0")
+    sys.exit(2)
+
+version = args.tag[0]
+
+if version.startswith('v'):
+    version = version.split('v')[1]
+
+major = int(version.split(".")[0])
+minor = int(version.split(".")[1])
+patch = int(version.split(".")[2])
+build = int(version.split(".")[3])
+# create AVC .version file
+avc = {
+	"NAME" : "Realistic Progression One",
+	"URL" : "https://raw.githubusercontent.com/KSP-RO/RP-0/master/GameData/RP-0/RP-1.version",
+	"DOWNLOAD" : "https://github.com/KSP-RO/RP-0/releases/download/{}/RP-1-{}.zip".format(args.tag[0],args.tag[0]),
+	"HOMEPAGE"  : "https://github.com/KSP-RO/RP-0/",
+	"VERSION" :
+	{
+		"MAJOR" : major,
+		"MINOR" : minor,
+		"PATCH" : patch,
+		"BUILD" : build
+	},
+  "KSP_VERSION" : {
+      "MAJOR": "1",
+      "MINOR": "10",
+      "PATCH": "0"
+  },
+	"KSP_VERSION_MIN": {
+		"MAJOR": "1",
+		"MINOR": "10",
+		"PATCH": "0"
+	},
+	"KSP_VERSION_MAX": {
+		"MAJOR": "1",
+		"MINOR": "11",
+		"PATCH": "99"
+	}
+}
+with open("RP-1.version", "w") as f:
+	f.write(json.dumps(avc))


### PR DESCRIPTION
How to create releases in a repository once Github CI is enabled
Create the new release in Github as you normally would, with the following guidelines

1. The tag **must** be in the format `v[Major].[Minor].[Path].[Build]`.  All four elements are required.  Use 0 if you don't need them.  All elements **must** be integers. EG: `v1.10.0.0`
2. Be sure to point the release to the appropriate branch as desired
3. Title and Description as normal
4. Mark the release as **pre-release** initially.  This is so that CKAN won't pick it up until the release is finished building
5. Publish the release

After publishing, the CI should kick in if you did everything properly.  Once finished, it will automatically attach a ZIP file to the release, EG RP-1-v1.10.0.0.zip

Once that zip appears, you can go into an edit the release to uncheck pre-release and let CKAN pick it up

