### PR TITLE
Fix kOS Patch Application

### DIFF
--- a/GameData/RP-0/Avionics.cfg
+++ b/GameData/RP-0/Avionics.cfg
@@ -15,7 +15,7 @@
 
 // Add ability to turn off avionics to crewed parts
 // RP0.dll will only let them be turned off if they're currently empty
-@PART[*]:HAS[#CrewCapacity[*],~CrewCapacity[0]]:AFTER[RP-0]
+@PART:HAS[#CrewCapacity[>0]]:AFTER[RP-0]
 {
 	@MODULE[ModuleAvionics]
 	{
@@ -25,9 +25,9 @@
 }
 
 // Take the ec rate from any part with ModuleAvionics and remove it from the ModuleCommand
-@PART[*]:HAS[@MODULE[ModuleAvionics],@MODULE[ModuleCommand]:HAS[@RESOURCE[ElectricCharge]:HAS[#rate[*]]]]:AFTER[RP-0]
+@PART:HAS[@MODULE[ModuleAvionics],@MODULE[ModuleCommand]:HAS[@RESOURCE[ElectricCharge]:HAS[#rate]]]:AFTER[RP-0]
 {
-    @MODULE[ModuleAvionics]:HAS[~enabledkW[*]]
+    @MODULE[ModuleAvionics]:HAS[~enabledkW]
     {
         enabledkW = #$../MODULE[ModuleCommand]/RESOURCE[ElectricCharge]/rate$
     }
@@ -41,9 +41,9 @@
 }
 
 // Take the ec rate from any part with ModuleProceduralAvionics and remove it from the ModuleCommand
-@PART[*]:HAS[@MODULE[ModuleProceduralAvionics],@MODULE[ModuleCommand]:HAS[@RESOURCE[ElectricCharge]:HAS[#rate[*]]]]:AFTER[RP-0]
+@PART:HAS[@MODULE[ModuleProceduralAvionics],@MODULE[ModuleCommand]:HAS[@RESOURCE[ElectricCharge]:HAS[#rate]]]:AFTER[RP-0]
 {
-    @MODULE[ModuleProceduralAvionics]:HAS[~enabledkW[]]
+    @MODULE[ModuleProceduralAvionics]:HAS[~enabledkW]
     {
         enabledkW = #$../MODULE[ModuleCommand]/RESOURCE[ElectricCharge]/rate$
     }
@@ -59,11 +59,10 @@
 //Lunar Roving Vehicle
 @PART[LRV]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 0.4
-		interplanetary = True
+		%massLimit = 0.4
+		%interplanetary = True
 	}
 }
 
@@ -71,115 +70,51 @@
 // FIXME: Add any other 1-person capsules here
 @PART[mk1pod|mk1pod_v2|FASAMercuryPod|avionicsNoseCone|ROC-MercuryCM|ROC-MercuryCMBDB]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 1.5
-		interplanetary = False
+		%massLimit = 1.5
+		%interplanetary = False
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Mercury had no onboard computer, so just allow a small amount of storage for ground control linkups
-        diskSpace = 1000
-        diskSpaceCostFactor = 0.1       // 100F for double space
-        diskSpaceMassFactor = 0.00005   // 50 kg for double space
-        ECPerInstruction = 0.000001     // 100W @ 2000 IPU
-    }
+	%SetupKOS = Mercury
 }
 
 // Gemini
 @PART[Mk2Pod|FASAGeminiPod2|FASAGeminiPod2White|ROAdvCapsule|ROC-GeminiCM|ROC-GeminiCMBDB|ROC-D2CM]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 3.5		//Increased to 3.5 because it is very easy to lock Gemini if you decouple modules in the wrong order.
-		// Conveniently this is also what D2 needs.
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Gemini had circa 20kb storage
-        diskSpace = 20000
-        diskSpaceCostFactor = 0.0025     // 50F for double space
-        diskSpaceMassFactor = 0.0000001  // 2 kg for double space
-        ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 3.5 }
+	//Increased to 3.5 because it is very easy to lock Gemini if you decouple modules in the wrong order.
+	// Conveniently this is also what D2 needs.
+	%SetupKOS = Gemini
 }
+
 // Gemini SM, basically an Agena
 @PART[FASAGeminiUtilityPack|ROC-GeminiEquipmentSection|ROC-GeminiEquipmentSectionBDB|ROC-GeminiBEquipmentSection]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 15.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Gemini had circa 20kb storage
-        diskSpace = 20000
-        diskSpaceCostFactor = 0.0025     // 50F for double space
-        diskSpaceMassFactor = 0.0000001  // 2 kg for double space
-        ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 15.0 }
+	%SetupKOS = Gemini
 }
 
 @PART[ROC-DynaCockpitMoroz|ROC-DynaCockpitAltMoroz]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 20.0	//Dynasoar and payload + transtage
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Gemini had circa 20kb storage
-        diskSpace = 20000
-        diskSpaceCostFactor = 0.0025     // 50F for double space
-        diskSpaceMassFactor = 0.0000001  // 2 kg for double space
-        ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 20.0 }	//Dynasoar and payload + transtage
+	%SetupKOS = Gemini
 }
 
 // Vostok/Voskhod/Soyuz
 // All done via SM
 @PART[kv3pod|Voskhod_Crew_A|IronVostok_Crew_A|ROC-VostokCapsule|ROC-VoskhodCapsule|rn_vostok_sc|rn_voskhod_sc]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 0.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Mercury config
-        diskSpace = 1000
-        diskSpaceCostFactor = 0.1       // 100F for double space
-        diskSpaceMassFactor = 0.00005   // 50 kg for double space
-        ECPerInstruction = 0.000001     // 100W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 0.0 }
+	%SetupKOS = Mercury
 }
 @PART[IronVostok_Engine_A|Vostok_Module|rn_vostok_tdu|ROC-VostokService|ok_pao|t_pao|t_pao2|oks_pao|SOYUZ_ENGINE|rn_zond_top|rn_lok_tdu]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 20.0
-		interplanetary = False
+		%massLimit = 20.0
+		%interplanetary = False
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Mercury config
-        diskSpace = 1000
-        diskSpaceCostFactor = 0.1       // 100F for double space
-        diskSpaceMassFactor = 0.00005   // 50 kg for double space
-        ECPerInstruction = 0.000001     // 100W @ 2000 IPU
-    }
+	%SetupKOS = Mercury
 }
 
 @PART[rn_zond_top|rn_lok_tdu]:FOR[RP-0]
@@ -190,256 +125,115 @@
 // Big G
 @PART[FASABigGeminiRetroModule]
 {
-	//yes, you can do this without a ModuleCommand
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 30.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 30.0 }
 }
 
 // FIXME: do this for anything else Apollo sized
 // Just the capsule, SM handles avionics
 @PART[FASAApollo_CM|Mark1-2Pod|MK2VApod|SSTU-SC-B-CM|SSTU-SC-B-CMX|ROC-ApolloCM|ROC-ApolloCMBlockIII|rn_va_capsule|APOLLO_CM|mk1-3pod]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 7.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Apollo had circa 100kB of memory (I have split this with the SM).
-        diskSpace = 50000
-        diskSpaceCostFactor = 0.001       // 50F for double space
-        diskSpaceMassFactor = 0.00000005  // 2.5 kg for double space
-        ECPerInstruction = 0.00000008     // 8W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 7.0 }
+	%SetupKOS = ApolloCM
 }
+
 // Big G, Soyuz DM
 @PART[FASAGeminiBigG|FASAGeminiBigGWhite|ROC-BigGeminiCabinBDB|SSTU-SC-A-DM|ok_sa|tg_sa|rn_zond_sa]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 4.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Gemini had circa 20kb storage
-        diskSpace = 20000
-        diskSpaceCostFactor = 0.0025     // 50F for double space
-        diskSpaceMassFactor = 0.0000001  // 2 kg for double space
-        ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 4.0 }
+	%SetupKOS = Gemini
 }
 
 // 50t guidance for Apollo SM, Orion CM, FGB/TKS
 @PART[SSTU-SC-B-SM|SSTU-SC-C-CM|SSTU-SC-C-CMX|FASAApollo_SM|ROC-ApolloSM|APOLLO_SM|ROC-OrionCM|ROC-BigGeminiSM|rn_tks]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 50.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Apollo had circa 100kB of memory (I have split this with the CM).
