### PR TITLE
Adjust ScanSat bodies categories

### DIFF
--- a/GameData/RP-0/Contracts/Groups.cfg
+++ b/GameData/RP-0/Contracts/Groups.cfg
@@ -288,8 +288,9 @@ CONTRACT_GROUP
 		
 		nextBodies = NextUnreachedBodies(2).Where(cb => (cb.HasSurface() && cb != HomeWorld() && cb.Parent() != HomeWorld()))
 		
-		avgBodies 		= [ Vesta, Ceres, Phobos, Deimos ]
-		normBodies 		= [ Venus, Mars, Vesta, Ceres, Phobos, Deimos ]
+		avgBodies 		= [ Vesta, Ceres ]
+		normBodies 		= [ Venus, Mars, Moon, Vesta, Ceres ]
+		potatoBodies    = [ Phobos, Deimos ]
 		noLandBodies 	= [ Jupiter, Saturn, Uranus, Neptune ]
 		hardBodies 		= [ Mercury, Pluto, Charon ]
 		jupiterMoons 	= AllBodies().Where(cb => cb.Parent() == Jupiter)

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_Biome.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Average_Biome.cfg
@@ -41,7 +41,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	DATA_EXPAND
 	{
 		type				= CelestialBody
-		targetBody1			= @RP0:avgBodies
+		targetBody1			= @RP0:normBodies
 	}
 	
 	DATA

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Potato_AltimetryLoRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Potato_AltimetryLoRes.cfg
@@ -1,18 +1,18 @@
 CONTRACT_TYPE:NEEDS[SCANsat]
 {
-	name = RP0_SCANSat_Average_HiRes
-	title = Conduct a High Resolution SAR SCANsat survey of @/targetBodyValid1
-	genericTitle = Conduct a High Resolution SAR SCANsat survey.
+	name = RP0_SCANSat_Potato_LoRes
+	title = Conduct Low Resolution SCANsat survey of @/targetBodyValid1
+	genericTitle = Conduct Low Resolution SCANsat survey.
 	group = RP0ScanSat
 	agent = #autoLOC_SCANsat_Agents_Name
 	
-	description = Create a satellite that can provide high resolution SAR mapping of @/targetBodyValid1. For best results, the orbit should have a high inclination to cover all surface area of the planetary body. Be sure to look at the information available for each scanner to determine the best altitude to scan.
+	description = Create a satellite that can provide low resolution images and mapping of @/targetBodyValid1. For best results, the orbit should have a high inclination to cover all surface area of the planetary body. Be sure to look at the information available for each scanner to determine the best altitude to scan.
 	
-	genericDescription = Perform a High Resolution survey of the targeted celestial body.
+	genericDescription = Perform a Low Resolution Scan of the targeted celestial body.
 
-	synopsis = Perform a High Resolution survey of @/targetBodyValid1.
+	synopsis = Perform a Low Resolution survey of @/targetBodyValid1.
 
-	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the surface of the planet. The increased fidelity from the SAR mapping will unlock many more details about the planet.
+	completedMessage = Mission Success! This mapping survey will be very valuable to the scientists on Earth looking to learn more about the surface of the planet.
 
 	sortKey = 100
 
@@ -23,14 +23,14 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	maxExpiry = 0
 	maxCompletions = 0
 	maxSimultaneous = 5
-	deadline = 365 * RP1DeadlineMult() * ( @/targetBodyValid1.Multiplier() / 2 )
+	deadline = 365 * RP1DeadlineMult() * ( @/targetBodyValid1.Multiplier() / 3 )
 
 	targetBody = @/targetBodyValid1
 
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 1500 * @RP0:globalHardContractMultiplier
+	advanceFunds = 500 * @RP0:globalHardContractMultiplier
 	rewardFunds = @advanceFunds * 6
 	rewardScience = 0
 	rewardReputation = 10
@@ -41,7 +41,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	DATA_EXPAND
 	{
 		type				= CelestialBody
-		targetBody1			= @RP0:normBodies
+		targetBody1			= @RP0:potatoBodies
 	}
 	
 	DATA
@@ -67,7 +67,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	{
 		name				= ReachedBody
 		type				= Expression
-		title				= Must have orbited the target body
+		title				= Must have reached the target body
 		expression			= @/targetBodyList1.Contains(@/targetBodyValid1) == true
 	}
 	
@@ -85,7 +85,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 		targetBody 	= @/targetBodyValid1
 		minCoverage = -1
 		maxCoverage	= 70
-		scanType	= AltimetryHiRes
+		scanType	= AltimetryLoRes
 		title		= Must have scanned less than 70% of the target body.
 	}
 	
@@ -93,8 +93,8 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	{
 		name = TechResearched
 		type = TechResearched
-		tech = deepSpaceScience
-		title = Have unlocked Deep Space Science Experiments for SAR
+		tech = scienceHuman
+		title = Have unlocked Early Human Spaceflight Era Science for Radar Altimeter
 	}
 	
 	// ************ PARAMETERS ************
@@ -105,6 +105,6 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 		type		= SCANsatCoverage
 		targetBody 	= @/targetBodyValid1
 		coverage	= 85
-		scanType	= AltimetryHiRes
+		scanType	= AltimetryLoRes
 	}	
 }

--- a/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Potato_HiRes.cfg
+++ b/GameData/RP-0/Contracts/ScanSat/RP0_SCANSat_Potato_HiRes.cfg
@@ -1,6 +1,6 @@
 CONTRACT_TYPE:NEEDS[SCANsat]
 {
-	name = RP0_SCANSat_Average_HiRes
+	name = RP0_SCANSat_Potato_HiRes
 	title = Conduct a High Resolution SAR SCANsat survey of @/targetBodyValid1
 	genericTitle = Conduct a High Resolution SAR SCANsat survey.
 	group = RP0ScanSat
@@ -30,7 +30,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 
 	// ************ REWARDS ************
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 1500 * @RP0:globalHardContractMultiplier
+	advanceFunds = 750 * @RP0:globalHardContractMultiplier
 	rewardFunds = @advanceFunds * 6
 	rewardScience = 0
 	rewardReputation = 10
@@ -41,7 +41,7 @@ CONTRACT_TYPE:NEEDS[SCANsat]
 	DATA_EXPAND
 	{
 		type				= CelestialBody
-		targetBody1			= @RP0:normBodies
+		targetBody1			= @RP0:potatoBodies
 	}
 	
 	DATA


### PR DESCRIPTION
Fix issue mentioned in https://discord.com/channels/319857228905447436/320197886614700033/908046700965404732.
1. Add biome and HiRes scans to the moon, Mars, and Venus.
2. Remove biome scans from Phobos and Deimos since they have only one biome. Also lowered the reward for altimetry scans.