### PR TITLE
Add kOS disk space to upgrade part description

### DIFF
--- a/GameData/RP-0/Tree/ProceduralAvionics.cfg
+++ b/GameData/RP-0/Tree/ProceduralAvionics.cfg
@@ -1078,7 +1078,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL1</b> - <color=white>Mass: -34.5%</color> <color=green>Cost: +100%</color> <color=orange>Power: -50%</color>
+	description = <b>Science-Core TL1</b> - <color=white>Mass: -34.5%</color> <color=green>Cost: +100%</color> <color=orange>Power: -50%</color> <color=white>kOS Disk Space: same</color>
 }
 
 PARTUPGRADE
@@ -1091,7 +1091,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL2</b> - <color=white>Mass: -55%</color> <color=green>Cost: +33.3%</color> <color=orange>Power: -50%</color><br><b>Near-Earth TL1</b> - <color=white>Mass: -20%</color> <color=green>Cost: +7%</color> <color=orange>Power: -15%</color><br>
+	description = <b>Science-Core TL2</b> - <color=white>Mass: -55%</color> <color=green>Cost: +33.3%</color> <color=orange>Power: -50%</color> <color=white>kOS Disk Space: same</color><br><b>Near-Earth TL1</b> - <color=white>Mass: -20%</color> <color=green>Cost: +7%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: same</color><br>
 }
 
 PARTUPGRADE
@@ -1104,7 +1104,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL3</b> - <color=white>Mass: -76%</color> <color=green>Cost: +25%</color> <color=orange>Power: -99.4%</color><br><b>Near-Earth TL2</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color><br>
+	description = <b>Science-Core TL3</b> - <color=white>Mass: -76%</color> <color=green>Cost: +25%</color> <color=orange>Power: -99.4%</color> <color=white>kOS Disk Space: same</color><br><b>Near-Earth TL2</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: same</color><br>
 }
 
 PARTUPGRADE
@@ -1117,7 +1117,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL4</b> - <color=white>Mass: -62.5%</color> <color=green>Cost: +20%</color> <color=orange>Power: -33.3%</color><br><b>Near-Earth TL3</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color>
+	description = <b>Science-Core TL4</b> - <color=white>Mass: -62.5%</color> <color=green>Cost: +20%</color> <color=orange>Power: -33.3%</color> <color=white>kOS Disk Space: same</color><br><b>Near-Earth TL3</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: same</color>
 }
 
 PARTUPGRADE
@@ -1130,7 +1130,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL5</b> - <color=white>Mass: -33.3%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color><br><b>Near-Earth TL4</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color><br><b>Deep-Space TL1</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color>
+	description = <b>Science-Core TL5</b> - <color=white>Mass: -33.3%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +650 %</color><br><b>Near-Earth TL4</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +900 %</color><br><b>Deep-Space TL1</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +900 %</color>
 }
 
 PARTUPGRADE
@@ -1143,7 +1143,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL6</b> - <color=white>Mass: -19%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color><br><b>Near-Earth TL5</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color><br><b>Deep-Space TL2</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color>
+	description = <b>Science-Core TL6</b> - <color=white>Mass: -19%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Near-Earth TL5</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Deep-Space TL2</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color>
 }
 
 PARTUPGRADE
@@ -1156,7 +1156,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL7</b> - <color=white>Mass: -10%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color><br><b>Near-Earth TL6</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color><br><b>Deep-Space TL3</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color>
+	description = <b>Science-Core TL7</b> - <color=white>Mass: -10%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Near-Earth TL6</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Deep-Space TL3</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color>
 }
 
 PARTUPGRADE
@@ -1169,7 +1169,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL8</b> - <color=white>Mass: -10%</color> <color=green>Cost: -16.6%</color> <color=orange>Power: -10%</color><br><b>Near-Earth TL7</b> - <color=white>Mass: -15%</color> <color=green>Cost: -11%</color> <color=orange>Power: -15%</color><br><b>Deep-Space TL4</b> - <color=white>Mass: -15%</color> <color=green>Cost: -10%</color> <color=orange>Power: -15%</color>
+	description = <b>Science-Core TL8</b> - <color=white>Mass: -10%</color> <color=green>Cost: -16.6%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +150 %</color><br><b>Near-Earth TL7</b> - <color=white>Mass: -15%</color> <color=green>Cost: -11%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +150 %</color><br><b>Deep-Space TL4</b> - <color=white>Mass: -15%</color> <color=green>Cost: -10%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +150 %</color>
 }
 
 PARTUPGRADE
@@ -1182,7 +1182,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL9</b> - <color=white>Mass: -11%</color> <color=green>Cost: -10%</color> <color=orange>Power: -11%</color><br><b>Near-Earth TL8</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color><br><b>Deep-Space TL5</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color>
+	description = <b>Science-Core TL9</b> - <color=white>Mass: -11%</color> <color=green>Cost: -10%</color> <color=orange>Power: -11%</color> <color=white>kOS Disk Space: +233 %</color><br><b>Near-Earth TL8</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Deep-Space TL5</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color>
 }
 
 PARTUPGRADE
