### PR TITLE
Add MLI PARTUPGRADES

### DIFF
--- a/GameData/RP-0/Tree/RFTechLevels.cfg
+++ b/GameData/RP-0/Tree/RFTechLevels.cfg
@@ -257,7 +257,7 @@ PARTUPGRADE
 	techRequired = materialsScienceLongTerm
 	entryCost = 100000
 	cost = 0
-	title = MLI Wrapping Upgrade  (100 layers)
+	title = MLI Wrapping Upgrade (100 layers)
 	manufacturer = Various
 	description = New precision welding techniques and composite materials allow for MLI blankets to be safely added to Balloon tanks.
 }

--- a/GameData/RP-0/Tree/RFTechLevels.cfg
+++ b/GameData/RP-0/Tree/RFTechLevels.cfg
@@ -264,7 +264,6 @@ PARTUPGRADE
 
 @PART[*]:HAS[@MODULE[ModuleFuelTanks]]:AFTER[zzzRealFuels]
 {
-
 	@MODULE[ModuleFuelTanks]:HAS[~type[Tank-Balloon*]]
 	{
 		%maxMLILayers = 0

--- a/GameData/RP-0/Tree/RFTechLevels.cfg
+++ b/GameData/RP-0/Tree/RFTechLevels.cfg
@@ -210,60 +210,43 @@ PARTUPGRADE
 	description = This is an upgrade to the technology level of RCS Thrusters and Engines
 }
 // MLI Tank Upgrades
-PARTUPGRADE
+@PARTUPGRADE[MLI.Upgrade1]
 {
-	name = RFTech-MLI-Upgrade1
-	partIcon = RCSBlock
-	techRequired = materialsScienceHuman
-	entryCost = 25000
-	cost = 0
-	title = MLI Wrapping Upgrade (1 layer)
-	manufacturer = Various
-	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+	@partIcon = RFTank-I
+	@techRequired = materialsScienceHuman
+	@entryCost = 25000
+	@title = MLI Wrapping Upgrade (1 layer)
+	@description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
 }
-PARTUPGRADE
+@PARTUPGRADE[MLI.Upgrade2]
 {
-	name = RFTech-MLI-Upgrade2
-	partIcon = RCSBlock
-	techRequired = materialsScienceAdvCapsules
-	entryCost = 25000
-	cost = 0
-	title = MLI Wrapping Upgrade (25 layers)
-	manufacturer = Various
-	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+	@partIcon = RFTank-I
+	@techRequired = materialsScienceAdvCapsules
+	@entryCost = 25000
+	@title = MLI Wrapping Upgrade (25 layers)
+	@description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
 }
-PARTUPGRADE
+@PARTUPGRADE[MLI.Upgrade3]
 {
-	name = RFTech-MLI-Upgrade3
-	partIcon = RCSBlock
-	techRequired = materialsScienceSpaceStation
-	entryCost = 50000
-	cost = 0
-	title = MLI Wrapping Upgrade (50 layers)
-	manufacturer = Various
-	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+	@partIcon = RFTank-I
+	@techRequired = materialsScienceSpaceStation
+	@entryCost = 50000
+	@title = MLI Wrapping Upgrade (50 layers)
+	@description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
 }
-PARTUPGRADE
+@PARTUPGRADE[MLI.Upgrade4]
 {
-	name = RFTech-MLI-Upgrade4
-	partIcon = RCSBlock
-	techRequired = materialsScienceSpaceplanes
-	entryCost = 50000
-	cost = 0
-	title = MLI Wrapping Upgrade (75 layers)
-	manufacturer = Various
-	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+	@partIcon = RFTank-I
+	@techRequired = materialsScienceSpaceplanes
+	@entryCost = 50000
+	@title = MLI Wrapping Upgrade (75 layers)
+	@description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
 }
-PARTUPGRADE
+@PARTUPGRADE[MLI.Upgrade5]
 {
-	name = RFTech-MLI-Upgrade5
-	partIcon = RCSBlock
-	techRequired = materialsScienceLongTerm
-	entryCost = 50000
-	cost = 0
-	title = MLI Wrapping Upgrade  (100 layers)
-	manufacturer = Various
-	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+	@partIcon = RFTank-I
+	@techRequired = materialsScienceLongTerm
+	@entryCost = 50000
 }
 
 PARTUPGRADE
@@ -296,31 +279,31 @@ PARTUPGRADE
 		{
 			UPGRADE
 			{
-				name__ = RFTech-MLI-Upgrade1
+				name__ = MLI.Upgrade1
 				description__ = Improved tank wrapping techniques allow 1 layer now.
 				maxMLILayers = 1
 			}
 			UPGRADE
 			{
-				name__ = RFTech-MLI-Upgrade2
+				name__ = MLI.Upgrade2
 				description__ = Improved tank wrapping techniques allow 25 layers now.
 				maxMLILayers = 25
 			}
 			UPGRADE
 			{
-				name__ = RFTech-MLI-Upgrade3
+				name__ = MLI.Upgrade3
 				description__ = Improved tank wrapping techniques allow 50 layers now.
 				maxMLILayers = 50
 			}
 			UPGRADE
 			{
-				name__ = RFTech-MLI-Upgrade4
+				name__ = MLI.Upgrade4
 				description__ = Improved tank wrapping techniques allow 75 layers now.
 				maxMLILayers = 75
 			}
 			UPGRADE
 			{
-				name__ = RFTech-MLI-Upgrade5
+				name__ = MLI.Upgrade5
 				description__ = Improved tank wrapping techniques allow 100 layers now.
 				maxMLILayers = 100
 			}

--- a/GameData/RP-0/Tree/RFTechLevels.cfg
+++ b/GameData/RP-0/Tree/RFTechLevels.cfg
@@ -263,55 +263,42 @@ PARTUPGRADE
 
 @PART[*]:HAS[@MODULE[ModuleFuelTanks]]:AFTER[zzzRealFuels]
 {
-	@MODULE[ModuleFuelTanks]
-	{
-		@UPGRADES
-		{
-			!UPGRADE:HAS[#name__[MLI*]] {}
-		}
-	}
 
 	@MODULE[ModuleFuelTanks]:HAS[~type[Tank-Balloon*]]
 	{
-	%maxMLILayers = 0
-	
-		%UPGRADES
+		%maxMLILayers = 0
+		@UPGRADES
 		{
-			UPGRADE
+			@UPGRADE:HAS[#name__[MLI.Upgrade1]]
 			{
-				name__ = MLI.Upgrade1
-				description__ = Improved tank wrapping techniques allow 1 layer now.
-				maxMLILayers = 1
+				@description__ = Improved tank wrapping techniques allow 1 layer now.
+				@maxMLILayers = 1
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[MLI.Upgrade2]]
 			{
-				name__ = MLI.Upgrade2
-				description__ = Improved tank wrapping techniques allow 25 layers now.
-				maxMLILayers = 25
+				@description__ = Improved tank wrapping techniques allow 25 layers now.
+				@maxMLILayers = 25
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[MLI.Upgrade3]]
 			{
-				name__ = MLI.Upgrade3
-				description__ = Improved tank wrapping techniques allow 50 layers now.
-				maxMLILayers = 50
+				@description__ = Improved tank wrapping techniques allow 50 layers now.
+				@maxMLILayers = 50
 			}
-			UPGRADE
+			@UPGRADE:HAS[#name__[MLI.Upgrade4]]
 			{
-				name__ = MLI.Upgrade4
-				description__ = Improved tank wrapping techniques allow 75 layers now.
-				maxMLILayers = 75
-			}
-			UPGRADE
-			{
-				name__ = MLI.Upgrade5
-				description__ = Improved tank wrapping techniques allow 100 layers now.
-				maxMLILayers = 100
+				@description__ = Improved tank wrapping techniques allow 75 layers now.
+				@maxMLILayers = 75
 			}
 		}
 	}
 	@MODULE[ModuleFuelTanks]:HAS[#type[Tank-Balloon*]]
 	{
-	%maxMLILayers = 0
+		%maxMLILayers = 0
+	
+		@UPGRADES
+		{
+			!UPGRADE:HAS[#name__[MLI*]] {}
+		}
 	
 		%UPGRADES
 		{

--- a/GameData/RP-0/Tree/RFTechLevels.cfg
+++ b/GameData/RP-0/Tree/RFTechLevels.cfg
@@ -216,7 +216,7 @@ PARTUPGRADE
 	@techRequired = materialsScienceAdvCapsules
 	@entryCost = 25000
 	@title = MLI Wrapping Upgrade (1 layer)
-	@description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+	@description = New materials research allows for tanks to be wrapped in a metallicized Mylar and Kapton blanket, greatly reducing radiative heating.
 }
 @PARTUPGRADE[MLI.Upgrade2]
 {
@@ -224,7 +224,7 @@ PARTUPGRADE
 	@techRequired = materialsScienceLunar
 	@entryCost = 25000
 	@title = MLI Wrapping Upgrade (25 layers)
-	@description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+	@description = Improved wrapping techniques allow additional layers of insulation.
 }
 @PARTUPGRADE[MLI.Upgrade3]
 {
@@ -232,7 +232,7 @@ PARTUPGRADE
 	@techRequired = materialsScienceSpaceStation
 	@entryCost = 50000
 	@title = MLI Wrapping Upgrade (50 layers)
-	@description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+	@description = Improved wrapping techniques allow additional layers of insulation.
 }
 @PARTUPGRADE[MLI.Upgrade4]
 {
@@ -240,13 +240,14 @@ PARTUPGRADE
 	@techRequired = materialsScienceSpaceplanes
 	@entryCost = 50000
 	@title = MLI Wrapping Upgrade (75 layers)
-	@description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+	@description = Improved wrapping techniques allow additional layers of insulation.
 }
 @PARTUPGRADE[MLI.Upgrade5]
 {
 	@partIcon = RFTank-I
 	@techRequired = materialsScienceLongTerm
 	@entryCost = 50000
+	@description = Improved wrapping techniques allow additional layers of insulation.
 }
 
 PARTUPGRADE
@@ -258,7 +259,7 @@ PARTUPGRADE
 	cost = 0
 	title = MLI Wrapping Upgrade  (100 layers)
 	manufacturer = Various
-	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+	description = New precision welding techniques and composite materials allow for MLI blankets to be safely added to Balloon tanks.
 }
 
 @PART[*]:HAS[@MODULE[ModuleFuelTanks]]:AFTER[zzzRealFuels]

--- a/GameData/RP-0/Tree/RFTechLevels.cfg
+++ b/GameData/RP-0/Tree/RFTechLevels.cfg
@@ -209,3 +209,135 @@ PARTUPGRADE
 	manufacturer = Generic
 	description = This is an upgrade to the technology level of RCS Thrusters and Engines
 }
+// MLI Tank Upgrades
+PARTUPGRADE
+{
+	name = RFTech-MLI-Upgrade1
+	partIcon = RCSBlock
+	techRequired = materialsScienceHuman
+	entryCost = 25000
+	cost = 0
+	title = MLI Wrapping Upgrade (1 layer)
+	manufacturer = Various
+	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+}
+PARTUPGRADE
+{
+	name = RFTech-MLI-Upgrade2
+	partIcon = RCSBlock
+	techRequired = materialsScienceAdvCapsules
+	entryCost = 25000
+	cost = 0
+	title = MLI Wrapping Upgrade (25 layers)
+	manufacturer = Various
+	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+}
+PARTUPGRADE
+{
+	name = RFTech-MLI-Upgrade3
+	partIcon = RCSBlock
+	techRequired = materialsScienceSpaceStation
+	entryCost = 50000
+	cost = 0
+	title = MLI Wrapping Upgrade (50 layers)
+	manufacturer = Various
+	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+}
+PARTUPGRADE
+{
+	name = RFTech-MLI-Upgrade4
+	partIcon = RCSBlock
+	techRequired = materialsScienceSpaceplanes
+	entryCost = 50000
+	cost = 0
+	title = MLI Wrapping Upgrade (75 layers)
+	manufacturer = Various
+	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+}
+PARTUPGRADE
+{
+	name = RFTech-MLI-Upgrade5
+	partIcon = RCSBlock
+	techRequired = materialsScienceLongTerm
+	entryCost = 50000
+	cost = 0
+	title = MLI Wrapping Upgrade  (100 layers)
+	manufacturer = Various
+	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+}
+
+PARTUPGRADE
+{
+	name = RFTech-MLI-UpgradeBalloon
+	partIcon = RCSBlock
+	techRequired = materialsScienceLongTerm
+	entryCost = 100000
+	cost = 0
+	title = MLI Wrapping Upgrade  (100 layers)
+	manufacturer = Various
+	description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
+}
+
+@PART[*]:HAS[@MODULE[ModuleFuelTanks]]:AFTER[zzzRealFuels]
+{
+	@MODULE[ModuleFuelTanks]
+	{
+		@UPGRADES
+		{
+			!UPGRADE:HAS[#name__[MLI*]] {}
+		}
+	}
+
+	@MODULE[ModuleFuelTanks]:HAS[~type[Tank-Balloon*]]
+	{
+	%maxMLILayers = 0
+	
+		%UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = RFTech-MLI-Upgrade1
+				description__ = Improved tank wrapping techniques allow 1 layer now.
+				maxMLILayers = 1
+			}
+			UPGRADE
+			{
+				name__ = RFTech-MLI-Upgrade2
+				description__ = Improved tank wrapping techniques allow 25 layers now.
+				maxMLILayers = 25
+			}
+			UPGRADE
+			{
+				name__ = RFTech-MLI-Upgrade3
+				description__ = Improved tank wrapping techniques allow 50 layers now.
+				maxMLILayers = 50
+			}
+			UPGRADE
+			{
+				name__ = RFTech-MLI-Upgrade4
+				description__ = Improved tank wrapping techniques allow 75 layers now.
+				maxMLILayers = 75
+			}
+			UPGRADE
+			{
+				name__ = RFTech-MLI-Upgrade5
+				description__ = Improved tank wrapping techniques allow 100 layers now.
+				maxMLILayers = 100
+			}
+		}
+	}
+	@MODULE[ModuleFuelTanks]:HAS[#type[Tank-Balloon*]]
+	{
+	%maxMLILayers = 0
+	
+		%UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = RFTech-MLI-UpgradeBalloon
+				description__ = Improved tank wrapping techniques allow 100 layers of MLI on balloon tanks.
+				maxMLILayers = 100
+			}
+		}
+	}
+}

--- a/GameData/RP-0/Tree/RFTechLevels.cfg
+++ b/GameData/RP-0/Tree/RFTechLevels.cfg
@@ -213,7 +213,7 @@ PARTUPGRADE
 @PARTUPGRADE[MLI.Upgrade1]
 {
 	@partIcon = RFTank-I
-	@techRequired = materialsScienceHuman
+	@techRequired = materialsScienceAdvCapsules
 	@entryCost = 25000
 	@title = MLI Wrapping Upgrade (1 layer)
 	@description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.
@@ -221,7 +221,7 @@ PARTUPGRADE
 @PARTUPGRADE[MLI.Upgrade2]
 {
 	@partIcon = RFTank-I
-	@techRequired = materialsScienceAdvCapsules
+	@techRequired = materialsScienceLunar
 	@entryCost = 25000
 	@title = MLI Wrapping Upgrade (25 layers)
 	@description = Improved wrapping techniques allow for an even greater increased layering of multi layer insulation.


### PR DESCRIPTION
Use the RF partupgrade system to allow MLI upgrades to upgrade tank types over time, rather than assigning MLI based on the tank type.

Conventional, Isogrid and Service Modules gain upgrades from 1-100 layers
Balloon tanks require more advanced technology to mount MLI, due to the difficulty in fixing MLI to the thin walls of Balloon tanks

RO PR: https://github.com/KSP-RO/RealismOverhaul/pull/2595