-        diskSpace = 50000
-        diskSpaceCostFactor = 0.001       // 50F for double space
-        diskSpaceMassFactor = 0.00000005  // 2.5 kg for double space
-        ECPerInstruction = 0.00000008     // 8W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 50.0 }
+	%SetupKOS = ApolloCM
 }
 
 // 30t guidance for landers, CST-100, Big G SM
 @PART[FASALM_AscentStage|mk2LanderCabin|mk2LanderCabin_v2|MEMLander|SXTLander|bahaMk2LightningCockpit|rn_lk_lander|RO-Mk1Cockpit|RO-Mk1CockpitInline|SSTU-LC2-POD|MEMLanderSXT|ROC-LEMAscent|rn_lok_sa|LEM_ASCENT_STAGE|ROC-CSTCM]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 30.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Apollo had circa 100kB of memory (I have split this with the CM).
-        diskSpace = 50000
-        diskSpaceCostFactor = 0.001       // 50F for double space
-        diskSpaceMassFactor = 0.00000005  // 2.5 kg for double space
-        ECPerInstruction = 0.00000008     // 8W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 30.0 }
+	%SetupKOS = ApolloCM
 }
 
 // Apollo D-2 SM
 @PART[ROC-D2ServiceModule]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 20.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Apollo had circa 100kB of memory. Let's do half that.
