### PR TITLE
Split X-405H configs

### DIFF
--- a/GameData/RP-0/Tree/ECM-Engines.cfg
+++ b/GameData/RP-0/Tree/ECM-Engines.cfg
@@ -553,7 +553,8 @@
     X-405 = 12000, Navaho-PhaseIII-TP
     X-405-Exhaust = 0
     X-405H = 10000, PumpReignition, X-405
-    X-405H-3 = 10000,X-405H
+    X-405H-2 = 5000,X-405H
+    X-405H-3 = 10000,X-405H-2
     X-405H-4 = 10000,X-405H-3
     X3 = 100000
     X3-HV = 50000,X3

--- a/GameData/RP-0/Tree/ECM-Engines.cfg
+++ b/GameData/RP-0/Tree/ECM-Engines.cfg
@@ -552,8 +552,8 @@
     Waxwing = 10000, SolidsCTPB
     X-405 = 12000, Navaho-PhaseIII-TP
     X-405-Exhaust = 0
-    X-405H = 10000, PumpReignition, X-405
-    X-405H-2 = 5000,X-405H
+    X-405H = 10000,X-405
+    X-405H-2 = 5000,X-405H,PumpReignition
     X-405H-3 = 10000,X-405H-2
     X-405H-4 = 10000,X-405H-3
     X3 = 100000

--- a/GameData/RP-0/Tree/TREE-Engines.cfg
+++ b/GameData/RP-0/Tree/TREE-Engines.cfg
@@ -3588,6 +3588,13 @@
                 *@PARTUPGRADE[RFUpgrade_X-405H]/deleteme -= 1
             }
 
+            @CONFIG[X-405H-2]
+            {
+                %techRequired = orbitalRocketry1961
+                %cost = 115
+                *@PARTUPGRADE[RFUpgrade_X-405H-2]/deleteme -= 1
+            }
+
             @CONFIG[X-405H-3]
             {
                 %techRequired = orbitalRocketry1962
@@ -7510,6 +7517,20 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The X405 Engine now supports the X-405H configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nEngine for proposed Vega stage for NASA Atlas-Vega LV. Superceded by Atlas-Agena once NASA became aware of the USAF's Agena stage.
+}
+
+PARTUPGRADE
+{
+        name = RFUpgrade_X-405H-2
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = orbitalRocketry1961
+        entryCost = 0
+        cost = 0      
+        title = X405 Engine Upgrade: X-405H-2 Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The X405 Engine now supports the X-405H-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
 PARTUPGRADE

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -12237,6 +12237,27 @@
         "module_tags": []
     },
     {
+        "name": "X-405H-2",
+        "title": "X-405H-2",
+        "description": "",
+        "mod": "Engine_Config",
+        "cost": "115",
+        "entry_cost": "0",
+        "category": "ORBITAL",
+        "info": "",
+        "year": "1961",
+        "technology": "orbitalRocketry1961",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "X405",
+        "upgrade": true,
+        "entry_cost_mods": "5000,X-405H",
+        "identical_part_name": "",
+        "module_tags": []
+    },
+    {
         "name": "X-405H-3",
         "title": "X-405H-3",
         "description": "",
@@ -12253,7 +12274,7 @@
         "spacecraft": "Vega",
         "engine_config": "X405",
         "upgrade": true,
-        "entry_cost_mods": "10000,X-405H",
+        "entry_cost_mods": "10000,X-405H-2",
         "identical_part_name": "",
         "module_tags": []
     },

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -12232,7 +12232,7 @@
         "spacecraft": "",
         "engine_config": "X405",
         "upgrade": true,
-        "entry_cost_mods": "10000, PumpReignition, X-405",
+        "entry_cost_mods": "10000,X-405",
         "identical_part_name": "",
         "module_tags": []
     },
@@ -12253,7 +12253,7 @@
         "spacecraft": "",
         "engine_config": "X405",
         "upgrade": true,
-        "entry_cost_mods": "5000,X-405H",
+        "entry_cost_mods": "5000,X-405H,PumpReignition",
         "identical_part_name": "",
         "module_tags": []
     },


### PR DESCRIPTION
Split X-405H proposals into one config without restart, and one with restart. Also adjust mass a bit based on Convair documents.

RO PR: https://github.com/KSP-RO/RealismOverhaul/pull/2619