### PR TITLE
Reconfigure naut G limits

### DIFF
--- a/GameData/RP-0/CrewSettings.cfg
+++ b/GameData/RP-0/CrewSettings.cfg
@@ -1,15 +1,17 @@
 @PHYSICSGLOBALS:FOR[RP-0]
 {
-	@kerbalGBraveMult = 1
-	@kerbalGBadMult = 1.05
-	@kerbalGOffset = 3165
+	@kerbalGBraveMult = 1           // Courage stat no longer has any effect on G tolerances
+	@kerbalGBadMult = 1.025         // Down significantly from the 1.5 mult that stock uses
+	@kerbalGOffset = 1786           // Gives 6.5 sustained G's for Engineers and Scientists. Pilots have their own multiplier on top that brings the value to 7.5.
+	@kerbalGThresholdLOC = 90000    // A slight increase from the stock 60 000
+	@kerbalGThresholdWarn = 45000   // Stock uses a value that is half of kerbalGThresholdLOC
 }
 
 @EXPERIENCE_TRAIT[Pilot]:FOR[RP-0]
 {
 	@EFFECT[GeeForceTolerance]
 	{
-		@modifiers = 1.025, 1.05, 1.075, 1.1, 1.125
+		@modifiers = 1.183, 1.206, 1.223, 1.235, 1.246
 	}
 	
 	@EFFECT[EVAChuteSkill]
@@ -22,7 +24,7 @@
 {
 	@EFFECT[GeeForceTolerance]
 	{
-		@modifiers = 1.025, 1.05, 1.075, 1.1, 1.125
+		@modifiers = 1.025, 1.045, 1.06, 1.07, 1.08
 	}
 	
 	@EFFECT[EVAChuteSkill]
@@ -35,7 +37,7 @@
 {
 	@EFFECT[GeeForceTolerance]
 	{
-		@modifiers = 1.025, 1.05, 1.075, 1.1, 1.125
+		@modifiers = 1.025, 1.045, 1.06, 1.07, 1.08
 	}
 	
 	@EFFECT[EVAChuteSkill]

--- a/GameData/RP-0/CrewSettings.cfg
+++ b/GameData/RP-0/CrewSettings.cfg
@@ -1,0 +1,45 @@
+@PHYSICSGLOBALS:FOR[RP-0]
+{
+	@kerbalGBraveMult = 1
+	@kerbalGBadMult = 1.05
+	@kerbalGOffset = 3165
+}
+
+@EXPERIENCE_TRAIT[Pilot]:FOR[RP-0]
+{
+	@EFFECT[GeeForceTolerance]
+	{
+		@modifiers = 1.025, 1.05, 1.075, 1.1, 1.125
+	}
+	
+	@EFFECT[EVAChuteSkill]
+	{
+		@level = 0
+	}
+}
+
+@EXPERIENCE_TRAIT[Engineer]:FOR[RP-0]
+{
+	@EFFECT[GeeForceTolerance]
+	{
+		@modifiers = 1.025, 1.05, 1.075, 1.1, 1.125
+	}
+	
+	@EFFECT[EVAChuteSkill]
+	{
+		@level = 0
+	}
+}
+
+@EXPERIENCE_TRAIT[Scientist]:FOR[RP-0]
+{
+	@EFFECT[GeeForceTolerance]
+	{
+		@modifiers = 1.025, 1.05, 1.075, 1.1, 1.125
+	}
+	
+	@EFFECT[EVAChuteSkill]
+	{
+		@level = 0
+	}
+}


### PR DESCRIPTION
* Pilot, engineer and scientist now have the same G multipliers
* Each experience level adds 0.025 to the multiplier
* Badass flag adds 0.05 to the multiplier
* Courage no longer has any effect on G mult
* Set max sustained at 7.5G
* As an unrelated change - make chute available from experience lvl 0 for all naut classes