-        diskSpace = 50000
-        diskSpaceCostFactor = 0.0015       // 75F for double space
-        diskSpaceMassFactor = 0.0000001   // 5 kg for double space
-        ECPerInstruction = 0.00000008     // 8W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 20.0 }
+	%SetupKOS = ApolloCM
 }
 
 // 20t guidance for smaller landers, Soyuz SM
 @PART[landerCabinSmall|landerCabinMedium|SSTU-SC-A-SM|ROC-ApolloSMBlockIII]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 20.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // Gemini config
-        diskSpace = 20000
-        diskSpaceCostFactor = 0.0025     // 50F for double space
-        diskSpaceMassFactor = 0.0000001  // 2 kg for double space
-        ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 20.0 }
+	%SetupKOS = Gemini
 }
 
 // Big fellers. 100t avionics.
 // Cockpits and Orion SM.
 @PART[mk2Cockpit_Standard|mk2Cockpit_Inline|B9_Body_Mk2_Cockpit|B9_Body_Mk2_Cockpit_Intake|B9_Cockpit_M27|B9_Cockpit_MK2|B9_Cockpit_S3|B9_Cockpit_S2|XOrionPodX|XOrionPodXbb31|LazTekDragonV2|SSTU_LanderCore_LC3-POD|SSTU-SC-C-SM|ROC-OrionESM|SSTU_LanderCore_LC5-POD]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 100.0
-	}
-    MODULE:NEEDS[kOS]
+	%MODULE[ModuleAvionics] { %massLimit = 100.0 }
+    %MODULE[kOSProcessor]:NEEDS[kOS]
     {
-        name = kOSProcessor
-        diskSpace = 100000
-        diskSpaceCostFactor = 0.0005       // 50F for double space
-        diskSpaceMassFactor = 0.000000005  // 0.5 kg for double space
-        ECPerInstruction = 0.00000004      // 4W @ 2000 IPU
+        %diskSpace = 100000
+        %diskSpaceCostFactor = 0.0005       // 50F for double space
+        %diskSpaceMassFactor = 0.000000005  // 0.5 kg for double space
+        %ECPerInstruction = 0.00000004      // 4W @ 2000 IPU
     }
 }
 
 // Huge cockpits and that sort of thing
 @PART[HL_Aero_Cockpit|B9_Cockpit_MK5|mk3Cockpit_Shuttle|STSOrbiter|CSSCrewCompartment]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 3000.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 3000.0 }
+	%SetupKOS = Station
 }
 
 // STS, some margin above official 2030 t stack
 @PART[benjee10_shuttle_forwardFuselage]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 2500
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 2500 }
 }
 
 @PART[cupola|investpod]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 0.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 0.0 }
+	%SetupKOS = Station
 }
 
 // Salyut and Almaz Stations
 @PART[salyut1-4|almaz3-5|rn-almaz-ops4]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 55
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 55 }
+	%SetupKOS = Station
 }
 
 @PART[salyut6|salyut7]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 70
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 70 }
+	%SetupKOS = Station
 }
 
 // RN Skylab Station
 @PART[skylab]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 180.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 180.0 }
+	%SetupKOS = Station
 }
 
+// ((((massLimit ^ massExponent) + 1.035) * powerFactor) / 1000)
 // 3.05m Station Core from SSPX
 // One of each part would be about 25t
 @PART[sspx-core-125-1]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 35.0
-		// ((((massLimit ^ massExponent) + 1.035) * powerFactor) / 1000)
-		enabledkW = 0.158
-		interplanetary = false
+		%massLimit = 35.0
+		%enabledkW = 0.158
+		%interplanetary = false
 	}
 }
 
