### PR TITLE
Remove DBS from conflicts in netkan

### DIFF
--- a/RP-0.netkan
+++ b/RP-0.netkan
@@ -83,7 +83,6 @@
 		{ "name" : "CrowdSourcedScience" },
 		{ "name" : "HideEmptyTechNodes" },
 		{ "name" : "MechJebForAll" },
-		{ "name" : "DynamicBatteryStorage" },
 		{ "name" : "KRASH" }
 	]
 }


### PR DESCRIPTION
Dynamic Battery Storage disables itself when Kerbalism is installed, so it doesn't cause `incoherent behaviour`