### PR TITLE
Add Model 304, more fuel type gates

### DIFF
--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -534,6 +534,7 @@
     RO-X-248 = Altair
     RO-X-258 = Altair-II
     RO-XLR99 = XLR99
+    RO-model304 = 10000,HydroloxPumps
     RO-rangerSolarPanel = 1000, solarLevel1, solarDeployable
     RO-reactor-BES5 = 100000
     RO-reactor-TOPAZI = 200000

--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -534,7 +534,6 @@
     RO-X-248 = Altair
     RO-X-258 = Altair-II
     RO-XLR99 = XLR99
-    RO-model304 = 10000,HydroloxPumps
     RO-rangerSolarPanel = 1000, solarLevel1, solarDeployable
     RO-reactor-BES5 = 100000
     RO-reactor-TOPAZI = 200000

--- a/GameData/RP-0/Tree/ResourceTechs.cfg
+++ b/GameData/RP-0/Tree/ResourceTechs.cfg
@@ -10,23 +10,7 @@
 	}
 	@TANK[LqdHydrogen]
 	{
-		%techRequired = materialsScienceSatellite  // 1956 Blue Sky Node (for SUNTAN)
-	}
-	@TANK[FLOX30]
-	{
-		%techRequired = materialsScienceSatellite
-	}
-	@TANK[FLOX70]
-	{
-		%techRequired = materialsScienceSatellite
-	}
-	@TANK[FLOX88]
-	{
-		%techRequired = materialsScienceSatellite
-	}
-	@TANK[Syntin]
-	{
-		%techRequired = materialsScienceSpaceplanes
+		%techRequired = materialsScienceHuman  // 1961 Blue Sky Node
 	}
 }
 @TANK_DEFINITION[*]:AFTER[TacLifeSupport]

--- a/GameData/RP-0/Tree/ResourceTechs.cfg
+++ b/GameData/RP-0/Tree/ResourceTechs.cfg
@@ -10,7 +10,23 @@
 	}
 	@TANK[LqdHydrogen]
 	{
-		%techRequired = materialsScienceHuman  // 1961 Blue Sky Node
+		%techRequired = materialsScienceSatellite  // 1956 Blue Sky Node (for SUNTAN)
+	}
+	@TANK[FLOX30]
+	{
+		%techRequired = materialsScienceSatellite
+	}
+	@TANK[FLOX70]
+	{
+		%techRequired = materialsScienceSatellite
+	}
+	@TANK[FLOX88]
+	{
+		%techRequired = materialsScienceSatellite
+	}
+	@TANK[Syntin]
+	{
+		%techRequired = materialsScienceSpaceplanes
 	}
 }
 @TANK_DEFINITION[*]:AFTER[TacLifeSupport]

--- a/GameData/RP-0/Tree/ResourceTechs.cfg
+++ b/GameData/RP-0/Tree/ResourceTechs.cfg
@@ -10,7 +10,7 @@
 	}
 	@TANK[LqdHydrogen]
 	{
-		%techRequired = materialsScienceHuman  // 1961 Blue Sky Node
+		%techRequired = materialsScienceSatellite  // 1956 Blue Sky Node (for SUNTAN)
 	}
 }
 @TANK_DEFINITION[*]:AFTER[TacLifeSupport]

--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -9677,6 +9677,14 @@
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
+@PART[RO-model304]:FOR[xxxRP0]
+{
+    %TechRequired = highSpeedFlight
+    %cost = 200
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From Advanced Jet Engines mod</color></b>
+}
 @PART[RO-rangerSolarPanel]:FOR[xxxRP0]
 {
     %TechRequired = earlyPower

--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -9677,14 +9677,6 @@
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
-@PART[RO-model304]:FOR[xxxRP0]
-{
-    %TechRequired = highSpeedFlight
-    %cost = 200
-    %entryCost = 0
-    RP0conf = true
-    @description ^=:$: <b><color=green>From Advanced Jet Engines mod</color></b>
-}
 @PART[RO-rangerSolarPanel]:FOR[xxxRP0]
 {
     %TechRequired = earlyPower

--- a/Source/Tech Tree/Parts Browser/data/Advanced_Jet_Engines.json
+++ b/Source/Tech Tree/Parts Browser/data/Advanced_Jet_Engines.json
@@ -126,27 +126,6 @@
         "module_tags": []
     },
     {
-        "name": "RO-model304",
-        "title": "Model 304-2 Turbojet",
-        "description": "",
-        "mod": "Advanced Jet Engines",
-        "cost": "200",
-        "entry_cost": "0",
-        "category": "FLIGHT",
-        "info": "Engine",
-        "year": "1959",
-        "technology": "highSpeedFlight",
-        "ro": true,
-        "orphan": false,
-        "rp0_conf": true,
-        "spacecraft": "SUNTAN",
-        "engine_config": "",
-        "upgrade": false,
-        "entry_cost_mods": "10000,HydroloxPumps",
-        "identical_part_name": "",
-        "module_tags": []
-    },
-    {
         "name": "aje_al31",
         "title": "AL-31FM turbofan",
         "description": "Modern afterburning turbofan used on the Su-27M, Su-30, and Su-34 featuring vector thrust.  122.4 kN wet, 76.2 kN dry, SFC 0.75/1.92 lb/lb hr. Max 2.5 Mach.",

--- a/Source/Tech Tree/Parts Browser/data/Advanced_Jet_Engines.json
+++ b/Source/Tech Tree/Parts Browser/data/Advanced_Jet_Engines.json
@@ -126,6 +126,27 @@
         "module_tags": []
     },
     {
+        "name": "RO-model304",
+        "title": "Model 304-2 Turbojet",
+        "description": "",
+        "mod": "Advanced Jet Engines",
+        "cost": "200",
+        "entry_cost": "0",
+        "category": "FLIGHT",
+        "info": "Engine",
+        "year": "1959",
+        "technology": "highSpeedFlight",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "SUNTAN",
+        "engine_config": "",
+        "upgrade": false,
+        "entry_cost_mods": "10000,HydroloxPumps",
+        "identical_part_name": "",
+        "module_tags": []
+    },
+    {
         "name": "aje_al31",
         "title": "AL-31FM turbofan",
         "description": "Modern afterburning turbofan used on the Su-27M, Su-30, and Su-34 featuring vector thrust.  122.4 kN wet, 76.2 kN dry, SFC 0.75/1.92 lb/lb hr. Max 2.5 Mach.",


### PR DESCRIPTION
Add the P&W Model 304. Also move LH2 gate back to Satellite era science to allow the Model 304 to be used, and add gates to FLOX and Syntin.