@@ -447,13 +241,11 @@
 // One of each part would be about 30t
 @PART[sspx-core-25-1]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 60.0
-		// ((((massLimit ^ massExponent) + 1.035) * powerFactor) / 1000)
-		enabledkW = 0.098 // Next Generation Avionics
-		interplanetary = false
+		%massLimit = 60.0
+		%enabledkW = 0.098 // Next Generation Avionics
+		%interplanetary = false
 	}
 }
 
@@ -461,13 +253,11 @@
 // One of each part would be about 83t
 @PART[sspx-core-375-1]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 160.0
-		// ((((massLimit ^ massExponent) + 1.035) * powerFactor) / 1000)
-		enabledkW = 0.106 // International Era Avionics
-		interplanetary = false
+		%massLimit = 160.0
+		%enabledkW = 0.106 // International Era Avionics
+		%interplanetary = false
 	}
 }
 
@@ -475,517 +265,237 @@
 // ~ 2x weight control in avionics, allows for extra attitude/propulsion
 @PART[pioneer_5]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 0.1
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1960 config
-        diskSpace = 1000
-        diskSpaceCostFactor = 0.1       // 100F for double space
-        diskSpaceMassFactor = 0.00005   // 50 kg for double space
-        ECPerInstruction = 0.000001     // 100W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 0.1 }
+	%SetupKOS = 1960
 }
 
 @PART[pioneer_6_7_8_9]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 0.15
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1965 config
-        diskSpace = 20000
-        diskSpaceCostFactor = 0.0025     // 50F for double space
-        diskSpaceMassFactor = 0.0000001  // 2 kg for double space
-        ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 0.15 }
+	%SetupKOS = 1965
 }
 
 @PART[pioneer_10_11|quetzal]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 0.3
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1972 config
-        diskSpace = 100000
-        diskSpaceCostFactor = 0.0005       // 50F for double space
-        diskSpaceMassFactor = 0.000000005  // 0.5 kg for double space
-        ECPerInstruction = 0.00000004      // 4W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 0.3 }
+	%SetupKOS = 1972
 }
 
 @PART[neo_ulysses|neo_ds1|neo_near|neo_stardust|rn_new_horizons]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 1.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 1.0 }
+	%SetupKOS = 1980
 }
 
 @PART[rn_surveyor3|roverBody|roverBody_v2|torekka]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 2.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1965 config
-        diskSpace = 20000
-        diskSpaceCostFactor = 0.0025     // 50F for double space
-        diskSpaceMassFactor = 0.0000001  // 2 kg for double space
-        ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 2.0 }
+	%SetupKOS = 1965
 }
 
 @PART[neo_dawn|rn_messenger|magellan]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 2.2
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 2.2 }
+	%SetupKOS = 1980
 }
 
 @PART[neo_deepimpact]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 3.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 3.0 }
+	%SetupKOS = 1980
 }
 
 @PART[ius_top]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 18.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 18.0 }
+	%SetupKOS = 1980
 }
 
 @PART[eos_terra]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 8.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 8.0 }
+	%SetupKOS = 1980
 }
 
 @PART[eos_aqua|eos_aura|galileo_mb]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 5.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 5.0 }
+	%SetupKOS = 1980
 }
 
 @PART[eos_tdrs]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 6.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 6.0 }
+	%SetupKOS = 1980
 }
 
 // ** Soviet Probes, Probes with individual attitude control get
 // Basing values on the ~2x control allowed for US probes.
 @PART[molniya1]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 3.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1960 config
-        diskSpace = 1000
-        diskSpaceCostFactor = 0.1       // 100F for double space
-        diskSpaceMassFactor = 0.00005   // 50 kg for double space
-        ECPerInstruction = 0.000001     // 100W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 3.0 }
+	%SetupKOS = 1960
 }
 
 @PART[luna3]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 0.5
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1960 config
-        diskSpace = 1000
-        diskSpaceCostFactor = 0.1       // 100F for double space
-        diskSpaceMassFactor = 0.00005   // 50 kg for double space
-        ECPerInstruction = 0.000001     // 100W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 0.5 }
+	%SetupKOS = 1960
 }
 
 @PART[luna9_als|luna_als]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 2.0
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1960 config
-        diskSpace = 1000
-        diskSpaceCostFactor = 0.1       // 100F for double space
-        diskSpaceMassFactor = 0.00005   // 50 kg for double space
-        ECPerInstruction = 0.000001     // 100W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 2.0 }
+	%SetupKOS = 1960
 }
 
 @PART[polyot]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 1.5
