### PR TITLE
Change the ScanSat contracts to require technology instead of scanner part

### DIFF
--- a/GameData/RP-0/Contracts/ScanSat/Earth_AltimetryLoRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/Earth_AltimetryLoRes.cfg
@@ -56,10 +56,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 		
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = scienceHuman
+		title = Have unlocked Early Human Spaceflight Era Science for Radar Altimeter
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/Mars_AltimetryLoRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/Mars_AltimetryLoRes.cfg
@@ -57,10 +57,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = scienceHuman
+		title = Have unlocked Early Human Spaceflight Era Science for Radar Altimeter
 	}	
 	
 	// ************ PARAMETERS ************
@@ -134,10 +134,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 		
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = scienceHuman
+		title = Have unlocked Early Human Spaceflight Era Science for Radar Altimeter
 	}	
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/Moon_AltimetryLoRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/Moon_AltimetryLoRes.cfg
@@ -60,7 +60,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 		name = TechResearched
 		type = TechResearched
 		tech = scienceHuman
-		title = Have unlocked Early Human Spaceflight Era Science for Low Res Altimeter
+		title = Have unlocked Early Human Spaceflight Era Science for Radar Altimeter
 	}	
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/Moon_AltimetryLoRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/Moon_AltimetryLoRes.cfg
@@ -57,10 +57,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = scienceHuman
+		title = Have unlocked Early Human Spaceflight Era Science for Low Res Altimeter
 	}	
 	
 	// ************ PARAMETERS ************
@@ -134,10 +134,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 		
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = scienceHuman
+		title = Have unlocked Early Human Spaceflight Era Science for Radar Altimeter
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_AltimetryLoRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_AltimetryLoRes.cfg
@@ -91,10 +91,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = scienceHuman
+		title = Have unlocked Early Human Spaceflight Era Science for Radar Altimeter
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_Biome.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_Biome.cfg
@@ -91,10 +91,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner24
-		title = Have unlocked the Biome Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = scienceAdvCapsules
+		title = Have unlocked Interplanetary Era Science for Basic TV Camera
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_HiRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_HiRes.cfg
@@ -91,10 +91,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner2
-		title = Have unlocked the High Resolution Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = deepSpaceScience
+		title = Have unlocked Deep Space Science Experiments for SAR
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Earth.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Earth.cfg
@@ -73,7 +73,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	{
 		name = TechResearched
 		type = TechResearched
-		tech = @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
+		tech = @/scanString1 == "Biome" ? "scienceAdvCapsules" : "deepSpaceScience"
 		title = Have unlocked the associated tech for the respective scanner
 	}
 	

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Earth.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Earth.cfg
@@ -39,14 +39,14 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	DATA_EXPAND
 	{
 		type			= string
-		scanString1		= [ "AltimetryLoRes", "Biome", "AltimetryHiRes" ]	
+		scanString1		= [ "Biome", "AltimetryHiRes" ]	
 	}
 	
 	DATA
 	{
 		type			= string
 		uniquenessCheck	= CONTRACT_ALL
-		scanReadString1	= @/scanString1	== "AltimetryLoRes" ? "a Low Resolution" : @/scanString1 == "Biome" ? "a Biome" : "a High Resolution"
+		scanReadString1	= @/scanString1	== "Biome" ? "a Biome" : "a High Resolution"
 	}
 	
 	// ************ REQUIREMENTS ************
@@ -73,7 +73,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	{
 		name = TechResearched
 		type = TechResearched
-		tech = @/scanString1 == "AltimetryLoRes" ? scienceHuman : @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
+		tech = @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
 		title = Have unlocked the associated tech for the respective scanner
 	}
 	

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Earth.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Earth.cfg
@@ -8,7 +8,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	description = Create a satellite that can provide images and mapping of Earth. For best results, the orbit should have a high inclination to cover all surface area of the planet. Be sure to look at the information available for each scanner to determine the best altitude to scan.
 
-	synopsis = Perform a @/scanReadString1 survey of Earth.
+	synopsis = Perform @/scanReadString1 survey of Earth.
 
 	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the planet.
 

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Earth.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Earth.cfg
@@ -71,10 +71,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = @/scanString1 == "AltimetryLoRes" ? SCANsat_Scanner : @/scanString1 == "Biome" ? SCANsat_Scanner24 : SCANsat_Scanner2
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = @/scanString1 == "AltimetryLoRes" ? scienceHuman : @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
+		title = Have unlocked the associated tech for the respective scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_GasGiant_Biome.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_GasGiant_Biome.cfg
@@ -92,10 +92,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner24
-		title = Have unlocked the Biome Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = scienceAdvCapsules
+		title = Have unlocked Interplanetary Era Science for Basic TV Camera
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_AltimetryLoRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_AltimetryLoRes.cfg
@@ -91,10 +91,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner
-		title = Have unlocked the Low Resolution Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = scienceHuman
+		title = Have unlocked Early Human Spaceflight Era Science for Radar Altimeter
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_Biome.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_Biome.cfg
@@ -91,10 +91,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner24
-		title = Have unlocked the Biome Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = scienceAdvCapsules
+		title = Have unlocked Interplanetary Era Science for Basic TV Camera
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_HiRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Hard_HiRes.cfg
@@ -91,10 +91,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = SCANsat_Scanner2
-		title = Have unlocked the High Resolution Scanner
+		name = TechResearched
+		type = TechResearched
+		tech = deepSpaceScience
+		title = Have unlocked Deep Space Science Experiments for SAR
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_JupiterMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_JupiterMoons.cfg
@@ -8,7 +8,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	description = Create a satellite that can provide images and mapping of the moon. For best results, the orbit should have a high inclination to cover all surface area of the planet. Be sure to look at the information available for each scanner to determine the best altitude to scan.
 
