### PR TITLE
Fix Zond/LOK avionics

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -150,7 +150,7 @@
 	MODULE
 	{
 		name = ModuleAvionics
-		massLimit = 10.0
+		massLimit = 20.0
 		interplanetary = False
 	}
     MODULE:NEEDS[kOS]
@@ -164,7 +164,7 @@
     }
 }
 
-@PART[rn_zond_top]:FOR[RP-0]
+@PART[rn_zond_top|rn_lok_tdu]:FOR[RP-0]
 {
 	@MODULE[ModuleAvionics] { %interplanetary = True }
 }


### PR DESCRIPTION
Give the LOK service module interplanetary rating, increase Soyuz mass limit to 20 tons to allow for hauling LK lander/ space station components.