-	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1961 config
-        diskSpace = 5000
-        diskSpaceCostFactor = 0.01       // 50F for double space
-        diskSpaceMassFactor = 0.0000005  // 2.5 kg for double space
-        ECPerInstruction = 0.0000004     // 40W @ 2000 IPU
-    }
+	%MODULE[ModuleAvionics] { %massLimit = 1.5 }
+	%SetupKOS = 1961
 }
 
 // ** Command parts (uncrewed)
 @PART[probeCoreOcto2]:FOR[RP-0]  // Deprecated
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 0.2
-		toggleable = true
-		disabledkW = 0.001
+		%massLimit = 0.2
+		%toggleable = true
+		%disabledkW = 0.001
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1960 config
-        diskSpace = 1000
-        diskSpaceCostFactor = 0.1       // 100F for double space
-        diskSpaceMassFactor = 0.00005   // 50 kg for double space
-        ECPerInstruction = 0.000001     // 100W @ 2000 IPU
-    }
+	%SetupKOS = 1960
 }
 
 // Ranger / Mariner
 @PART[SXTHECSRanger|bluedog_rangerCore|rn_mariner1_2|ca_argo-mk2]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 0.32		// 7-9-17 Pap: Up from 0.3 to have 5-1 Mass Ratio
-		toggleable = true
-		disabledkW = 0.0008
+		%massLimit = 0.32		// 7-9-17 Pap: Up from 0.3 to have 5-1 Mass Ratio
+		%toggleable = true
+		%disabledkW = 0.0008
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1961 config
-        diskSpace = 5000
-        diskSpaceCostFactor = 0.01       // 50F for double space
-        diskSpaceMassFactor = 0.0000005  // 2.5 kg for double space
-        ECPerInstruction = 0.0000004     // 40W @ 2000 IPU
-    }
+	%SetupKOS = 1961
 }
 
 // Ranger Block III
 @PART[probeCoreHex|probeCoreHex_v2]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 0.5			// 6-7-19 Pap: Was way out of whack. Lowered the mass of the part, still at 6.5 Mass Ratio
-		toggleable = true
-		disabledkW = 0.0015
+		%massLimit = 0.5			// 6-7-19 Pap: Was way out of whack. Lowered the mass of the part, still at 6.5 Mass Ratio
+		%toggleable = true
+		%disabledkW = 0.0015
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1965 config
-        diskSpace = 20000
-        diskSpaceCostFactor = 0.0025     // 50F for double space
-        diskSpaceMassFactor = 0.0000001  // 2 kg for double space
-        ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
-    }
+	%SetupKOS = 1965
 }
 
 // Surveyor (Deprecated)
 @PART[probeCoreOcto]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 1.0
-		toggleable = true
-		disabledkW = 0.0015
+		%massLimit = 1.0
+		%toggleable = true
+		%disabledkW = 0.0015
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1965 config
-        diskSpace = 20000
-        diskSpaceCostFactor = 0.0025     // 50F for double space
-        diskSpaceMassFactor = 0.0000001  // 2 kg for double space
-        ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
-    }
+	%SetupKOS = 1965
 }
 
 // AsteroidDay Core (1T Satellite)
 @PART[HECS2_ProbeCore]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 1.0
-		toggleable = true
-		disabledkW = 0.0015
+		%massLimit = 1.0
+		%toggleable = true
+		%disabledkW = 0.0015
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%SetupKOS = 1980
 }
 
 // Other Satellite Bus
 @PART[novapod|UAEcubplate|torpod|sondex2pod|neptuno|explonpod|Maxurpod|B9_Body_Mk2_SAS_050m|mk2DroneCore|B9_Cockpit_D25|B9_Cockpit_MK1_Control_ACU|FASAICBMProbe]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 10.0
-		toggleable = true
-		disabledkW = 0.002
+		%massLimit = 10.0
+		%toggleable = true
+		%disabledkW = 0.002
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%SetupKOS = 1980
 }
 
 // Early Cube Probe Core
 @PART[RO_probeCoreCubeEarly]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 3.3
-		toggleable = true
-		disabledkW = 0.002
+		%massLimit = 3.3
+		%toggleable = true
+		%disabledkW = 0.002
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%SetupKOS = 1980
 }
 
 // Small Satellite Bus
 @PART[probeCoreCube]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 7.7