-	synopsis = Perform a @/scanReadString1 survey of @/targetBodyValid1.
+	synopsis = Perform @/scanReadString1 survey of @/targetBodyValid1.
 
 	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the moon.
 

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_JupiterMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_JupiterMoons.cfg
@@ -1,7 +1,7 @@
 CONTRACT_TYPE:NEEDS[SCANsat]
 {
 	name = RP0_SCANSat_JupiterMoons
-	title = Conduct a @/scanReadString1 SCANsat survey of @/targetBodyValid1
+	title = Conduct @/scanReadString1 SCANsat survey of @/targetBodyValid1
 	genericTitle = Conduct SCANsat survey of a moon of Jupiter
 	group = RP0ScanSat
 	agent = #autoLOC_SCANsat_Agents_Name
@@ -89,7 +89,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	{
 		name = TechResearched
 		type = TechResearched
-		tech = @/scanString1 == "AltimetryLoRes" ? scienceHuman : @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
+		tech = @/scanString1 == "AltimetryLoRes" ? "scienceHuman" : @/scanString1 == "Biome" ? "scienceAdvCapsules" : "deepSpaceScience"
 		title = Have unlocked the associated tech for the respective scanner
 	}
 	

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_JupiterMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_JupiterMoons.cfg
@@ -87,10 +87,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = @/scanString1 == "AltimetryLoRes" ? SCANsat_Scanner : @/scanString1 == "Biome" ? SCANsat_Scanner24 : SCANsat_Scanner2
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = @/scanString1 == "AltimetryLoRes" ? scienceHuman : @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
+		title = Have unlocked the associated tech for the respective scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_NeptuneMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_NeptuneMoons.cfg
@@ -8,7 +8,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	description = Create a satellite that can provide images and mapping of the moon. For best results, the orbit should have a high inclination to cover all surface area of the planet. Be sure to look at the information available for each scanner to determine the best altitude to scan.
 
-	synopsis = Perform a @/scanReadString1 survey of @/targetBodyValid1.
+	synopsis = Perform @/scanReadString1 survey of @/targetBodyValid1.
 
 	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the moon.
 

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_NeptuneMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_NeptuneMoons.cfg
@@ -87,10 +87,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = @/scanString1 == "AltimetryLoRes" ? SCANsat_Scanner : @/scanString1 == "Biome" ? SCANsat_Scanner24 : SCANsat_Scanner2
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = @/scanString1 == "AltimetryLoRes" ? scienceHuman : @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
+		title = Have unlocked the associated tech for the respective scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_NeptuneMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_NeptuneMoons.cfg
@@ -1,7 +1,7 @@
 CONTRACT_TYPE:NEEDS[SCANsat]
 {
 	name = RP0_SCANSat_NeptuneMoons
-	title = Conduct a @/scanReadString1 SCANsat survey of @/targetBodyValid1
+	title = Conduct @/scanReadString1 SCANsat survey of @/targetBodyValid1
 	genericTitle = Conduct SCANsat survey of a moon of Neptune
 	group = RP0ScanSat
 	agent = #autoLOC_SCANsat_Agents_Name
@@ -89,7 +89,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	{
 		name = TechResearched
 		type = TechResearched
-		tech = @/scanString1 == "AltimetryLoRes" ? scienceHuman : @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
+		tech = @/scanString1 == "AltimetryLoRes" ? "scienceHuman" : @/scanString1 == "Biome" ? "scienceAdvCapsules" : "deepSpaceScience"
 		title = Have unlocked the associated tech for the respective scanner
 	}
 	

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_SaturnMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_SaturnMoons.cfg
@@ -1,7 +1,7 @@
 CONTRACT_TYPE:NEEDS[SCANsat]
 {
 	name = RP0_SCANSat_SaturnMoons
-	title = Conduct a @/scanReadString1 SCANsat survey of @/targetBodyValid1
+	title = Conduct @/scanReadString1 SCANsat survey of @/targetBodyValid1
 	genericTitle = Conduct SCANsat survey of a moon of Saturn
 	group = RP0ScanSat
 	agent = #autoLOC_SCANsat_Agents_Name
@@ -89,7 +89,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	{
 		name = TechResearched
 		type = TechResearched
-		tech = @/scanString1 == "AltimetryLoRes" ? scienceHuman : @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
+		tech = @/scanString1 == "AltimetryLoRes" ? "scienceHuman" : @/scanString1 == "Biome" ? "scienceAdvCapsules" : "deepSpaceScience"
 		title = Have unlocked the associated tech for the respective scanner
 	}
 	

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_SaturnMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_SaturnMoons.cfg
@@ -8,7 +8,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	description = Create a satellite that can provide images and mapping of the moon. For best results, the orbit should have a high inclination to cover all surface area of the planet. Be sure to look at the information available for each scanner to determine the best altitude to scan.
 
-	synopsis = Perform a @/scanReadString1 survey of @/targetBodyValid1.
+	synopsis = Perform @/scanReadString1 survey of @/targetBodyValid1.
 
 	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the moon.
 

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_SaturnMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_SaturnMoons.cfg
@@ -87,10 +87,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = @/scanString1 == "AltimetryLoRes" ? SCANsat_Scanner : @/scanString1 == "Biome" ? SCANsat_Scanner24 : SCANsat_Scanner2
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = @/scanString1 == "AltimetryLoRes" ? scienceHuman : @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
+		title = Have unlocked the associated tech for the respective scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_UranusMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_UranusMoons.cfg
@@ -8,7 +8,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	description = Create a satellite that can provide images and mapping of the moon. For best results, the orbit should have a high inclination to cover all surface area of the planet. Be sure to look at the information available for each scanner to determine the best altitude to scan.
 
-	synopsis = Perform a @/scanReadString1 survey of @/targetBodyValid1.
+	synopsis = Perform @/scanReadString1 survey of @/targetBodyValid1.
 
 	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the moon.
 

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_UranusMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_UranusMoons.cfg
@@ -1,7 +1,7 @@
 CONTRACT_TYPE:NEEDS[SCANsat]
 {
 	name = RP0_SCANSat_UranusMoons
-	title = Conduct a @/scanReadString1 SCANsat survey of @/targetBodyValid1
+	title = Conduct @/scanReadString1 SCANsat survey of @/targetBodyValid1
 	genericTitle = Conduct SCANsat survey of a moon of Uranus
 	group = RP0ScanSat
 	agent = #autoLOC_SCANsat_Agents_Name
@@ -89,7 +89,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	{
 		name = TechResearched
 		type = TechResearched
-		tech = @/scanString1 == "AltimetryLoRes" ? scienceHuman : @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
+		tech = @/scanString1 == "AltimetryLoRes" ? "scienceHuman" : @/scanString1 == "Biome" ? "scienceAdvCapsules" : "deepSpaceScience"
 		title = Have unlocked the associated tech for the respective scanner
 	}
 	

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_UranusMoons.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_UranusMoons.cfg
@@ -87,10 +87,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = @/scanString1 == "AltimetryLoRes" ? SCANsat_Scanner : @/scanString1 == "Biome" ? SCANsat_Scanner24 : SCANsat_Scanner2
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = @/scanString1 == "AltimetryLoRes" ? scienceHuman : @/scanString1 == "Biome" ? scienceAdvCapsules : deepSpaceScience
+		title = Have unlocked the associated tech for the respective scanner
 	}
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/Venus_AltimetryLoRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/Venus_AltimetryLoRes.cfg
@@ -57,10 +57,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = scienceHuman
+		title = Have unlocked Early Human Spaceflight Era Science for Low Res Altimeter
 	}
 	
 	// ************ PARAMETERS ************
@@ -134,10 +134,10 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 		
 	REQUIREMENT
 	{
-		name = PartUnlocked
-		type = PartUnlocked
-		part = scansat-radar-poseidon-3b-1
-		title = Have unlocked the associated part
+		name = TechResearched
+		type = TechResearched
+		tech = scienceHuman
+		title = Have unlocked Early Human Spaceflight Era Science for Radar Altimeter
 	}	
 	
 	// ************ PARAMETERS ************

--- a/GameData/RP-0/Contracts/ScanSat/Venus_AltimetryLoRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/Venus_AltimetryLoRes.cfg
@@ -60,7 +60,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 		name = TechResearched
 		type = TechResearched
 		tech = scienceHuman
-		title = Have unlocked Early Human Spaceflight Era Science for Low Res Altimeter
+		title = Have unlocked Early Human Spaceflight Era Science for Radar Altimeter
 	}
 	
 	// ************ PARAMETERS ************


### PR DESCRIPTION
Two major consequences: 
1) Now low-resolution contracts will show up only after finishing research human spaceflight science, whereas previously the contract is available once the tech is in the queue. 
2) Since neither SCANsat_Scanner24 nor SCANsat_Scanner2 has RP-1 configs, this pull request will actually allow biome and high-resolution scan contracts to be accepted. 