### PR TITLE
Move RF resource cost setting to RP-0

### DIFF
--- a/GameData/RP-0/ResourceCosts.cfg
+++ b/GameData/RP-0/ResourceCosts.cfg
@@ -1,0 +1,359 @@
+// Costs for RF (now CRP) resources
+// Source:
+// https://www.dla.mil/Portals/104/Documents/Energy/Standard%20Prices/Aerospace%20Prices/E_2016Oct1AerospaceStandardPrices_160921.pdf
+// https://www.dla.mil/Portals/104/Documents/Energy/Standard%20Prices/Aerospace%20Prices/E_2017Oct1AerospaceStandardPrices_170913.pdf?ver=2017-09-13-145335-477
+@RESOURCE_DEFINITION[LqdOxygen]:FOR[RealismOverhaul]
+{
+  //$22.38/US ton, 1965$
+  //@density = 0.001141
+  @unitCost = 0.00002815
+}
+@RESOURCE_DEFINITION[Kerosene]:FOR[RealismOverhaul]
+{
+  //$0.55/gallon for JP-4, 1965$
+  //We're letting this represent commercial jet fuels (Jet-A, JP-4, JP-5, T-1, etc.).
+  @unitCost = 0.000145
+}
+@RESOURCE_DEFINITION[LqdHydrogen]:FOR[RealismOverhaul]
+{
+  //$11.90/m^3, 1965$
+  @unitCost = 0.00001190
+}
+@RESOURCE_DEFINITION[NTO]:FOR[RealismOverhaul]
+{
+  //$13.05/lb, 1965$
+  //High because of enviromental regulations, divide by 10
+  @unitCost = 0.004172
+}
+@RESOURCE_DEFINITION[UDMH]:FOR[RealismOverhaul]
+{
+  //$11.51/lb, 1965$
+  //High because of enviromental regulations, divide by 10
+  @unitCost = 0.002007
+}
+@RESOURCE_DEFINITION[Hydrazine]:FOR[RealismOverhaul]
+{
+  //11.51/lb, 1965$
+  //High because of enviromental regulations, divide by 10
+  @unitCost = 0.002548
+}
+@RESOURCE_DEFINITION[Aerozine50]:FOR[RealismOverhaul]
+{
+  //11.51/lb, 1965$
+  //High because of enviromental regulations, divide by 10
+  @unitCost = 0.002284
+}
+@RESOURCE_DEFINITION[MMH]:FOR[RealismOverhaul]
+{
+  //11.51/lb, 1965$
+  //High because of enviromental regulations, divide by 10
+  @unitCost = 0.002233
+}
+@RESOURCE_DEFINITION[HTP]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0021465
+}
+@RESOURCE_DEFINITION[AvGas]:FOR[RealismOverhaul]
+{
+  //$0.61/gallon, 1965$
+  @unitCost = 0.0001770
+}
+@RESOURCE_DEFINITION[Nitrogen]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00000005004
+}
+@RESOURCE_DEFINITION[IWFNA]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00031773
+}
+@RESOURCE_DEFINITION[IRFNA-III]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00034818
+}
+@RESOURCE_DEFINITION[IRFNA-IV]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.000399
+}
+@RESOURCE_DEFINITION[NitrousOxide]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.000000392
+}
+@RESOURCE_DEFINITION[Aniline]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.000521333322
+}
+@RESOURCE_DEFINITION[Aniline22]:FOR[RealismOverhaul]
+{
+  %unitCost = 0.000453226657
+}
+@RESOURCE_DEFINITION[Aniline37]:FOR[RealismOverhaul]
+{
+  %unitCost = 0.000402146659
+}
+@RESOURCE_DEFINITION[Ethanol75]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00012624
+}
+@RESOURCE_DEFINITION[Ethanol90]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00014 // Slightly more than 75
+}
+@RESOURCE_DEFINITION[Ethanol]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.001 // Denatured ethanol is very expensive
+}
+@RESOURCE_DEFINITION[LqdAmmonia]:FOR[RealismOverhaul]
+{
+  //$0.07/L, $1965
+  @unitCost = 0.00009970
+}
+@RESOURCE_DEFINITION[LqdMethane]:FOR[RealismOverhaul]
+{
+  @unitCost = 3.02655999995271E-05
+}
+@RESOURCE_DEFINITION[Helium]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0000000091284246
+}
+@RESOURCE_DEFINITION[ClF3]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.01062
+}
+@RESOURCE_DEFINITION[ClF5]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0152
+}
+@RESOURCE_DEFINITION[Diborane]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00421
+}
+@RESOURCE_DEFINITION[Pentaborane]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00618
+}
+@RESOURCE_DEFINITION[Ethane]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00009248
+}
+@RESOURCE_DEFINITION[Ethylene]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00009656
+}
+@RESOURCE_DEFINITION[OF2]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0285
+}
+@RESOURCE_DEFINITION[LqdFluorine]:FOR[RealismOverhaul]
+{
+  //$6.49/kg, 1965$
+  @unitCost = 0.00977
+}
+@RESOURCE_DEFINITION[N2F4]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.02406
+}
+@RESOURCE_DEFINITION[Methanol]:FOR[RealismOverhaul]
+{
+  //$0.58/gallon, 1965$
+  @unitCost = 0.0001532
+}
+@RESOURCE_DEFINITION[Furfuryl]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0001808
+}
+@RESOURCE_DEFINITION[UH25]:FOR[RealismOverhaul]
+{
+  //assuming same as UDMH/MMH
+  //$11.51/lb, 1965$
+  //High because of enviromental regulations, divide by 10
+  @unitCost = 0.002104
+}
+@RESOURCE_DEFINITION[Tonka250]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0004365
+}
+@RESOURCE_DEFINITION[Tonka500]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00044605
+}
+@RESOURCE_DEFINITION[FLOX30]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.002951
+}
+@RESOURCE_DEFINITION[FLOX70]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.006847
+}
+@RESOURCE_DEFINITION[FLOX88]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.008601
+}
+@RESOURCE_DEFINITION[AK20]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0002998
+}
+@RESOURCE_DEFINITION[AK27]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0002988
+}
+@RESOURCE_DEFINITION[CaveaB]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00033022
+}
+@RESOURCE_DEFINITION[MON1]:FOR[RealismOverhaul]
+{
+  //$13.05/L, 1965$
+  //High because of enviromental regulations, divide by 10
+  @unitCost = 0.004111
+}
+@RESOURCE_DEFINITION[MON3]:FOR[RealismOverhaul]
+{
+  //$13.05/L, 1965$
+  //High because of enviromental regulations, divide by 10
+  @unitCost = 0.004094
+}
+@RESOURCE_DEFINITION[MON10]:FOR[RealismOverhaul]
+{
+  //$15.62/L, 1965$
+  //High because of enviromental regulations, divide by 10
+  @unitCost = 0.004845
+}
+@RESOURCE_DEFINITION[MON15]:FOR[RealismOverhaul]
+{
+  //$24.25/L, 1965$
+  //High because of enviromental regulations, divide by 10
+  @unitCost = 0.007469
+}
+@RESOURCE_DEFINITION[MON20]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.009925
+}
+@RESOURCE_DEFINITION[MON25]:FOR[RealismOverhaul]
+{
+  //$40.69/L, 1965$
+  //High because of enviromental regulations, divide by 10
+  @unitCost = 0.01238
+}
+@RESOURCE_DEFINITION[ArgonGas]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00001784
+}
+@RESOURCE_DEFINITION[KryptonGas]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00003749
+}
+@RESOURCE_DEFINITION[Hydrogen]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.000008841
+}
+@RESOURCE_DEFINITION[Oxygen]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0000000282
+}
+@RESOURCE_DEFINITION[Food]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.014051452991453
+}
+@RESOURCE_DEFINITION[Water]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0005
+}
+@RESOURCE_DEFINITION[CarbonDioxide]:FOR[RealismOverhaul]
+{
+  @unitCost = 0
+}
+@RESOURCE_DEFINITION[Waste]:FOR[RealismOverhaul]
+{
+  @unitCost = 0
+}
+@RESOURCE_DEFINITION[WasteWater]:FOR[RealismOverhaul]
+{
+  @unitCost = 0
+}
+@RESOURCE_DEFINITION[LithiumPeroxide]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.1155
+}
+@RESOURCE_DEFINITION[LithiumHydroxide]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.073
+}
+@RESOURCE_DEFINITION[PotassiumSuperoxide]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.107
+}
+@RESOURCE_DEFINITION[Hydyne]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.000688
+}
+@RESOURCE_DEFINITION[Syntin]:FOR[RealismOverhaul]
+{
+  //$100/kg in 2016 (no good source, but Scott Manley said it)
+  @unitCost = 0.01117
+}
+@RESOURCE_DEFINITION[LiquidFuel]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0001111111
+}
+@RESOURCE_DEFINITION[Oxidizer]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00211111111
+}
+@RESOURCE_DEFINITION[MonoPropellant]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0016888888888
+}
+@RESOURCE_DEFINITION[XenonGas]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00005894
+}
+@RESOURCE_DEFINITION[ElectricCharge]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.0
+}
+@RESOURCE_DEFINITION[IntakeAir]:FOR[RealismOverhaul]
+{
+  @unitCost = 0
+}
+@RESOURCE_DEFINITION[SolidFuel]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.03026
+}
+@RESOURCE_DEFINITION[DepletedUranium]:FOR[RealismOverhaul]
+{
+  @unitCost = -1.097
+}
+@RESOURCE_DEFINITION[EnrichedUranium]:FOR[RealismOverhaul]
+{
+  @unitCost = 54.85
+}
+@RESOURCE_DEFINITION[LeadBallast]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.001134
+}
+@RESOURCE_DEFINITION[TEATEB]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.00280124
+}
+
+// Fallback solid costs:
+@RESOURCE_DEFINITION[HTPB|PBAN]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.03 // same as SolidFuel, i.e. bog standard.
+}
+@RESOURCE_DEFINITION[PSPC]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.01
+}
+@RESOURCE_DEFINITION[HNIW|NGNC]:FOR[RealismOverhaul]
+{
+  @unitCost = 0.1 // expensive as heck.
+}
+
+// Plutonium-238 Costs
+// https://inldigitallibrary.inl.gov/sites/sti/sti/7267852.pdf
+// Call it $2,000 per gram in 1997 money converted to 1965 = $395 per gram
+@RESOURCE_DEFINITION[Plutonium-238]:FOR[RealismOverhaul]
+{
+  @unitCost = 7821.782178
+}


### PR DESCRIPTION
Move resource costs that were previously set in RO to RP-0, where they probably belong. RO will be left using whatever costs CRP defines.