-		toggleable = true
-		disabledkW = 0.002
+		%massLimit = 7.7
+		%toggleable = true
+		%disabledkW = 0.002
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%SetupKOS = 1980
 }
 
 // Medium Satellite Bus
 @PART[RO_probeCoreCubeMedium]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 12
-		toggleable = true
-		disabledkW = 0.002
+		%massLimit = 12
+		%toggleable = true
+		%disabledkW = 0.002
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 80s config
-        diskSpace = 200000
-        diskSpaceCostFactor = 0.00025      // 50F for double space
-        diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
-        ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
-    }
+	%SetupKOS = 1980
 }
 
 // Boeing 702
 @PART[RO_boeing702]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 15
-		toggleable = true
-		disabledkW = 0.002
+		%massLimit = 15
+		%toggleable = true
+		%disabledkW = 0.002
 	}
 }
 
 // Early Controllable Core
 @PART[RO_earlyControllableCore]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 0.2
-		toggleable = true
-		disabledkW = 0.001
+		%massLimit = 0.2
+		%toggleable = true
+		%disabledkW = 0.001
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1960 config
-        diskSpace = 1000
-        diskSpaceCostFactor = 0.1       // 100F for double space
-        diskSpaceMassFactor = 0.00005   // 50 kg for double space
-        ECPerInstruction = 0.000001     // 100W @ 2000 IPU
-    }
+	%SetupKOS = 1960
 }
 
 // Surveyor Core
 @PART[RO_surveyorCore|ca_landv_core|ca_landv_orbiter_core]:FOR[RP-0]
 {
-	MODULE
+	%MODULE[ModuleAvionics]
 	{
-		name = ModuleAvionics
-		massLimit = 1
-		toggleable = true
-		disabledkW = 0.0015
+		%massLimit = 1
+		%toggleable = true
+		%disabledkW = 0.0015
 	}
-    MODULE:NEEDS[kOS]
-    {
-        name = kOSProcessor
-        // 1965 config
-        diskSpace = 20000
-        diskSpaceCostFactor = 0.0025     // 50F for double space
-        diskSpaceMassFactor = 0.0000001  // 2 kg for double space
-        ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
-    }
+	%SetupKOS = 1985
 }
 
 // *** Guidance units (including stages)
@@ -1049,11 +559,7 @@
 //  Centaur guidance provides control for both Centaur and Atlas stages
 @PART[RSBtankAtlasCentaur]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 600
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 600 }
 }
 
 // FIXME: Do this for other small upper stages.
@@ -1071,11 +577,7 @@
 // Athena Orbital Adjustment Module (OAM)
 @PART[RSBathenaOAM]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 130.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 130.0 }
 }
 
 // Saturn IU, S-IVB. Note we make a stock version, RP0probeAvionics66m
@@ -1093,22 +595,14 @@
 @PART[SXT375mProbe|bluedog_Saturn_S4_InstrumentUnit|RSBprobeSaturn2]:FOR[RP-0]
 {
 	@description ^= :$: Allows full control over the vessel, up to the tonnage limit (cumulative).:
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 1500.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 1500.0 }
 }
 
 // ** Titan
 // Transtage
 @PART[FASAGeminiLFECentarTwin]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 35.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 35.0 }
 }
 // Titan I upper stage, Titan I was 105t but let's add some margin.
 @PART[TitanIUpper]:FOR[RP-0]
@@ -1306,82 +800,50 @@
 // Ares I
 @PART[RSBtankAresIstage2]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 900.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 900.0 }
 }
 
 // Ariane V
 @PART[RSBtankArianeVescA]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 800.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 800.0 }
 }
 
 // Delta II
 @PART[RSBtankDelta2K]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 250.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 250.0 }
 }
 
 // Delta III
 @PART[RSBtankDelta3dcss4m]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 330.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 330.0 }
 }
 
 // Delta Cryogenic Second Stage (DCSS)
 // 4m variant, used on Delta IV Medium 4+
 @PART[RSBtankDeltaIVdcss4m]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 450.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 450.0 }
 }
 
 // 5m variant, used on Delta IV Medium 5+ and Delta IV Heavy
 @PART[RSBtankDeltaIVdcss5m]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 800.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 800.0 }
 }
 
 // Polar Satellite Launch Vehicle (PSLV)
 @PART[RSBtankPSLVps4]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 350.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 350.0 }
 }
 
 // Falcon 9 and Falcon Heavy
 @PART[KK_SPX_Falcon9_FC]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 1500.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 1500.0 }
 }
 
 // Stage guidance rings
