### PR TITLE
Fix cost of ROE-215, RN RD-216

### DIFF
--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -13317,7 +13317,7 @@
 @PART[ROE-RD215]:FOR[xxxRP0]
 {
     %TechRequired = orbitalRocketry1960
-    %cost = 350
+    %cost = 700
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From ROEngines mod</color></b>
@@ -28878,7 +28878,7 @@
 @PART[rn_kosmos3_rd216]:FOR[xxxRP0]
 {
     %TechRequired = orbitalRocketry1960
-    %cost = 350
+    %cost = 700
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From RN Soviet Rockets mod</color></b>

--- a/Source/Tech Tree/Parts Browser/data/RN_Soviet_Rockets.json
+++ b/Source/Tech Tree/Parts Browser/data/RN_Soviet_Rockets.json
@@ -775,10 +775,10 @@
     },
     {
         "name": "rn_kosmos3_rd216",
-        "title": "RD-215 Series",
+        "title": "dual-RD-215 Series",
         "description": "",
         "mod": "RN Soviet Rockets",
-        "cost": "350",
+        "cost": 700,
         "entry_cost": "0",
         "category": "ORBITAL",
         "info": "",

--- a/Source/Tech Tree/Parts Browser/data/ROEngines.json
+++ b/Source/Tech Tree/Parts Browser/data/ROEngines.json
@@ -5156,10 +5156,10 @@
     },
     {
         "name": "ROE-RD215",
-        "title": "RD-215 Series",
+        "title": "dual-RD-215 Series",
         "description": "",
         "mod": "ROEngines",
-        "cost": "350",
+        "cost": 700,
         "entry_cost": "0",
         "category": "ORBITAL",
         "info": "",


### PR DESCRIPTION
They both use a 2x engine multiplier, but seem to be costed for the
1x rd-215.

This change makes the initial config an ok deal at 700 and the rd215m
still a decent deal at 600 (lr87 goes 500-760-...) instead of a great
deal and a fantastic deal at 350/250.

Other configs (rd217/225/250) are trickier to compare, but at least
probably aren't becoming overpriced to the point of uselessness.