### PR TITLE
Adding Reputation and Hype to career logging

### DIFF
--- a/Source/CareerLog/CareerLog.cs
+++ b/Source/CareerLog/CareerLog.cs
@@ -482,7 +482,7 @@ namespace RP0
                 otherFees = logPeriod.OtherFees - constructionFees,
                 fundsGainMult = logPeriod.FundsGainMult,
                 numNautsKilled = logPeriod.NumNautsKilled,
-                Reputation = logPeriod.Reputation,
+                reputation = logPeriod.Reputation,
                 headlinesHype = logPeriod.HeadlinesHype
             };
         }

--- a/Source/CareerLog/CareerLog.cs
+++ b/Source/CareerLog/CareerLog.cs
@@ -315,7 +315,7 @@ namespace RP0
                     p.EntryCosts.ToString("F0"),
                     constructionFees.ToString("F0"),
                     (p.OtherFees - constructionFees).ToString("F0"),
-                    p.KSPReputation.ToString("F1"),
+                    p.Reputation.ToString("F1"),
                     p.HeadlinesHype.ToString("F1"),
                     string.Join(", ", _launchedVessels.Where(l => l.IsInPeriod(p))
                                                       .Select(l => l.VesselName)
@@ -482,7 +482,7 @@ namespace RP0
                 otherFees = logPeriod.OtherFees - constructionFees,
                 fundsGainMult = logPeriod.FundsGainMult,
                 numNautsKilled = logPeriod.NumNautsKilled,
-                kspReputation = logPeriod.KSPReputation,
+                Reputation = logPeriod.Reputation,
                 headlinesHype = logPeriod.HeadlinesHype
             };
         }
@@ -499,7 +499,7 @@ namespace RP0
                 _prevPeriod.RnDUpgrades = GetKCTUpgradeCounts(SpaceCenterFacility.ResearchAndDevelopment);
                 _prevPeriod.ScienceEarned = GetSciPointTotalFromKCT();
                 _prevPeriod.FundsGainMult = HighLogic.CurrentGame.Parameters.Career.FundsGainMultiplier;
-                _prevPeriod.KSPReputation = Reputation.CurrentRep;
+                _prevPeriod.Reputation = Reputation.CurrentRep;
                 _prevPeriod.HeadlinesHype = GetHeadlinesHype();
             }
 

--- a/Source/CareerLog/CareerLog.cs
+++ b/Source/CareerLog/CareerLog.cs
@@ -316,7 +316,7 @@ namespace RP0
                     constructionFees.ToString("F0"),
                     (p.OtherFees - constructionFees).ToString("F0"),
                     p.KSPReputation.ToString("F1"),
-                    p.HeadlinesReputation.ToString("F1"),
+                    p.HeadlinesHype.ToString("F1"),
                     string.Join(", ", _launchedVessels.Where(l => l.IsInPeriod(p))
                                                       .Select(l => l.VesselName)
                                                       .ToArray()),
@@ -483,7 +483,7 @@ namespace RP0
                 fundsGainMult = logPeriod.FundsGainMult,
                 numNautsKilled = logPeriod.NumNautsKilled,
                 KSPReputation = logPeriod.KSPReputation,
-                HeadlinesReputation = logPeriod.HeadlinesReputation
+                HeadlinesReputation = logPeriod.HeadlinesHype
             };
         }
 
@@ -500,7 +500,7 @@ namespace RP0
                 _prevPeriod.ScienceEarned = GetSciPointTotalFromKCT();
                 _prevPeriod.FundsGainMult = HighLogic.CurrentGame.Parameters.Career.FundsGainMultiplier;
                 _prevPeriod.KSPReputation = Reputation.CurrentRep;
-                _prevPeriod.HeadlinesReputation = GetHeadlinesHype();
+                _prevPeriod.HeadlinesHype = GetHeadlinesHype();
             }
 
             _currentPeriod = GetOrCreatePeriod(NextPeriodStart);

--- a/Source/CareerLog/CareerLog.cs
+++ b/Source/CareerLog/CareerLog.cs
@@ -1,6 +1,5 @@
 ﻿using Contracts;
 using Csv;
-using Headlines;
 using KerbalConstructionTime;
 using System;
 using System.Collections;
@@ -47,6 +46,11 @@ namespace RP0
         private LogPeriod _currentPeriod;
 
         public static CareerLog Instance { get; private set; }
+
+        /// <summary>
+        /// Default means to get hype for career not using Headlines
+        /// </summary>
+        public static Func<double> GetHeadlinesHype = () => { return 0; };
 
         public LogPeriod CurrentPeriod
         { 
@@ -496,14 +500,7 @@ namespace RP0
                 _prevPeriod.ScienceEarned = GetSciPointTotalFromKCT();
                 _prevPeriod.FundsGainMult = HighLogic.CurrentGame.Parameters.Career.FundsGainMultiplier;
                 _prevPeriod.KSPReputation = Reputation.CurrentRep;
-                if (AssemblyLoader.loadedAssemblies.Any(a => string.Equals(a.name, "Headlines", StringComparison.OrdinalIgnoreCase)))
-                {
-                    _prevPeriod.HeadlinesReputation = StoryEngine.Instance.GetHeadlinesReputation();
-                }
-                else
-                {
-                    _prevPeriod.HeadlinesReputation = 0;
-                }
+                _prevPeriod.HeadlinesReputation = GetHeadlinesHype();
             }
 
             _currentPeriod = GetOrCreatePeriod(NextPeriodStart);