@@ -1489,11 +951,7 @@
 // Config for RN R-7 (Block L/E, Fregat)
 @PART[rn_fregat1|rn_fregat1_2|rn_fregat1_3|rn_molniya_blockl|rn_molniya_blockl_2|rn_molniya_blockl_3|rn_r7_vostok_blok_e|rn_r7_vostok_blok_e_2|rn_r7_vostok_blok_e_lunar|Alto_LFO_A]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 12.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 12.0 }
 }
 
 //Config for N-1 launcher (Block V)
@@ -1510,11 +968,7 @@
 //Config for L3 spaceship (LOK + LK + Block D + Block G), 95 tons departure mass + 5t to add some margin, avionics in Block G
 @PART[LLV_LFO_D]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 100.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 100.0 }
 }
 
 //
@@ -1565,48 +1019,29 @@
 }
 @PART[skylab-trs]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 150.0	// Just a guess but since the TRS was supposed to reposition Skylab, I figured it should be set high
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 150.0 }
+	// Just a guess but since the TRS was supposed to reposition Skylab, I figured it should be set high
 }
 
 // Do not allow the SSTU Upper Stages to control any avionics. They should require an additional avionics package like all other parts.
 @PART[SSTU-SC-TANK-MUS-*]:NEEDS[SSTU]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 0.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 0.0 }
 }
 
 @PART[ca_vor_core]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 6.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 6.0 }
 }
 
 @PART[ca_fom_lander]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 2.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 2.0 }
 }
 
 @PART[ca_linkor]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 12.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 12.0 }
 }
 
 // Support for the Sample Return Capsule
@@ -1628,61 +1063,146 @@
 // LM900 Satellite Bus 817 kg
 @PART[rn_voyager|torekka|ca_ESM2]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 0.875
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 0.875 }
 }
 
 // SSTL-150 Bus 153 kg max
 // https://rsdo.gsfc.nasa.gov/images/catalog/SSTL150.pdf
 @PART[barquetta]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 0.16
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 0.16 }
 }
 
 // IUE 672 kg
 // STEREO 619 kg
 @PART[ca_explorer|xihe]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 0.7
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 0.7 }
 }
 
 // Juno 3625 kg launch mass
 @PART[ca_hera]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 3.7
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 3.7 }
 }
 
 // Cassini 5712 kg Launch mass
 @PART[meridiani]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 6.0
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 6.0 }
 }
 
 // LM 400 Series 800 kg
 @PART[tatsujin]:FOR[RP-0]
 {
-	MODULE
-	{
-		name = ModuleAvionics
-		massLimit = 0.8
-	}
+	%MODULE[ModuleAvionics] { %massLimit = 0.8 }
 }
