### PR TITLE
Add kerbal chute and eva pack selection to KCT crew assignment dialog

### DIFF
--- a/Source/KerbalConstructionTime/KCTGameStates.cs
+++ b/Source/KerbalConstructionTime/KCTGameStates.cs
@@ -25,7 +25,7 @@ namespace KerbalConstructionTime
         public static int MiscellaneousTempUpgrades = 0, LastKnownTechCount = 0;
         public static int UpgradesResetCounter = 0;
         public static BuildListVessel LaunchedVessel, EditedVessel, RecoveredVessel;
-        public static List<CrewedPart> LaunchedCrew = new List<CrewedPart>();
+        public static List<PartCrewAssignment> LaunchedCrew = new List<PartCrewAssignment>();
 
         public static ToolbarControl ToolbarControl;
 
@@ -103,25 +103,6 @@ namespace KerbalConstructionTime
         public static void ClearLaunchpadList()
         {
             ActiveKSC.LaunchPads.Clear();
-        }
-    }
-
-    public class CrewedPart
-    {
-        public List<ProtoCrewMember> CrewList { get; set; }
-        public uint PartID { get; set; }
-
-        public CrewedPart(uint ID, List<ProtoCrewMember> crew)
-        {
-            PartID = ID;
-            CrewList = crew;
-        }
-
-        public CrewedPart FromPart(Part part, List<ProtoCrewMember> crew)
-        {
-            PartID = part.flightID;
-            CrewList = crew;
-            return this;
         }
     }
 }

--- a/Source/KerbalConstructionTime/KerbalConstructionTime.cs
+++ b/Source/KerbalConstructionTime/KerbalConstructionTime.cs
@@ -285,14 +285,14 @@ namespace KerbalConstructionTime
                 KerbalRoster roster = HighLogic.CurrentGame.CrewRoster;
                 foreach (Part p in FlightGlobals.ActiveVessel.parts)
                 {
-                    KCTDebug.Log("Part being tested: " + p.partInfo.title);
-                    if (!(KCTGameStates.LaunchedCrew.Find(part => part.PartID == p.craftID) is PartCrewAssignment cp))
+                    KCTDebug.Log($"Part being tested: {p.partInfo.title}");
+                    if (p.CrewCapacity == 0 || !(KCTGameStates.LaunchedCrew.Find(part => part.PartID == p.craftID) is PartCrewAssignment cp))
                         continue;
                     List<CrewMemberAssignment> crewList = cp.CrewList;
-                    KCTDebug.Log("cP.crewList.Count: " + cp.CrewList.Count);
+                    KCTDebug.Log($"cP.crewList.Count: {cp.CrewList.Count}");
                     foreach (CrewMemberAssignment assign in crewList)
                     {
-                        ProtoCrewMember crewMember = assign.PCM;
+                        ProtoCrewMember crewMember = assign?.PCM;
                         if (crewMember == null) continue;
 
                         // CrewRoster isn't reloaded from ConfigNode when starting flight. Can use the same instances as the previous scene.

--- a/Source/KerbalConstructionTime/KerbalConstructionTime.csproj
+++ b/Source/KerbalConstructionTime/KerbalConstructionTime.csproj
@@ -100,6 +100,7 @@
   <ItemGroup>
     <Compile Include="AirlaunchParams.cs" />
     <Compile Include="AirlaunchTechLevel.cs" />
+    <Compile Include="PartCrewAssignment.cs" />
     <Compile Include="BuildItems\PadConstruction.cs" />
     <Compile Include="GUI\DialogGUIButtonWithTooltip.cs" />
     <Compile Include="GUI\GUI_Tooltip.cs" />

--- a/Source/KerbalConstructionTime/PartCrewAssignment.cs
+++ b/Source/KerbalConstructionTime/PartCrewAssignment.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+
+namespace KerbalConstructionTime
+{
+    public class PartCrewAssignment
+    {
+        public List<CrewMemberAssignment> CrewList { get; set; }
+        public uint PartID { get; set; }
+
+        public PartCrewAssignment(uint ID, List<CrewMemberAssignment> crew)
+        {
+            PartID = ID;
+            CrewList = crew;
+        }
+
+        public PartCrewAssignment (Part part, List<CrewMemberAssignment> crew)
+        {
+            PartID = part.flightID;
+            CrewList = crew;
+        }
+    }
+
+    public class CrewMemberAssignment
+    {
+        public ProtoCrewMember PCM { get; set; }
+        public bool HasChute { get; set; }
+        public bool HasJetpack { get; set; }
+
+        public CrewMemberAssignment()
+        {
+        }
+
+        public CrewMemberAssignment(ProtoCrewMember pcm)
+        {
+            PCM = pcm;
+        }
+    }
+}


### PR DESCRIPTION
To support KSP 1.11 extracting chute and jetpack to separate inventory items that need to be assigned to the inventory of every kerbal. The stock logic of configuring inventories inside the VAB doesn't work too well since KCT assigns nauts to crewable parts in space center scene after the vessel has been built and rolled to the pad.

Depends on https://github.com/KSP-RO/RealismOverhaul/pull/2537 and https://github.com/KSP-RO/ROKerbalism/commit/27a696fde4daca919c4f50a43a91d3428b1db261.

![image](https://user-images.githubusercontent.com/1120038/140592602-0bd0d622-4f6c-4793-a5c7-b9a9610d38bb.png)
