### PR TITLE
Science hotfix

### DIFF
--- a/GameData/RP-0/Science/Experiments/CosmicRay.cfg
+++ b/GameData/RP-0/Science/Experiments/CosmicRay.cfg
@@ -4,7 +4,7 @@
 
 EXPERIMENT_DEFINITION
 {
-    id = RP0cosmicRay1
+    id = RP0cosmicRay1_5
     title = Cosmic Ray Science
     baseValue = 10
     scienceCap = 10
@@ -30,13 +30,13 @@ EXPERIMENT_DEFINITION
 // ============================================================================
 // Replacing stock experiments
 // ============================================================================
-@PART[*]:HAS[@MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1]]]:NEEDS[FeatureScience,RP-0]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[@MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1_5]]]:NEEDS[FeatureScience,RP-0]:FOR[RP-0-Kerbalism]
 {
-	!MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1]]	{}
+	!MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1_5]]	{}
 	MODULE
 	{
 		name = Experiment
-		experiment_id = RP0cosmicRay1
+		experiment_id = RP0cosmicRay1_5
 	}
 }
 
@@ -47,7 +47,7 @@ EXPERIMENT_DEFINITION
 // ============================================================================
 @PART[*]:HAS[@MODULE[Experiment]]:NEEDS[FeatureScience,RP-0]:AFTER[RP-0-Kerbalism]
 {
-	@MODULE[Experiment]:HAS[#experiment_id[RP0cosmicRay1]]
+	@MODULE[Experiment]:HAS[#experiment_id[RP0cosmicRay1_5]]
 	{
 		%ec_rate = 0.0001
 		%data_rate = 1.9656 //2 b/s
@@ -83,7 +83,7 @@ EXPERIMENT_DEFINITION:NEEDS[FeatureScience,RP-0]
     {
    		// sample mass in tons. if undefined or 0, the experiment produce a file
       	SampleMass = 0
-		IncludeExperiment = RP0cosmicRay1
+		IncludeExperiment = RP0cosmicRay1_5
     }
 }
 //ROK
@@ -119,7 +119,7 @@ EXPERIMENT_DEFINITION:NEEDS[FeatureScience,RP-0]
 	MODULE
 	{
 		name = DMModuleScienceAnimateGeneric
-		experimentID = RP0cosmicRay1
+		experimentID = RP0cosmicRay1_5
 		
 		animationName = needle
 		experimentAnimation = true
@@ -210,7 +210,7 @@ EXPERIMENT_DEFINITION:NEEDS[FeatureScience,RP-0]
 // ============================================================================
 @PART[RO-ScintillationCounter]:NEEDS[FeatureScience,RP-0]:BEFORE[RP-0-Kerbalism]
 {
-	!MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1]]	{}
+	!MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1_5]]	{}
 	MODULE
     {
         name = ModuleScienceExperiment

--- a/GameData/RP-0/Science/Experiments/GlobalExperimentPatches.cfg
+++ b/GameData/RP-0/Science/Experiments/GlobalExperimentPatches.cfg
@@ -1,0 +1,4 @@
+@EXPERIMENT_DEFINITION:FIRST 
+{ 
+    @dataScale /= #$baseValue$ 
+}


### PR DESCRIPTION
Renames the Cosmic Ray experiment back to 1_5 to prevent craft from breaking, and creates a global patch to perform a dataScale division that was not working in the experiment definitions