--- a/Source/CareerLog/CareerLog.cs
+++ b/Source/CareerLog/CareerLog.cs
@@ -482,8 +482,8 @@ namespace RP0
                 otherFees = logPeriod.OtherFees - constructionFees,
                 fundsGainMult = logPeriod.FundsGainMult,
                 numNautsKilled = logPeriod.NumNautsKilled,
-                KSPReputation = logPeriod.KSPReputation,
-                HeadlinesReputation = logPeriod.HeadlinesHype
+                kspReputation = logPeriod.KSPReputation,
+                headlinesHype = logPeriod.HeadlinesHype
             };
         }
 

--- a/Source/CareerLog/CareerLogDto.cs
+++ b/Source/CareerLog/CareerLogDto.cs
@@ -26,8 +26,8 @@ namespace RP0
         public double constructionFees;
         public double otherFees;
         public double fundsGainMult;
-        public double KSPReputation;
-        public double HeadlinesReputation;
+        public double kspReputation;
+        public double headlinesHype;
 
         public override string ToString()
         {
@@ -53,8 +53,8 @@ namespace RP0
                 $"{nameof(constructionFees)}: {constructionFees}, " +
                 $"{nameof(otherFees)}: {otherFees}, " +
                 $"{nameof(fundsGainMult)}: {fundsGainMult}, " +
-                $"{nameof(KSPReputation)}: {KSPReputation}, " +
-                $"{nameof(HeadlinesReputation)}: {HeadlinesReputation}";
+                $"{nameof(kspReputation)}: {kspReputation}, " +
+                $"{nameof(headlinesHype)}: {headlinesHype}";
         }
     }
 

--- a/Source/CareerLog/CareerLogDto.cs
+++ b/Source/CareerLog/CareerLogDto.cs
@@ -26,7 +26,7 @@ namespace RP0
         public double constructionFees;
         public double otherFees;
         public double fundsGainMult;
-        public double Reputation;
+        public double reputation;
         public double headlinesHype;
 
         public override string ToString()
@@ -53,7 +53,7 @@ namespace RP0
                 $"{nameof(constructionFees)}: {constructionFees}, " +
                 $"{nameof(otherFees)}: {otherFees}, " +
                 $"{nameof(fundsGainMult)}: {fundsGainMult}, " +
-                $"{nameof(Reputation)}: {Reputation}, " +
+                $"{nameof(reputation)}: {reputation}, " +
                 $"{nameof(headlinesHype)}: {headlinesHype}";
         }
     }

--- a/Source/CareerLog/CareerLogDto.cs
+++ b/Source/CareerLog/CareerLogDto.cs
@@ -26,7 +26,7 @@ namespace RP0
         public double constructionFees;
         public double otherFees;
         public double fundsGainMult;
-        public double kspReputation;
+        public double Reputation;
         public double headlinesHype;
 
         public override string ToString()
@@ -53,7 +53,7 @@ namespace RP0
                 $"{nameof(constructionFees)}: {constructionFees}, " +
                 $"{nameof(otherFees)}: {otherFees}, " +
                 $"{nameof(fundsGainMult)}: {fundsGainMult}, " +
-                $"{nameof(kspReputation)}: {kspReputation}, " +
+                $"{nameof(Reputation)}: {Reputation}, " +
                 $"{nameof(headlinesHype)}: {headlinesHype}";
         }
     }

--- a/Source/CareerLog/LogPeriod.cs
+++ b/Source/CareerLog/LogPeriod.cs
@@ -58,7 +58,7 @@ namespace RP0
         public int NumNautsKilled;
 
         [Persistent] 
-        public double KSPReputation;
+        public double Reputation;
 
         [Persistent] 
         public double HeadlinesHype;

--- a/Source/CareerLog/LogPeriod.cs
+++ b/Source/CareerLog/LogPeriod.cs
@@ -61,7 +61,7 @@ namespace RP0
         public double KSPReputation;
 
         [Persistent] 
-        public double HeadlinesReputation;
+        public double HeadlinesHype;
 
         public LogPeriod()
         {


### PR DESCRIPTION
Tested on RP1 install with and without Headlines. The first field, `Reputation` is KSP's reputation. The field `hype` is unique to Headlines and thus 0 when the mod isn't installed. We want one plot showing Reputation as one polygonal curve, and another curve for Reputation+hype. 

Not sure if the target of the PR should be master. 