### PR TITLE
Add missing Crew Training for RO parts

### DIFF
--- a/GameData/RP-0/CrewTrainingTimes.cfg
+++ b/GameData/RP-0/CrewTrainingTimes.cfg
@@ -111,6 +111,8 @@ TRAININGTIMES
 	// GE Apollo D-2
 	ApolloD2 = 50, SecondGenCapsules
 		ROC-D2CM = ApolloD2
+		ROC-D2MissionModule1 = ApolloD2
+		ROC-D2MissionModule2 = ApolloD2
 	ApolloD2-Mission = 135
 		
 	// Apollo
@@ -146,6 +148,8 @@ TRAININGTIMES
 		bluedog-LEM-Ascent-Cockpit = ApolloLEM
 		FASALM-AscentStage = ApolloLEM
 		MEMLander = ApolloLEM
+		MEMLanderSXT = ApolloLEM
+		ROC-LEMAscent = ApolloLEM
 		LEM_ASCENT_STAGE = ApolloLEM
 	landerCabinMedium = 100, Landing
 	mk2LanderCabin = 100, Landing


### PR DESCRIPTION
Dynasoar Cabin in ProtoSpaceplane to go with the Dyanasoar Cockpit
Apollo D2 Mission Modules to ApolloD2 with the Decent Module
ROC and SXT Apollo LEMs to ApolloLEM