### PR TITLE
Funds per day tooltip for Build Cost in New LC GUI

### DIFF
--- a/Source/KerbalConstructionTime/GUI/GUI_NewLC.cs
+++ b/Source/KerbalConstructionTime/GUI/GUI_NewLC.cs
@@ -393,11 +393,12 @@ namespace KerbalConstructionTime
                 GUILayout.Label(" ");
 
                 double buildTime = ConstructionBuildItem.CalculateBuildTime(totalCost, SpaceCenterFacility.LaunchPad, null);
+                double buildCost = -RP0.CurrencyUtils.Funds(RP0.TransactionReasonsRP0.StructureConstructionLC, -totalCost);
                 string sBuildTime = KSPUtil.PrintDateDelta(buildTime, includeTime: false);
                 string costString = isModify ? "Renovate Cost:" : "Build Cost:";
                 GUILayout.BeginHorizontal();
                 GUILayout.Label(costString, GUILayout.ExpandWidth(false));
-                GUILayout.Label($"√{-RP0.CurrencyUtils.Funds(RP0.TransactionReasonsRP0.StructureConstructionLC, -totalCost):N0}", GetLabelRightAlignStyle());
+                GUILayout.Label(new GUIContent($"√{buildCost:N0}", $"Daily: √{(buildCost * 86400d / buildTime):N1}"), GetLabelRightAlignStyle());
                 GUILayout.EndHorizontal();
                 if (!isModify || _newLCData.lcType == LaunchComplexType.Pad)
                 {


### PR DESCRIPTION
Creates a simpler way to view the daily fund impact of building a new LC.

![image](https://user-images.githubusercontent.com/48612811/185886636-d1f017a9-c03f-42e6-8add-4d6714fc19dc.png)
