### PR TITLE
Split cost of stock rd855

### DIFF
--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -29549,7 +29549,7 @@
 @PART[radialLiquidEngine1-2]:FOR[xxxRP0]
 {
     %TechRequired = orbitalRocketry1964
-    %cost = 350
+    %cost = 90
     %entryCost = 15000
     RP0conf = true
     @description ^=:$: <b><color=green>From Stock (RO Config) mod</color></b>

--- a/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
@@ -6606,7 +6606,7 @@
         "title": "RD-855 [Radial]",
         "description": "Vernier thruster used on the first stage of the Tsyklon rocket. Diameter: [0.3 m]. Plume configured by RealPlume.",
         "mod": "Stock (RO Config)",
-        "cost": "350",
+        "cost": 90,
         "entry_cost": "15000",
         "category": "ORBITAL",
         "info": "",


### PR DESCRIPTION
similar to #1346: 350 funds for each of 4 verniers doesn't seem to make
sense, especially when paired with 3x 2-nozzle rd250 (which would cost
1140, based on 760 for ROE's 4-nozzle rd250) for a tsyklon first stage.

so assume 350 was meant to be the cost of the full 4-vernier engine,
and divide by 4. RO already divides mass & thrust by 4.