### PR TITLE
Configure RO-RD215

### DIFF
--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -502,6 +502,7 @@
     RO-RD-0124 = RD-0124
     RO-RD-0210 = RD-0208
     RO-RD-253 = RD-253
+    RO-RD215 = RD-215-8D513
     RO-RD58 = S1-5400
     RO-RD9B = 2000
     RO-RFTank = 1

--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -9240,6 +9240,18 @@
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
+@PART[RO-RD215]:FOR[xxxRP0]
+{
+    %TechRequired = orbitalRocketry1960
+    %cost = 330
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From Stock (RO Config) mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
+    %MODULE[ModuleTagList] { tag = Toxic }
+
+}
 @PART[RO-RD58]:FOR[xxxRP0]
 {
     %TechRequired = firstStagedCombustion

--- a/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
@@ -2086,6 +2086,31 @@
         ]
     },
     {
+        "name": "RO-RD215",
+        "title": "RD-215",
+        "description": "",
+        "mod": "Stock (RO Config)",
+        "cost": "330",
+        "entry_cost": "0",
+        "category": "ORBITAL",
+        "info": "",
+        "year": "1960",
+        "technology": "orbitalRocketry1960",
+        "ro": true,
+        "rp0": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "RD215",
+        "upgrade": false,
+        "entry_cost_mods": "RD-215-8D513",
+        "identical_part_name": "",
+        "module_tags": [
+            "EngineLiquidTurbo",
+            "Toxic"
+        ]
+    },
+    {
         "name": "RO-RD58",
         "title": "S1.5400/RD-58 Series",
         "description": "World's first closed-cycle kerolox vacuum engine. The S1.5400 served as an R-7 upper stage and the RD-58 (an upgrade) as upper stage / OMS for many Soviet and Russian launchers and spacecraft (Proton, N1, Zenit, Buran...). The S1.5400 was designed for the Blok L stage which was the final stage for the Molniya configuration of the R-7, used to launch communication satellites and interplanetary probes. Unlike prior upper stages, it was restartable (this was needed to perform apogee kick to place Molniya satellites in their final orbits). It was given the industry designation 11D33. An upgraded version, termed 11D33M, had slightly improved performance. The RD-58 is a derivative of the 11D33M engine with higher performance (industry designation 11D58); it has been used on many Russian launchers and is still in use today on Proton and Zenit. In comparison to hydrolox upper stages, kerolox ones do not suffer boiloff as badly and need far less volume (kerosene being far denser than liquid hydrogen), but have much lower specific impulse. Diameter: [2.0 m]. Plume configured by RealPlume.",


### PR DESCRIPTION
Half the cost of ROE's double-rd215, minus a bit to account for
not having anything for attitude control

for https://github.com/KSP-RO/RealismOverhaul/pull/2712