+
+@PART:HAS[#SetupKOS[Mercury]]:FOR[RP-0]:NEEDS[kOS]
+{
+    %MODULE[kOSProcessor]
+    {
+        // Mercury had no onboard computer, so just allow a small amount of storage for ground control linkups
+        %diskSpace = 1000
+        %diskSpaceCostFactor = 0.1       // 100F for double space
+        %diskSpaceMassFactor = 0.00005   // 50 kg for double space
+        %ECPerInstruction = 0.000001     // 100W @ 2000 IPU
+    }
+}
+
+@PART:HAS[#SetupKOS[Gemini]]:FOR[RP-0]:NEEDS[kOS]
+{
+    %MODULE[kOSProcessor]
+    {
+        // Gemini had circa 20kb storage
+        %diskSpace = 20000
+        %diskSpaceCostFactor = 0.0025     // 50F for double space
+        %diskSpaceMassFactor = 0.0000001  // 2 kg for double space
+        %ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
+    }
+}
+
+@PART:HAS[#SetupKOS[ApolloCM]]:FOR[RP-0]:NEEDS[kOS]
+{
+    %MODULE[kOSProcessor]
+    {
+        // Apollo had circa 100kB of memory (I have split this with the SM).
+        %diskSpace = 50000
+        %diskSpaceCostFactor = 0.001       // 50F for double space
+        %diskSpaceMassFactor = 0.00000005  // 2.5 kg for double space
+        %ECPerInstruction = 0.00000008     // 8W @ 2000 IPU
+    }
+}
+
+@PART:HAS[#SetupKOS[Station]]:FOR[RP-0]:NEEDS[kOS]
+{
+    %MODULE[kOSProcessor]
+    {
+        %diskSpace = 200000
+        %diskSpaceCostFactor = 0.00025      // 50F for double space
+        %diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
+        %ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
+    }
+}
+
+@PART:HAS[#SetupKOS[1960]]:FOR[RP-0]:NEEDS[kOS]
+{
+    %MODULE[kOSProcessor]
+    {
+        // 1960 config
+        %diskSpace = 1000
+        %diskSpaceCostFactor = 0.1       // 100F for double space
+        %diskSpaceMassFactor = 0.00005   // 50 kg for double space
+        %ECPerInstruction = 0.000001     // 100W @ 2000 IPU
+    }
+}
+
+@PART:HAS[#SetupKOS[1961]]:FOR[RP-0]:NEEDS[kOS]
+{
+    %MODULE[kOSProcessor]
+    {
+        // 1961 config
+        %diskSpace = 5000
+        %diskSpaceCostFactor = 0.01       // 50F for double space
+        %diskSpaceMassFactor = 0.0000005  // 2.5 kg for double space
+        %ECPerInstruction = 0.0000004     // 40W @ 2000 IPU
+    }
+}
+
+@PART:HAS[#SetupKOS[1965]]:FOR[RP-0]:NEEDS[kOS]
+{
+    %MODULE[kOSProcessor]
+    {
+        // 1965 config
+        %diskSpace = 20000
+        %diskSpaceCostFactor = 0.0025     // 50F for double space
+        %diskSpaceMassFactor = 0.0000001  // 2 kg for double space
+        %ECPerInstruction = 0.0000001     // 10W @ 2000 IPU
+    }
+}
+
+@PART:HAS[#SetupKOS[1972]]:FOR[RP-0]:NEEDS[kOS]
+{
+    %MODULE[kOSProcessor]
+    {
+        // 1972 config
+        %diskSpace = 100000
+        %diskSpaceCostFactor = 0.0005       // 50F for double space
+        %diskSpaceMassFactor = 0.000000005  // 0.5 kg for double space
+        %ECPerInstruction = 0.00000004      // 4W @ 2000 IPU
+    }
+}
+
+@PART:HAS[#SetupKOS[1980]]:FOR[RP-0]:NEEDS[kOS]
+{
+    %MODULE[kOSProcessor]
+    {
+        // 80s config
+        %diskSpace = 200000
+        %diskSpaceCostFactor = 0.00025      // 50F for double space
+        %diskSpaceMassFactor = 0.000000002  // 0.4 kg for double space
+        %ECPerInstruction = 0.00000001      // 1W @ 2000 IPU
+    }
+}
+
+@PART:HAS[#SetupKOS]:FOR[RP-0] { !SetupKOS = DEL }

--- a/GameData/RP-0/Tree/ProceduralAvionics.cfg
+++ b/GameData/RP-0/Tree/ProceduralAvionics.cfg
@@ -1023,17 +1023,16 @@ AVIONICSCONFIGS
 
 // kOS processor tech level scaling
 // Note that numbers here are the base storage, rocket designers may add 2x or 4x as much for additional cost in the VAB.
-@PART[*]:HAS[@MODULE[ModuleProceduralAvionics]]:NEEDS[kOS]:AFTER[RP-0]
+@PART:HAS[@MODULE[ModuleProceduralAvionics]]:NEEDS[kOS]:AFTER[RP-0]
 {
-	MODULE
+	%MODULE[kOSProcessor]
 	{
-		name = kOSProcessor
 		// Base disk space is tiny, upgraded through proc avionics tech levels.
-		diskSpace = 500
-		baseDiskSpace = 500
-		diskSpaceCostFactor = 0.1       // 50F for double space
-		diskSpaceMassFactor = 0.0001    // 50 kg for double space
-		ECPerInstruction = 0.000001     // 1kW @ 2000 IPU
+		%diskSpace = 500
+		%baseDiskSpace = 500
+		%diskSpaceCostFactor = 0.1       // 50F for double space
+		%diskSpaceMassFactor = 0.0001    // 50 kg for double space
+		%ECPerInstruction = 0.000001     // 1kW @ 2000 IPU
 	}
 }
 


### PR DESCRIPTION
Use patching strategy of create-or-edit instead of create for kOS PartModule.  RO global patches now add one properly, and run first.
Extract individual patches into a tag-and-then-apply structure.  Removes copy-pasta-related errors.  Tag the part once, let the patch at the end apply consistent values.
Use create-or-edit for most ModuleAvionics patches.  Especially ones that can go on one line with a single setting -- Veyl hates whitespace!
Minor patch cleanup