@@ -1195,7 +1195,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL10</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color><br><b>Near-Earth TL9</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color><br><b>Deep-Space TL6</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color>
+	description = <b>Science-Core TL10</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Near-Earth TL9</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Deep-Space TL6</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color>
 }
 
 PARTUPGRADE
@@ -1208,7 +1208,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL11</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color><br><b>Near-Earth TL10</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color><br><b>Deep-Space TL7</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color>
+	description = <b>Science-Core TL11</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +50 %</color><br><b>Near-Earth TL10</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +50 %</color><br><b>Deep-Space TL7</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +50 %</color>
 }
 
 PARTUPGRADE
@@ -1221,7 +1221,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL12</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color><br><b>Near-Earth TL11</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color><br><b>Deep-Space TL8</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color>
+	description = <b>Science-Core TL12</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +33 %</color><br><b>Near-Earth TL11</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +33 %</color><br><b>Deep-Space TL8</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +330 %</color>
 }
 
 PARTUPGRADE
@@ -1234,7 +1234,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL13</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color><br><b>Near-Earth TL11</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color><br><b>Deep-Space TL9</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color>
+	description = <b>Science-Core TL13</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +20 %</color><br><b>Near-Earth TL11</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +20 %</color><br><b>Deep-Space TL9</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +20 %</color>
 }
 
 // Deep Space Avionics Upgrades ********************************************

--- a/GameData/RP-0/Tree/ProceduralAvionics.cfg
+++ b/GameData/RP-0/Tree/ProceduralAvionics.cfg
@@ -1078,7 +1078,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL1</b> - <color=white>Mass: -34.5%</color> <color=green>Cost: +100%</color> <color=orange>Power: -50%</color> <color=white>kOS Disk Space: same</color>
+	description = <b>Science-Core TL1</b> - <color=white>Mass: -34.5%</color> <color=green>Cost: +100%</color> <color=orange>Power: -50%</color> <color=white>kOS Disk Space: 400 B</color>
 }
 
 PARTUPGRADE
@@ -1091,7 +1091,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL2</b> - <color=white>Mass: -55%</color> <color=green>Cost: +33.3%</color> <color=orange>Power: -50%</color> <color=white>kOS Disk Space: same</color><br><b>Near-Earth TL1</b> - <color=white>Mass: -20%</color> <color=green>Cost: +7%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: same</color><br>
+	description = <b>Science-Core TL2</b> - <color=white>Mass: -55%</color> <color=green>Cost: +33.3%</color> <color=orange>Power: -50%</color> <color=white>kOS Disk Space: 400 B</color><br><b>Near-Earth TL1</b> - <color=white>Mass: -20%</color> <color=green>Cost: +7%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 500 B</color><br>
 }
 
 PARTUPGRADE
@@ -1104,7 +1104,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL3</b> - <color=white>Mass: -76%</color> <color=green>Cost: +25%</color> <color=orange>Power: -99.4%</color> <color=white>kOS Disk Space: same</color><br><b>Near-Earth TL2</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: same</color><br>
+	description = <b>Science-Core TL3</b> - <color=white>Mass: -76%</color> <color=green>Cost: +25%</color> <color=orange>Power: -99.4%</color> <color=white>kOS Disk Space: 400 B</color><br><b>Near-Earth TL2</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 500 B</color><br>
 }
 
 PARTUPGRADE
@@ -1117,7 +1117,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL4</b> - <color=white>Mass: -62.5%</color> <color=green>Cost: +20%</color> <color=orange>Power: -33.3%</color> <color=white>kOS Disk Space: same</color><br><b>Near-Earth TL3</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: same</color>
+	description = <b>Science-Core TL4</b> - <color=white>Mass: -62.5%</color> <color=green>Cost: +20%</color> <color=orange>Power: -33.3%</color> <color=white>kOS Disk Space: 400 B</color><br><b>Near-Earth TL3</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 500 B</color>
 }
 
 PARTUPGRADE
@@ -1130,7 +1130,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL5</b> - <color=white>Mass: -33.3%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +650 %</color><br><b>Near-Earth TL4</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +900 %</color><br><b>Deep-Space TL1</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +900 %</color>
+	description = <b>Science-Core TL5</b> - <color=white>Mass: -33.3%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: 3 kB</color><br><b>Near-Earth TL4</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 5 kB</color><br><b>Deep-Space TL1</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 5 kB</color>
 }
 
 PARTUPGRADE
