### PR TITLE
Set allowRestart for TF compatibility

### DIFF
--- a/GameData/RP-0/KCT/KCT_ModuleTemplates.cfg
+++ b/GameData/RP-0/KCT/KCT_ModuleTemplates.cfg
@@ -7,6 +7,7 @@ MODULE
 	engineShutdown = False
 	currentThrottle = 0
 	manuallyOverridden = False
+	allowRestart = True
 }
 MODULE
 {
@@ -17,6 +18,7 @@ MODULE
 	engineShutdown = False
 	currentThrottle = 0
 	manuallyOverridden = False
+	allowRestart = True
 }
 MODULE
 {
@@ -27,6 +29,7 @@ MODULE
 	engineShutdown = False
 	currentThrottle = 0
 	manuallyOverridden = False
+	allowRestart = True
 }
 MODULE
 {
@@ -37,6 +40,7 @@ MODULE
 	engineShutdown = False
 	currentThrottle = 0
 	manuallyOverridden = False
+	allowRestart = True
 }
 MODULE
 {
@@ -47,6 +51,7 @@ MODULE
 	engineShutdown = False
 	currentThrottle = 0
 	manuallyOverridden = False
+	allowRestart = True
 }
 MODULE
 {


### PR DESCRIPTION
Compatibility fix for updated failure logic in TF.

`allowRestart` starts `true` in `ModuleEngines`.