### PR TITLE
Limit both Lunar Rover contracts to a max latitude

### DIFF
--- a/GameData/RP-0/Contracts/Moon Exploration/Crewed Moon Landing and Rover.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Crewed Moon Landing and Rover.cfg
@@ -42,7 +42,41 @@ CONTRACT_TYPE
 		type = CompleteContract
 		contractType = RepeatMoonLandingCrew
 	}
-	
+
+	DATA
+	{
+		type = double
+		pi = 3.14159265358979
+	}
+
+	DATA
+	{
+		type = double
+		maxLat = 45
+	}
+
+	DATA
+	{
+		type = double
+		lat = 90 - 180 / @/pi * Acos(Sin(@/pi / 180 * @/maxLat) * (1 - 2 * Random()))
+		long = 180 * (1 - 2 * Random())
+	}
+
+	DATA
+	{
+		type = double
+		latMag = Max(@/lat, -@/lat)
+		longMag = Max(@/long, -@/long)
+	}
+
+	DATA
+	{
+		type = string
+		NorthSouthString = @/lat >= 0 ? "° North" : "° South"
+		EastWestString = @/long >= 0 ? "° East" : "° West"
+		hidden = true
+	}
+
 	DATA
 	{
 		type = int
@@ -110,7 +144,7 @@ CONTRACT_TYPE
 		type = VisitWaypoint
 		index = 0
 		distance = 100.0
-		title = Land near or travel to Site Alpha
+		title = Land near or travel to Site Alpha, located at: @/latMag.ToString("N2")@/NorthSouthString, @/longMag.ToString("N2")@/EastWestString
 		showMessages = true
 		disableOnStateChange = true
 		hideChildren = true
@@ -160,16 +194,15 @@ CONTRACT_TYPE
 		name = WaypointGenerator
 		type = WaypointGenerator
 
-		RANDOM_WAYPOINT
+		WAYPOINT
 		{
 			name = Site Alpha
 			hidden = False
 			targetBody = Moon
-			count = 1
 			icon = marker
 			altitude = 0.0
-			waterAllowed = false
-			forceEquatorial = false
+			latitude = @/lat
+			longitude = @/long
 		}
 
 		RANDOM_WAYPOINT_NEAR

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Rover.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Rover.cfg
@@ -111,6 +111,7 @@ CONTRACT_TYPE
 		type = string
 		NorthSouthString = @/NorthSouthList.ElementAt(@/NorthSouthInt)
 		EastWestString = @/EastWestList.ElementAt(@/EastWestInt)
+		hidden = true
 	}
 
 	DATA
@@ -212,10 +213,8 @@ CONTRACT_TYPE
 			name = Lunar Rover Alpha
 			hidden = False
 			targetBody = Moon
-			count = 1
 			icon = marker
 			altitude = 0.0
-			waterAllowed = false
 			latitude = @/lat
 			longitude = @/long
 		}

--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Rover.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Rover.cfg
@@ -69,8 +69,20 @@ CONTRACT_TYPE
 	DATA
 	{
 		type = double
-		lat = @/WaypointGenerator.Waypoints().ElementAt(0).Latitude()
-		long = @/WaypointGenerator.Waypoints().ElementAt(0).Longitude()
+		pi = 3.14159265358979
+	}
+
+	DATA
+	{
+		type = double
+		maxLat = 45
+	}
+
+	DATA
+	{
+		type = double
+		lat = 90 - 180 / @/pi * Acos(Sin(@/pi / 180 * @/maxLat) * (1 - 2 * Random()))
+		long = 180 * (1 - 2 * Random())
 	}
 
 	DATA
@@ -195,7 +207,7 @@ CONTRACT_TYPE
 		name = WaypointGenerator
 		type = WaypointGenerator
 
-		RANDOM_WAYPOINT
+		WAYPOINT
 		{
 			name = Lunar Rover Alpha
 			hidden = False
@@ -204,7 +216,8 @@ CONTRACT_TYPE
 			icon = marker
 			altitude = 0.0
 			waterAllowed = false
-			forceEquatorial = true
+			latitude = @/lat
+			longitude = @/long
 		}
 
 		RANDOM_WAYPOINT_NEAR


### PR DESCRIPTION
The distribution is uniform area wise, meaning a higher latitude is proportionally less likely as the total area at that latitude is less.

Currently both contracts are set to a max of 45°