### PR TITLE
Move return parameter on all sample return contracts inside vesselGroup

### DIFF
--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Sample Return.cfg
@@ -103,14 +103,14 @@ CONTRACT_TYPE
 			disableOnStateChange = true
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return Home Safely with the Science
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return Home Safely with the Science
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Asteroid Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Asteroid Sample Return.cfg
@@ -70,13 +70,13 @@ CONTRACT_TYPE
 			title = Attach to the Asteroid with a Grabbing Device
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 }

--- a/GameData/RP-0/Contracts/Sample Return/Callisto Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Callisto Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Callisto
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Charon Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Charon Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Charon
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Dione Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Dione Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Dione
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Enceladus Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Enceladus Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Enceladus
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Europa Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Europa Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Europa
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Ganymede Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Ganymede Sample Return.cfg
@@ -71,15 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Ganymede
 			hideChildren = true
 		}
-		
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Iapetus Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Iapetus Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Iapetus
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Io Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Io Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Io
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Mars Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Mars Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Mars
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Mercury Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Mercury Sample Return.cfg
@@ -71,15 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Mercury
 			hideChildren = true
 		}
-
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Mimas Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Mimas Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Mimas
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Phobos Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Phobos Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Phobos
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Pluto Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Pluto Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Pluto
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Rhea Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Rhea Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Rhea
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Tethys Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Tethys Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Tethys
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Titan Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Titan Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Titan
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Sample Return/Triton Sample Return.cfg
+++ b/GameData/RP-0/Contracts/Sample Return/Triton Sample Return.cfg
@@ -71,14 +71,14 @@ CONTRACT_TYPE
 			title = Safely Land on Triton
 			hideChildren = true
 		}
-	}
-	PARAMETER
-	{
-		name = ReturnHome
-		type = RP1ReturnHome
-		title = Return to Earth Safely with the Samples
-		hideChildren = true
-		completeInSequence = true
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return to Earth Safely with the Samples
+			hideChildren = true
+			completeInSequence = true
+		}
 	}
 	PARAMETER
 	{


### PR DESCRIPTION
Current structure often leads to contract completion too early. The reason for the old setup was because in some cases it would fail to complete, but not completing when it should might be desirable over completing too easily.