@@ -1143,7 +1143,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL6</b> - <color=white>Mass: -19%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Near-Earth TL5</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Deep-Space TL2</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color>
+	description = <b>Science-Core TL6</b> - <color=white>Mass: -19%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: 6 kB</color><br><b>Near-Earth TL5</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 19 kB</color><br><b>Deep-Space TL2</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 10 kB</color>
 }
 
 PARTUPGRADE
@@ -1156,7 +1156,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL7</b> - <color=white>Mass: -10%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Near-Earth TL6</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Deep-Space TL3</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color>
+	description = <b>Science-Core TL7</b> - <color=white>Mass: -10%</color> <color=green>Cost: same</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: 12 kB</color><br><b>Near-Earth TL6</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 29 kB</color><br><b>Deep-Space TL3</b> - <color=white>Mass: -15%</color> <color=green>Cost: +5%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 20 kB</color>
 }
 
 PARTUPGRADE
@@ -1169,7 +1169,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL8</b> - <color=white>Mass: -10%</color> <color=green>Cost: -16.6%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +150 %</color><br><b>Near-Earth TL7</b> - <color=white>Mass: -15%</color> <color=green>Cost: -11%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +150 %</color><br><b>Deep-Space TL4</b> - <color=white>Mass: -15%</color> <color=green>Cost: -10%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +150 %</color>
+	description = <b>Science-Core TL8</b> - <color=white>Mass: -10%</color> <color=green>Cost: -16.6%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: 30 kB</color><br><b>Near-Earth TL7</b> - <color=white>Mass: -15%</color> <color=green>Cost: -11%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 50 kB</color><br><b>Deep-Space TL4</b> - <color=white>Mass: -15%</color> <color=green>Cost: -10%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 50 kB</color>
 }
 
 PARTUPGRADE
@@ -1182,7 +1182,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL9</b> - <color=white>Mass: -11%</color> <color=green>Cost: -10%</color> <color=orange>Power: -11%</color> <color=white>kOS Disk Space: +233 %</color><br><b>Near-Earth TL8</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Deep-Space TL5</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color>
+	description = <b>Science-Core TL9</b> - <color=white>Mass: -11%</color> <color=green>Cost: -10%</color> <color=orange>Power: -11%</color> <color=white>kOS Disk Space: 100 kB</color><br><b>Near-Earth TL8</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 100 kB</color><br><b>Deep-Space TL5</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 100 kB</color>
 }
 
 PARTUPGRADE
@@ -1195,7 +1195,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL10</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Near-Earth TL9</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color><br><b>Deep-Space TL6</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +100 %</color>
+	description = <b>Science-Core TL10</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: 200 kB</color><br><b>Near-Earth TL9</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 200 kB</color><br><b>Deep-Space TL6</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 200 kB</color>
 }
 
 PARTUPGRADE
@@ -1208,7 +1208,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL11</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +50 %</color><br><b>Near-Earth TL10</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +50 %</color><br><b>Deep-Space TL7</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +50 %</color>
+	description = <b>Science-Core TL11</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: 300 kB</color><br><b>Near-Earth TL10</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 300 kB</color><br><b>Deep-Space TL7</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 300 kB</color>
 }
 
 PARTUPGRADE
@@ -1221,7 +1221,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL12</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +33 %</color><br><b>Near-Earth TL11</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +33 %</color><br><b>Deep-Space TL8</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +330 %</color>
+	description = <b>Science-Core TL12</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: 400 kB</color><br><b>Near-Earth TL11</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 400 kB</color><br><b>Deep-Space TL8</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 400 kB</color>
 }
 
 PARTUPGRADE
@@ -1234,7 +1234,7 @@ PARTUPGRADE
 	title = Procedural Avionics Upgrade
 	basicInfo = This is an upgrade for Procedural Avionics. Unlock the upgrade through the GUI accessed by right clicking on the part and choosing "Configure".
 	manufacturer = Generic
-	description = <b>Science-Core TL13</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: +20 %</color><br><b>Near-Earth TL11</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +20 %</color><br><b>Deep-Space TL9</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: +20 %</color>
+	description = <b>Science-Core TL13</b> - <color=white>Mass: -10%</color> <color=green>Cost: -10%</color> <color=orange>Power: -10%</color> <color=white>kOS Disk Space: 500 kB</color><br><b>Near-Earth TL11</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 500 kB</color><br><b>Deep-Space TL9</b> - <color=white>Mass: -15%</color> <color=green>Cost: -20%</color> <color=orange>Power: -15%</color> <color=white>kOS Disk Space: 500 kB</color>
 }
 
 // Deep Space Avionics Upgrades ********************************************


### PR DESCRIPTION
Siimav mentioned in Discord that a PR would be welcome to add **kOS disk space** to the descriptions of the procedural avionics upgrade parts in the tech tree.
Since it was me who complained about missing this information, it seems only fair that I take this upon myself. This is my very first PR ever, so please let me know if I'm not following the correct workflow.