### PR TITLE
Reset X-plane contracts when vessel gets destroyed

### DIFF
--- a/GameData/RP-0/Contracts/X-Planes/CrewedFlight.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedFlight.cfg
@@ -105,6 +105,8 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Maintain between @ReachAlt/minAltitude and @ReachAlt/maxAltitude m with a crewed aircraft.
 		define = lowAirplane
+		dissassociateVesselsOnContractCompletion = true
+		resetChildrenWhenVesselDestroyed = true
 
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmo.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmo.cfg
@@ -136,6 +136,9 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Reach @/altHighCrew.Print() km with a crewed vessel.
 		define = crewedSuborbitalCraft
+		dissassociateVesselsOnContractCompletion = true
+		resetChildrenWhenVesselDestroyed = true
+
 		PARAMETER
 		{
 			name = NewVessel

--- a/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoDifficult.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoDifficult.cfg
@@ -143,6 +143,9 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Reach @/altHighCrew.Print() km with a crewed vessel.
 		define = crewedSuborbitalCraft
+		dissassociateVesselsOnContractCompletion = true
+		resetChildrenWhenVesselDestroyed = true
+
 		PARAMETER
 		{
 			name = NewVessel

--- a/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
@@ -85,6 +85,8 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Maintain between @HoldSituation/minSpeed m/s and @HoldSituation/maxSpeed m/s in level flight with a crewed jet aircraft.
 		define = supersonicCraft
+		dissassociateVesselsOnContractCompletion = true
+		resetChildrenWhenVesselDestroyed = true
 
 		PARAMETER
 		{

--- a/GameData/RP-0/Contracts/X-Planes/RocketPlaneDevelopment.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/RocketPlaneDevelopment.cfg
@@ -162,6 +162,9 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Reach @/altitudeKm km with a crewed vessel.
 		define = crewedSuborbitalCraft
+		dissassociateVesselsOnContractCompletion = true
+		resetChildrenWhenVesselDestroyed = true
+
 		PARAMETER
 		{
 			name = NewVessel


### PR DESCRIPTION
Leverage the new CC resetChildrenWhenVesselDestroyed option to fix X-plane contracts staying locked to a destroyed vessel.

**NEEDS https://github.com/KSP-RO/ContractConfigurator/releases/tag/v99.9.9.3 TO WORK**