### PR TITLE
Fix :FOR[RealismOverhaul] in RP-0

### DIFF
--- a/GameData/RP-0/ResourceCosts.cfg
+++ b/GameData/RP-0/ResourceCosts.cfg
@@ -2,350 +2,350 @@
 // Source:
 // https://www.dla.mil/Portals/104/Documents/Energy/Standard%20Prices/Aerospace%20Prices/E_2016Oct1AerospaceStandardPrices_160921.pdf
 // https://www.dla.mil/Portals/104/Documents/Energy/Standard%20Prices/Aerospace%20Prices/E_2017Oct1AerospaceStandardPrices_170913.pdf?ver=2017-09-13-145335-477
-@RESOURCE_DEFINITION[LqdOxygen]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[LqdOxygen]:FOR[RP-0]
 {
   //$22.38/US ton, 1965$
   //@density = 0.001141
   @unitCost = 0.00002815
 }
-@RESOURCE_DEFINITION[Kerosene]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Kerosene]:FOR[RP-0]
 {
   //$0.55/gallon for JP-4, 1965$
   //We're letting this represent commercial jet fuels (Jet-A, JP-4, JP-5, T-1, etc.).
   @unitCost = 0.000145
 }
-@RESOURCE_DEFINITION[LqdHydrogen]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[LqdHydrogen]:FOR[RP-0]
 {
   //$11.90/m^3, 1965$
   @unitCost = 0.00001190
 }
-@RESOURCE_DEFINITION[NTO]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[NTO]:FOR[RP-0]
 {
   //$13.05/lb, 1965$
   //High because of enviromental regulations, divide by 10
   @unitCost = 0.004172
 }
-@RESOURCE_DEFINITION[UDMH]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[UDMH]:FOR[RP-0]
 {
   //$11.51/lb, 1965$
   //High because of enviromental regulations, divide by 10
   @unitCost = 0.002007
 }
-@RESOURCE_DEFINITION[Hydrazine]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Hydrazine]:FOR[RP-0]
 {
   //11.51/lb, 1965$
   //High because of enviromental regulations, divide by 10
   @unitCost = 0.002548
 }
-@RESOURCE_DEFINITION[Aerozine50]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Aerozine50]:FOR[RP-0]
 {
   //11.51/lb, 1965$
   //High because of enviromental regulations, divide by 10
   @unitCost = 0.002284
 }
-@RESOURCE_DEFINITION[MMH]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[MMH]:FOR[RP-0]
 {
   //11.51/lb, 1965$
   //High because of enviromental regulations, divide by 10
   @unitCost = 0.002233
 }
-@RESOURCE_DEFINITION[HTP]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[HTP]:FOR[RP-0]
 {
   @unitCost = 0.0021465
 }
-@RESOURCE_DEFINITION[AvGas]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[AvGas]:FOR[RP-0]
 {
   //$0.61/gallon, 1965$
   @unitCost = 0.0001770
 }
-@RESOURCE_DEFINITION[Nitrogen]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Nitrogen]:FOR[RP-0]
 {
   @unitCost = 0.00000005004
 }
-@RESOURCE_DEFINITION[IWFNA]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[IWFNA]:FOR[RP-0]
 {
   @unitCost = 0.00031773
 }
-@RESOURCE_DEFINITION[IRFNA-III]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[IRFNA-III]:FOR[RP-0]
 {
   @unitCost = 0.00034818
 }
-@RESOURCE_DEFINITION[IRFNA-IV]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[IRFNA-IV]:FOR[RP-0]
 {
   @unitCost = 0.000399
 }
-@RESOURCE_DEFINITION[NitrousOxide]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[NitrousOxide]:FOR[RP-0]
 {
   @unitCost = 0.000000392
 }
-@RESOURCE_DEFINITION[Aniline]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Aniline]:FOR[RP-0]
 {
   @unitCost = 0.000521333322
 }
-@RESOURCE_DEFINITION[Aniline22]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Aniline22]:FOR[RP-0]
 {
   %unitCost = 0.000453226657
 }
-@RESOURCE_DEFINITION[Aniline37]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Aniline37]:FOR[RP-0]
 {
   %unitCost = 0.000402146659
 }
-@RESOURCE_DEFINITION[Ethanol75]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Ethanol75]:FOR[RP-0]
 {
   @unitCost = 0.00012624
 }
-@RESOURCE_DEFINITION[Ethanol90]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Ethanol90]:FOR[RP-0]
 {
   @unitCost = 0.00014 // Slightly more than 75
 }
-@RESOURCE_DEFINITION[Ethanol]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Ethanol]:FOR[RP-0]
 {
   @unitCost = 0.001 // Denatured ethanol is very expensive
 }
-@RESOURCE_DEFINITION[LqdAmmonia]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[LqdAmmonia]:FOR[RP-0]
 {
   //$0.07/L, $1965
   @unitCost = 0.00009970
 }
-@RESOURCE_DEFINITION[LqdMethane]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[LqdMethane]:FOR[RP-0]
 {
   @unitCost = 3.02655999995271E-05
 }
