### PR TITLE
Fix Hydrazine

### DIFF
--- a/GameData/RP-0/Tree/ECM-Engines.cfg
+++ b/GameData/RP-0/Tree/ECM-Engines.cfg
@@ -152,7 +152,7 @@
     HiPAT-445 = 0
     HiPAT-445-Dual = 0
     HiPEP = 26200
-    Hydrazine = CatalystRCS, HydrazineFuel
+    Hydrazine = 5000, CatalystRCS, HydrazineFuel
     ID-500 = 150000
     ISE-100-445 = 10000,HydrazineFuel,NTOOxidizer,throttlingPF
     ISE-100-MON3 = ISE-100 (445N)

--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -1572,7 +1572,7 @@
     ntr-sc-125-2 = NERVA-II
     ntr-sc-25-1 = BNTR
     nuclearEngine = NERVA-I
-    ok-sa-rcs = capsulesSoyuz, catalystRCS
+    ok-sa-rcs = capsulesSoyuz, CatalystRCS
     ok-bo-fem = 50000, ok-sa, dockingProbeDrogue
     ok-bo-male = ok-bo-fem
     ok-dec = capsulesSoyuz

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -3218,7 +3218,7 @@
         "spacecraft": "",
         "engine_config": "RCS",
         "upgrade": true,
-        "entry_cost_mods": "CatalystRCS, HydrazineFuel",
+        "entry_cost_mods": "5000, CatalystRCS, HydrazineFuel",
         "identical_part_name": "",
         "module_tags": []
     },

--- a/Source/Tech Tree/Parts Browser/data/RN_Soyuz.json
+++ b/Source/Tech Tree/Parts Browser/data/RN_Soyuz.json
@@ -62,7 +62,7 @@
         "spacecraft": "Soyuz",
         "engine_config": "",
         "upgrade": false,
-        "entry_cost_mods": "capsulesSoyuz, catalystRCS",
+        "entry_cost_mods": "capsulesSoyuz, CatalystRCS",
         "identical_part_name": "",
         "module_tags": []
     },


### PR DESCRIPTION
Add small entry cost to Hydrazine RCS so it isn't unlocked if "Hydrazine Fuel" and "Catalyst RCS" nodes are unlocked.

Should resolve https://github.com/KSP-RO/RP-0/issues/1704, testing needed.