### PR TITLE
Make Basic Solids depend on Post-War Mat sci

### DIFF
--- a/GameData/RP-0/Tree/RP0TechTree.cfg
+++ b/GameData/RP-0/Tree/RP0TechTree.cfg
@@ -3233,7 +3233,7 @@
 		nodeName = earlySolids
 		anyToUnlock = False
 		icon = RDicon_rocketry-general
-		pos = -3632,1240,-1
+		pos = -3692,1240,-1
 		scale = 0.6
 		Parent
 		{
@@ -3252,7 +3252,7 @@
 		nodeName = basicSolids
 		anyToUnlock = False
 		icon = RDicon_rocketry-general
-		pos = -3507,1240,-1
+		pos = -3587,1240,-1
 		scale = 0.6
 		Parent
 		{
@@ -3262,7 +3262,7 @@
 		}
 		Parent
 		{
-			parentID = earlyMaterialsScience
+			parentID = postWarMaterialsScience
 			lineFrom = RIGHT
 			lineTo = LEFT
 		}
@@ -3277,7 +3277,7 @@
 		nodeName = solids1956
 		anyToUnlock = False
 		icon = RDicon_rocketry-general
-		pos = -3377,1240,-1
+		pos = -3437,1240,-1
 		scale = 0.6
 		Parent
 		{


### PR DESCRIPTION
Because gating it behind the 7sci of Early Mat Sci basically
made it useless.

per https://discord.com/channels/319857228905447436/620690446540341261/964606272617996298

Also shifted the solid nodes a bit to make the tree a bit clearer.

![Screen Shot 2022-04-23 at 13 09 45](https://user-images.githubusercontent.com/5061230/164916680-716621ef-65e6-4003-bf28-2697509395a1.png)