-@RESOURCE_DEFINITION[Helium]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Helium]:FOR[RP-0]
 {
   @unitCost = 0.0000000091284246
 }
-@RESOURCE_DEFINITION[ClF3]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[ClF3]:FOR[RP-0]
 {
   @unitCost = 0.01062
 }
-@RESOURCE_DEFINITION[ClF5]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[ClF5]:FOR[RP-0]
 {
   @unitCost = 0.0152
 }
-@RESOURCE_DEFINITION[Diborane]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Diborane]:FOR[RP-0]
 {
   @unitCost = 0.00421
 }
-@RESOURCE_DEFINITION[Pentaborane]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Pentaborane]:FOR[RP-0]
 {
   @unitCost = 0.00618
 }
-@RESOURCE_DEFINITION[Ethane]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Ethane]:FOR[RP-0]
 {
   @unitCost = 0.00009248
 }
-@RESOURCE_DEFINITION[Ethylene]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Ethylene]:FOR[RP-0]
 {
   @unitCost = 0.00009656
 }
-@RESOURCE_DEFINITION[OF2]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[OF2]:FOR[RP-0]
 {
   @unitCost = 0.0285
 }
-@RESOURCE_DEFINITION[LqdFluorine]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[LqdFluorine]:FOR[RP-0]
 {
   //$6.49/kg, 1965$
   @unitCost = 0.00977
 }
-@RESOURCE_DEFINITION[N2F4]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[N2F4]:FOR[RP-0]
 {
   @unitCost = 0.02406
 }
-@RESOURCE_DEFINITION[Methanol]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Methanol]:FOR[RP-0]
 {
   //$0.58/gallon, 1965$
   @unitCost = 0.0001532
 }
-@RESOURCE_DEFINITION[Furfuryl]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Furfuryl]:FOR[RP-0]
 {
   @unitCost = 0.0001808
 }
-@RESOURCE_DEFINITION[UH25]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[UH25]:FOR[RP-0]
 {
   //assuming same as UDMH/MMH
   //$11.51/lb, 1965$
   //High because of enviromental regulations, divide by 10
   @unitCost = 0.002104
 }
-@RESOURCE_DEFINITION[Tonka250]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Tonka250]:FOR[RP-0]
 {
   @unitCost = 0.0004365
 }
-@RESOURCE_DEFINITION[Tonka500]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Tonka500]:FOR[RP-0]
 {
   @unitCost = 0.00044605
 }
-@RESOURCE_DEFINITION[FLOX30]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[FLOX30]:FOR[RP-0]
 {
   @unitCost = 0.002951
 }
-@RESOURCE_DEFINITION[FLOX70]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[FLOX70]:FOR[RP-0]
 {
   @unitCost = 0.006847
 }
-@RESOURCE_DEFINITION[FLOX88]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[FLOX88]:FOR[RP-0]
 {
   @unitCost = 0.008601
 }
-@RESOURCE_DEFINITION[AK20]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[AK20]:FOR[RP-0]
 {
   @unitCost = 0.0002998
 }
-@RESOURCE_DEFINITION[AK27]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[AK27]:FOR[RP-0]
 {
   @unitCost = 0.0002988
 }
-@RESOURCE_DEFINITION[CaveaB]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[CaveaB]:FOR[RP-0]
 {
   @unitCost = 0.00033022
 }
-@RESOURCE_DEFINITION[MON1]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[MON1]:FOR[RP-0]
 {
   //$13.05/L, 1965$
   //High because of enviromental regulations, divide by 10
   @unitCost = 0.004111
 }
-@RESOURCE_DEFINITION[MON3]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[MON3]:FOR[RP-0]
 {
   //$13.05/L, 1965$
   //High because of enviromental regulations, divide by 10
   @unitCost = 0.004094
 }
-@RESOURCE_DEFINITION[MON10]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[MON10]:FOR[RP-0]
 {
   //$15.62/L, 1965$
   //High because of enviromental regulations, divide by 10
   @unitCost = 0.004845
 }
-@RESOURCE_DEFINITION[MON15]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[MON15]:FOR[RP-0]
 {
   //$24.25/L, 1965$
   //High because of enviromental regulations, divide by 10
   @unitCost = 0.007469
 }
-@RESOURCE_DEFINITION[MON20]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[MON20]:FOR[RP-0]
 {
   @unitCost = 0.009925
 }
-@RESOURCE_DEFINITION[MON25]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[MON25]:FOR[RP-0]
 {
   //$40.69/L, 1965$
   //High because of enviromental regulations, divide by 10
   @unitCost = 0.01238
 }
-@RESOURCE_DEFINITION[ArgonGas]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[ArgonGas]:FOR[RP-0]
 {
   @unitCost = 0.00001784
 }
-@RESOURCE_DEFINITION[KryptonGas]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[KryptonGas]:FOR[RP-0]
 {
   @unitCost = 0.00003749
 }
-@RESOURCE_DEFINITION[Hydrogen]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Hydrogen]:FOR[RP-0]
 {
   @unitCost = 0.000008841
 }
-@RESOURCE_DEFINITION[Oxygen]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Oxygen]:FOR[RP-0]
 {
   @unitCost = 0.0000000282
 }
