### PR TITLE
Add soft cooldown reputation reward to repeatable SRs and X-Planes

### DIFF
--- a/GameData/RP-0/Contracts/Early X-Plane Research/CrewedSupersonic.cfg
+++ b/GameData/RP-0/Contracts/Early X-Plane Research/CrewedSupersonic.cfg
@@ -31,8 +31,26 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 10
-	failureReputation = 10
+	rewardReputation = Round((20.0 * @rewardFactor, 1)
+	failureReputation = @rewardReputation
+	
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $XPSS_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $XPSS_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 120
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
+	}
+	
+	// ************* REQUIREMENTS ****************
 
 	REQUIREMENT
 	{

--- a/GameData/RP-0/Contracts/Early X-Plane Research/RocketPlaneDevelopment.cfg
+++ b/GameData/RP-0/Contracts/Early X-Plane Research/RocketPlaneDevelopment.cfg
@@ -31,9 +31,26 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 8
-	failureReputation = 8
+	rewardReputation = Round(15 * @rewardFactor, 1)
+	failureReputation = @rewardReputation
+	
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $RPD_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $RPD_Completion
+	}
 
+	DATA
+	{
+		type = float
+		expectedDays = 120
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 3 - 0.05, 1), 2) / 1.5607
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
+	}
+	
+	// ************ REQUIREMENTS ************
 	REQUIREMENT
 	{
 		name = ProgramActive

--- a/GameData/RP-0/Contracts/Suborbital Rocket Development/DistanceSoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Suborbital Rocket Development/DistanceSoundingDifficult.cfg
@@ -32,8 +32,30 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 10
-	failureReputation = 10
+	rewardReputation = Round(20 * @rewardFactor * @noPlaneFundMult, 1)
+	failureReputation = @rewardReputation
+
+	DATA
+	{
+		type = float
+		noPlaneFundMult = RP1YesPlanes() ? 1 : @RP0:noPlaneFundMult
+	}
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $SRD_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $SRD_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 90
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 3 - 0.05, 1), 2) / 1.5607
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
+	}
 
 	// The global modifiers for all sounding rockets are stored in the main Groups.cfg file in the root Contracts folder
 	DATA

--- a/GameData/RP-0/Contracts/Suborbital Rocket Development/DistanceSoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Suborbital Rocket Development/DistanceSoundingIntermediate.cfg
@@ -32,8 +32,31 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 5
-	failureReputation = 5
+	rewardReputation = Round(15 * @rewardFactor * @noPlaneFundMult, 1)
+	failureReputation = @rewardReputation
+	
+	DATA
+	{
+		type = float
+		noPlaneFundMult = RP1YesPlanes() ? 1 : @RP0:noPlaneFundMult
+	}
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $SRD_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $SRD_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 90
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 3 - 0.05, 1), 2) / 1.5607
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
+	}
+
 
 	// The global modifiers for all sounding rockets are stored in the main Groups.cfg file in the root Contracts folder
 	DATA

--- a/GameData/RP-0/Contracts/Suborbital Rocket Development/SoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Suborbital Rocket Development/SoundingDifficult.cfg
@@ -32,7 +32,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = Round(10 * @rewardFactor * @noPlaneFundMult, 1)
+	rewardReputation = Round(20 * @rewardFactor * @noPlaneFundMult, 1)
 	failureReputation = @rewardReputation
 	
 

--- a/GameData/RP-0/Contracts/Suborbital Rocket Development/SoundingDifficult.cfg
+++ b/GameData/RP-0/Contracts/Suborbital Rocket Development/SoundingDifficult.cfg
@@ -32,8 +32,32 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 10
-	failureReputation = 10
+	rewardReputation = Round(10 * @rewardFactor * @noPlaneFundMult, 1)
+	failureReputation = @rewardReputation
+	
+
+	DATA
+	{
+		type = float
+		noPlaneFundMult = RP1YesPlanes() ? 1 : @RP0:noPlaneFundMult
+	}
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $SRA_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $SRA_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 90
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 3 - 0.05, 1), 2) / 1.5607
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
+	}
+
 
   // The global modifiers for all sounding rockets are stored in the main Groups.cfg file in the root Contracts folder
   DATA

--- a/GameData/RP-0/Contracts/Suborbital Rocket Development/SoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Suborbital Rocket Development/SoundingIntermediate.cfg
@@ -32,8 +32,30 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = 5
-	failureReputation = 5
+	rewardReputation = Round(5 * @rewardFactor * @noPlaneFundMult, 1)
+	failureReputation = @rewardReputation
+
+	DATA
+	{
+		type = float
+		noPlaneFundMult = RP1YesPlanes() ? 1 : @RP0:noPlaneFundMult
+	}
+
+	DATA
+	{
+		type = int
+		antiGrindCompletion = $SRA_Completion == 0 ? (UniversalTime() - @expectedDays * 86400) : $SRA_Completion
+	}
+
+	DATA
+	{
+		type = float
+		expectedDays = 90
+
+		elapsedDays = Round((UniversalTime() - @antiGrindCompletion) / 86400.0)
+		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 3 - 0.05, 1), 2) / 1.5607
+		rewardFactorPercent = Round(@rewardFactor * 100, 1)
+	}
 
   // The global modifiers for all sounding rockets are stored in the main Groups.cfg file in the root Contracts folder
   DATA

--- a/GameData/RP-0/Contracts/Suborbital Rocket Development/SoundingIntermediate.cfg
+++ b/GameData/RP-0/Contracts/Suborbital Rocket Development/SoundingIntermediate.cfg
@@ -32,7 +32,7 @@ CONTRACT_TYPE
 	rewardScience = 0
 	rewardFunds = 0
 	failureFunds = 0
-	rewardReputation = Round(5 * @rewardFactor * @noPlaneFundMult, 1)
+	rewardReputation = Round(15 * @rewardFactor * @noPlaneFundMult, 1)
 	failureReputation = @rewardReputation
 
 	DATA


### PR DESCRIPTION
Done mostly according to the spreadsheet, except that I gave a lower reward to altitude SRs vs. Downrange. Also, all X-plane contracts are giving Rep, as it's not clear to me how we would go about giving Rep only to later completions beyond a "required" level.