### PR TITLE
Add support for FWC-SRM engine config

### DIFF
--- a/GameData/RP-0/Tree/ECM-Engines.cfg
+++ b/GameData/RP-0/Tree/ECM-Engines.cfg
@@ -544,4 +544,5 @@
     XM-20 = 4000, SolidsHollow, SolidsComposite
     XRS-2200 = 0
     YF-77 = 300000,HydroloxPumps
+    FWC-SRM = RSRM-1981
 }

--- a/GameData/RP-0/Tree/TREE-Engines.cfg
+++ b/GameData/RP-0/Tree/TREE-Engines.cfg
@@ -3541,6 +3541,13 @@
                 %cost = 0
             }
 
+            @CONFIG[FWC-SRM]
+            {
+                %techRequired = solids1992
+                %cost = 6780
+                *@PARTUPGRADE[RFUpgrade_FWC-SRM]/deleteme -= 1
+            }
+
         }
 }
 
@@ -7168,4 +7175,18 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Agena Engine now supports the XLR81-LF2-SPS configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nLiquid Fluorine based design, proposed for use on the GE D-2 Apollo vehicle, and later high performance Agena tugs.
+}
+
+PARTUPGRADE
+{
+        name = RFUpgrade_FWC-SRM
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = solids1992
+        entryCost = 0
+        cost = 0      
+        title = RSRM Engine Upgrade: FWC-SRM Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The RSRM Engine now supports the FWC-SRM configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -2165,6 +2165,27 @@
         "module_tags": []
     },
     {
+        "name": "FWC-SRM",
+        "title": "FWC-SRM config",
+        "description": "",
+        "mod": "Engine_Config",
+        "cost": "6780",
+        "entry_cost": "0",
+        "category": "SOLID",
+        "info": "",
+        "year": "1992",
+        "technology": "solids1992",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "STS",
+        "engine_config": "RSRM",
+        "upgrade": true,
+        "entry_cost_mods": "RSRM-1981",
+        "identical_part_name": "",
+        "module_tags": []
+    },
+    {
         "name": "GCRC",
         "title": "GCRC",
         "description": "",


### PR DESCRIPTION
Places the FWC-SRM config one node after the redesigned (Post Challenger) RSRM, even though it was developed before. This is for game-play reasons, since having two configs in the same node would be odd, and placing the better config later seems like the better choise, especially since it never flew.