-@RESOURCE_DEFINITION[Food]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Food]:FOR[RP-0]
 {
   @unitCost = 0.014051452991453
 }
-@RESOURCE_DEFINITION[Water]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Water]:FOR[RP-0]
 {
   @unitCost = 0.0005
 }
-@RESOURCE_DEFINITION[CarbonDioxide]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[CarbonDioxide]:FOR[RP-0]
 {
   @unitCost = 0
 }
-@RESOURCE_DEFINITION[Waste]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Waste]:FOR[RP-0]
 {
   @unitCost = 0
 }
-@RESOURCE_DEFINITION[WasteWater]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[WasteWater]:FOR[RP-0]
 {
   @unitCost = 0
 }
-@RESOURCE_DEFINITION[LithiumPeroxide]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[LithiumPeroxide]:FOR[RP-0]
 {
   @unitCost = 0.1155
 }
-@RESOURCE_DEFINITION[LithiumHydroxide]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[LithiumHydroxide]:FOR[RP-0]
 {
   @unitCost = 0.073
 }
-@RESOURCE_DEFINITION[PotassiumSuperoxide]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[PotassiumSuperoxide]:FOR[RP-0]
 {
   @unitCost = 0.107
 }
-@RESOURCE_DEFINITION[Hydyne]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Hydyne]:FOR[RP-0]
 {
   @unitCost = 0.000688
 }
-@RESOURCE_DEFINITION[Syntin]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Syntin]:FOR[RP-0]
 {
   //$100/kg in 2016 (no good source, but Scott Manley said it)
   @unitCost = 0.01117
 }
-@RESOURCE_DEFINITION[LiquidFuel]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[LiquidFuel]:FOR[RP-0]
 {
   @unitCost = 0.0001111111
 }
-@RESOURCE_DEFINITION[Oxidizer]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Oxidizer]:FOR[RP-0]
 {
   @unitCost = 0.00211111111
 }
-@RESOURCE_DEFINITION[MonoPropellant]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[MonoPropellant]:FOR[RP-0]
 {
   @unitCost = 0.0016888888888
 }
-@RESOURCE_DEFINITION[XenonGas]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[XenonGas]:FOR[RP-0]
 {
   @unitCost = 0.00005894
 }
-@RESOURCE_DEFINITION[ElectricCharge]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[ElectricCharge]:FOR[RP-0]
 {
   @unitCost = 0.0
 }
-@RESOURCE_DEFINITION[IntakeAir]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[IntakeAir]:FOR[RP-0]
 {
   @unitCost = 0
 }
-@RESOURCE_DEFINITION[SolidFuel]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[SolidFuel]:FOR[RP-0]
 {
   @unitCost = 0.03026
 }
-@RESOURCE_DEFINITION[DepletedUranium]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[DepletedUranium]:FOR[RP-0]
 {
   @unitCost = -1.097
 }
-@RESOURCE_DEFINITION[EnrichedUranium]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[EnrichedUranium]:FOR[RP-0]
 {
   @unitCost = 54.85
 }
-@RESOURCE_DEFINITION[LeadBallast]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[LeadBallast]:FOR[RP-0]
 {
   @unitCost = 0.001134
 }
-@RESOURCE_DEFINITION[TEATEB]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[TEATEB]:FOR[RP-0]
 {
   @unitCost = 0.00280124
 }
 
 // Fallback solid costs:
-@RESOURCE_DEFINITION[HTPB|PBAN]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[HTPB|PBAN]:FOR[RP-0]
 {
   @unitCost = 0.03 // same as SolidFuel, i.e. bog standard.
 }
-@RESOURCE_DEFINITION[PSPC]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[PSPC]:FOR[RP-0]
 {
   @unitCost = 0.01
 }
-@RESOURCE_DEFINITION[HNIW|NGNC]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[HNIW|NGNC]:FOR[RP-0]
 {
   @unitCost = 0.1 // expensive as heck.
 }
@@ -353,7 +353,7 @@
 // Plutonium-238 Costs
 // https://inldigitallibrary.inl.gov/sites/sti/sti/7267852.pdf
 // Call it $2,000 per gram in 1997 money converted to 1965 = $395 per gram
-@RESOURCE_DEFINITION[Plutonium-238]:FOR[RealismOverhaul]
+@RESOURCE_DEFINITION[Plutonium-238]:FOR[RP-0]
 {
   @unitCost = 7821.782178
 }


### PR DESCRIPTION
Hi KSP-RO team,

After #1640, RP-0 now has `:FOR[RealismOverhaul]` clauses in it. ModuleManager inteprets `:FOR` as a declaration that we are the specified mod; clauses using `:NEEDS[RealismOverhaul]` would be activated even if the real RO is absent. RP-0 depends on RO, so there should be no impact as long as the user's install is valid, but it's still better to avoid this:

https://github.com/sarbian/ModuleManager/wiki/Patch-Ordering#the-beforemodname-formodname-and-aftermodname-directives

> It is not recommended to use the :FOR directive to refer to other mods than the one you are writing.

Now these are changed to `:FOR[RP-0]`.

Cheers!