### PR TITLE
Improve RnD UX for experimental parts and under-research tech nodes

### DIFF
--- a/Source/HarmonyPatcher.cs
+++ b/Source/HarmonyPatcher.cs
@@ -1,0 +1,137 @@
+﻿using HarmonyLib;
+using KerbalConstructionTime;
+using KSP.UI.Screens;
+using KSP.UI.Screens.Editor;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace RP0
+{
+    [KSPAddon(KSPAddon.Startup.Instantly, true)]
+    public class HarmonyPatcher : MonoBehaviour
+    {
+        internal void Start()
+        {
+            var harmony = new Harmony("RP0.HarmonyPatcher");
+            harmony.PatchAll();
+        }
+
+        [HarmonyPatch(typeof(ResearchAndDevelopment))]
+        internal class PatchRnDPartAvailability
+        {
+            [HarmonyPrefix]
+            [HarmonyPatch("PartTechAvailable")]
+            internal static bool Prefix(AvailablePart ap, ref bool __result)
+            {
+                if (ResearchAndDevelopment.Instance == null)
+                {
+                    __result = true;
+                    return false;
+                }
+
+                Dictionary<string, ProtoTechNode> protoTechNodes = GetProtoTechNodes();
+                __result = PartTechAvailable(ap, protoTechNodes);
+
+                return false;
+            }
+
+            [HarmonyPrefix]
+            [HarmonyPatch("PartModelPurchased")]
+            internal static bool Prefix_PartModelPurchased(AvailablePart ap, ref bool __result)
+            {
+                if (ResearchAndDevelopment.Instance == null)
+                {
+                    __result = true;
+                    return false;
+                }
+
+                Dictionary<string, ProtoTechNode> protoTechNodes = GetProtoTechNodes();
+
+                if (PartTechAvailable(ap, protoTechNodes))
+                {
+                    if (protoTechNodes.TryGetValue(ap.TechRequired, out ProtoTechNode ptn) &&
+                        ptn.partsPurchased.Contains(ap))
+                    {
+                        __result =  true;
+                        return false;
+                    }
+
+                    __result = false;
+                    return false;
+                }
+
+                __result = false;
+                return false;
+            }
+
+            private static Dictionary<string, ProtoTechNode> GetProtoTechNodes()
+            {
+                return Traverse.Create(ResearchAndDevelopment.Instance)
+                               .Field("protoTechNodes")
+                               .GetValue<Dictionary<string, ProtoTechNode>>();
+            }
+
+            private static bool PartTechAvailable(AvailablePart ap, Dictionary<string, ProtoTechNode> protoTechNodes)
+            {
+                if (string.IsNullOrEmpty(ap.TechRequired))
+                {
+                    return false;
+                }
+
+                if (protoTechNodes.TryGetValue(ap.TechRequired, out ProtoTechNode ptn))
+                {
+                    return ptn.state == RDTech.State.Available;
+                }
+
+                return false;
+            }
+        }
+
+        [HarmonyPatch(typeof(RDController))]
+        [HarmonyPatch("UpdatePurchaseButton")]
+        internal class PatchRnDUpdatePurchaseButton
+        {
+            internal static bool Prefix(RDController __instance)
+            {
+                if (KCTGameStates.TechList.Any(tech => tech.TechID == __instance.node_selected.tech.techID))
+                {
+                    __instance.actionButton.gameObject.SetActive(false);
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        [HarmonyPatch(typeof(PartListTooltip))]
+        internal class PatchPartListTooltipSetup
+        {
+            [HarmonyPostfix]
+            [HarmonyPatch("Setup")]
+            [HarmonyPatch(new Type[] { typeof(AvailablePart), typeof(Callback<PartListTooltip>), typeof(RenderTexture) })]
+            internal static void Postfix_Setup1(PartListTooltip __instance, AvailablePart availablePart, bool ___requiresEntryPurchase)
+            {
+                PatchButtons(__instance, availablePart, ___requiresEntryPurchase);
+            }
+
+            [HarmonyPostfix]
+            [HarmonyPatch("Setup")]
+            [HarmonyPatch(new Type[] { typeof(AvailablePart), typeof(PartUpgradeHandler.Upgrade), typeof(Callback<PartListTooltip>), typeof(RenderTexture) })]
+            internal static void Postfix_Setup2(PartListTooltip __instance, AvailablePart availablePart, bool ___requiresEntryPurchase)
+            {
+                PatchButtons(__instance, availablePart, ___requiresEntryPurchase);
+            }
+
+            private static void PatchButtons(PartListTooltip __instance, AvailablePart availablePart, bool ___requiresEntryPurchase)
+            {
+                if (___requiresEntryPurchase && KCTGameStates.TechList.Any(tech => tech.TechID == availablePart.TechRequired))
+                {
+                    __instance.buttonPurchaseContainer.SetActive(false);
+                    __instance.costPanel.SetActive(true);
+                }
+            }
+        }
+    }
+}

--- a/Source/RP0.csproj
+++ b/Source/RP0.csproj
@@ -56,6 +56,7 @@
     <Compile Include="EntryCostStorage.cs" />
     <Compile Include="FirstStart.cs" />
     <Compile Include="GameplayTips.cs" />
+    <Compile Include="HarmonyPatcher.cs" />
     <Compile Include="LoadingScreenChanger.cs" />
     <Compile Include="Maintenance\MaintenanceSettings.cs" />
     <Compile Include="Maintenance\MaintenanceHandler.cs" />
@@ -108,6 +109,10 @@
     <Compile Include="Avionics\AvionicsGUI.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Assembly-CSharp">
       <Private>False</Private>
     </Reference>


### PR DESCRIPTION
* Remove *Purchase all* button from under-research nodes
* Remove *Purchase* button from individual parts that are in nodes that are under-research
* Add *Purchase* button to experimental parts that have completed research
* KSP itself and hopefully also contracts no longer consider experimental parts as being available 