### PR TITLE
Prevent Surface Outpost contracts from choosing any vessel

### DIFF
--- a/GameData/RP-0/Contracts/Surface Outposts/MarsOutpost.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MarsOutpost.cfg
@@ -74,6 +74,34 @@ CONTRACT_TYPE
 			title = Launch a New Outpost
 			hideChildren = true
 		}
+		PARAMETER
+		{
+			name = HasCapacity
+			type = HasCrewCapacity
+			minCapacity = 4
+			title = Space for at least 4 crew
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Uncrewed
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+			title = Uncrewed
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = LandOnMars
+			type = ReachState
+			targetBody = Mars
+			situation = LANDED
+   			situation = SPLASHED
+			title = Land on Mars
+			disableOnStateChange = True
+			hideChildren = true
+		}
 		disableOnStateChange = true
 	}
 	PARAMETER
@@ -91,14 +119,6 @@ CONTRACT_TYPE
 			type = HasCrew
 			minCrew = 2
 			title = Have at least 2 crewmembers on board
-			hideChildren = true
-		}
-		PARAMETER
-		{
-			name = HasCapacity
-			type = HasCrewCapacity
-			minCapacity = 4
-			title = Space for at least 4 crew
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Surface Outposts/MarsOutpostWithLab.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MarsOutpostWithLab.cfg
@@ -68,6 +68,33 @@ CONTRACT_TYPE
 			title = Launch a New Outpost
 			hideChildren = true
 		}
+		PARAMETER
+		{
+			name = HasCapacity
+			type = HasCrewCapacity
+			minCapacity = 10
+			title = Space for at least 10 crew
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = HasLab
+			type = PartValidation
+			partModule = ModuleScienceLab
+			title = Surface outpost has a lab
+			minCount = 1
+		}
+		PARAMETER
+		{
+			name = LandOnMars
+			type = ReachState
+			targetBody = Mars
+			situation = LANDED
+   			situation = SPLASHED
+			title = Land on Mars
+			disableOnStateChange = True
+			hideChildren = true
+		}
 		disableOnStateChange = true
 	}
 		
@@ -86,14 +113,6 @@ CONTRACT_TYPE
 			type = HasCrew
 			minCrew = 4
 			title = Have at least 2 crewmembers on board
-			hideChildren = true
-		}
-		PARAMETER
-		{
-			name = HasCapacity
-			type = HasCrewCapacity
-			minCapacity = 10
-			title = Space for at least 10 crew
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Surface Outposts/MoonOutpost.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MoonOutpost.cfg
@@ -68,6 +68,33 @@ CONTRACT_TYPE
 			title = Launch a New Outpost
 			hideChildren = true
 		}
+		PARAMETER
+		{
+			name = HasCapacity
+			type = HasCrewCapacity
+			minCapacity = 4
+			title = Space for at least 4 crew
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Uncrewed
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+			title = Uncrewed
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = LandOnMoon
+			type = ReachState
+			targetBody = Moon
+			situation = LANDED
+			title = Land on the Moon
+			disableOnStateChange = True
+			hideChildren = true
+		}
 		disableOnStateChange = true
 	}
 	PARAMETER
@@ -85,14 +112,6 @@ CONTRACT_TYPE
 			type = HasCrew
 			minCrew = 2
 			title = Have at least 2 crewmembers on board
-			hideChildren = true
-		}
-		PARAMETER
-		{
-			name = HasCapacity
-			type = HasCrewCapacity
-			minCapacity = 4
-			title = Space for at least 4 crew
 			hideChildren = true
 		}
 		PARAMETER

--- a/GameData/RP-0/Contracts/Surface Outposts/MoonOutpostWithLab.cfg
+++ b/GameData/RP-0/Contracts/Surface Outposts/MoonOutpostWithLab.cfg
@@ -61,6 +61,32 @@ CONTRACT_TYPE
 			title = Launch a New Outpost
 			hideChildren = true
 		}
+		PARAMETER
+		{
+			name = HasCapacity
+			type = HasCrewCapacity
+			minCapacity = 10
+			title = Space for at least 10 crew
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = HasLab
+			type = PartValidation
+			partModule = ModuleScienceLab
+			title = Surface outpost has a lab
+			minCount = 1
+		}
+		PARAMETER
+		{
+			name = LandOnMoon
+			type = ReachState
+			targetBody = Moon
+			situation = LANDED
+			title = Land on the Moon
+			disableOnStateChange = True
+			hideChildren = true
+		}
 		disableOnStateChange = true
 	}
 	
@@ -79,14 +105,6 @@ CONTRACT_TYPE
 			type = HasCrew
 			minCrew = 4
 			title = Have at least 4 crewmembers on board
-			hideChildren = true
-		}
-		PARAMETER
-		{
-			name = HasCapacity
-			type = HasCrewCapacity
-			minCapacity = 10
-			title = Space for at least 10 crew
 			hideChildren = true
 		}
 		PARAMETER


### PR DESCRIPTION
Fixes the Surface Outpost contracts so that it doesn't choose a random vessel and locks onto it.