### PR TITLE
Support new HG-5 antenna model

### DIFF
--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -35837,3 +35837,14 @@
     RP0conf = true
     @description ^=:$: <b><color=green>From Chaka Monkey mod</color></b>
 }
+@PART[HighGainAntenna5_v2]:FOR[xxxRP0]
+{
+    %TechRequired = interplanetaryComms
+    %cost = 2
+    %entryCost = 200
+    RP0conf = true
+    @description ^=:$: <b><color=green>From Stock (RO Config) mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = Instruments }
+
+}

--- a/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
@@ -768,6 +768,29 @@
         ]
     },
     {
+        "name": "HighGainAntenna5_v2",
+        "title": "0.5 m Retractable Parabolic Antenna",
+        "description": "",
+        "mod": "Stock (RO Config)",
+        "cost": "2",
+        "entry_cost": "200",
+        "category": "COMMS",
+        "info": "Dish",
+        "year": "1962",
+        "technology": "interplanetaryComms",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "",
+        "upgrade": false,
+        "entry_cost_mods": "",
+        "identical_part_name": "",
+        "module_tags": [
+            "Instruments"
+        ]
+    },
+    {
         "name": "IntakeRadialLong",
         "title": "Adjustable Ramp Intake (Radial)",
         "description": "This intake addresses those sometimes absurd contraptions that SSTO engineers designed in an attempt to pump more and more air into their engines. Optimized for supersonic flight.",


### PR DESCRIPTION
Fix the issue mentioned in https://discord.com/channels/319857228905447436/512556137380315139/964727589581258802.
Add RP-1 configs for `HighGainAntenna5_v2`.
Requires [RO-#2639](https://github.com/KSP-RO/RealismOverhaul/pull/2639). 