### PR TITLE
Reputation reward adjustment for early contracts

### DIFF
--- a/GameData/RP-0/Contracts/Human Contracts/Suborbital Crewed.cfg
+++ b/GameData/RP-0/Contracts/Human Contracts/Suborbital Crewed.cfg
@@ -31,7 +31,7 @@ CONTRACT_TYPE
 	prestige = Significant   // 1.25x
 	advanceFunds = (2000 + @VesselGroup/ReachAlt/minAltitude*0.03) * @RP0:globalHardContractMultiplier
 	rewardScience = 0
-	rewardReputation = 3
+	rewardReputation = 6
 	rewardFunds = @advanceFunds
 	failureReputation = 3
 	failureFunds = @advanceFunds * 0.5

--- a/GameData/RP-0/Contracts/Milestones/First Flight.cfg
+++ b/GameData/RP-0/Contracts/Milestones/First Flight.cfg
@@ -29,7 +29,7 @@ CONTRACT_TYPE
 	prestige = Trivial       // 1.0x
 	advanceFunds = 1000 * @RP0:globalHardContractMultiplier * @noPlaneFundMult
 	rewardScience = 0
-	rewardReputation = 0
+	rewardReputation = 2
 	rewardFunds = 1500 * @RP0:globalHardContractMultiplier * @noPlaneFundMult
 
 	DATA

--- a/GameData/RP-0/Contracts/X-Planes/CrewedFlight.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedFlight.cfg
@@ -31,7 +31,7 @@ CONTRACT_TYPE
 	advanceFunds = Round((650 + @VesselGroup/ReachAlt/minAltitude * 0.135) * @RP0:globalHardContractMultiplier * @rewardFactor, 100)
 	rewardFunds = @advanceFunds
 	failureFunds = @advanceFunds * 0.5
-	rewardReputation = 0.5
+	rewardReputation = 1
 	failureReputation = 0.5
 
 	DATA

--- a/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoDifficult.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoDifficult.cfg
@@ -28,7 +28,7 @@ CONTRACT_TYPE
 	advanceFunds = Round((2050 + @VesselGroup/ReachAlt/minAltitude * 0.035) * @RP0:globalHardContractMultiplier * @rewardFactor, 100)
 	rewardFunds = Round(@advanceFunds * 1.15, 100)
 	failureFunds = @advanceFunds * 0.5
-	rewardReputation = 2
+	rewardReputation = 4
 	failureReputation = 2
 
 	DATA

--- a/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
@@ -29,7 +29,7 @@ CONTRACT_TYPE
 	advanceFunds = Round((700.0 + 5.0 * @VesselGroup/HoldSituation/minSpeed) * @RP0:globalHardContractMultiplier * @rewardFactor, 100)
 	rewardFunds = Round(@advanceFunds + 1200.0 * @rewardFactor, 100)
 	failureFunds = @advanceFunds * 0.5
-	rewardReputation = 1
+	rewardReputation = 2
 	failureReputation = 1
 
 	DATA


### PR DESCRIPTION
Arbitrary changes that don't really affect RP1, but makes a difference when playing with Headlines. The later game contracts (rewards over 100) are likely too high compared to what is in the 20-100 range. However, I think that these are material for a different PR. 