### PR TITLE
Fix MMH+NTO and UDMH+NTO early unlocks

### DIFF
--- a/GameData/RP-0/Tree/ECM-Engines.cfg
+++ b/GameData/RP-0/Tree/ECM-Engines.cfg
@@ -255,7 +255,7 @@
     MB-XX-Demo = 200000,HydroloxPumps
     MMH+MON10 = 1000, MMHRCS
     MMH+MON3 = 1000, MMHRCS
-    MMH+NTO = MMHRCS
+    MMH+NTO = 1000, MMHRCS
     MR-510-Ammonia = 0
     MR-510-Hydrazine = 0
     MR-510-Hydrogen = 0
@@ -551,7 +551,7 @@
     UA1206 = 5000, UA120inch
     UA1207 = 7000, ULA120inch
     UA1208 = 8000,ULA120inch
-    UDMH+NTO = BipropRCS
+    UDMH+NTO = 1000, BipropRCS
     VF-200-Ar = 150000
     VF-200-Kr = VF-200-Ar
     VX-200SS-Ar = 100000, VF-200-Ar

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -5535,7 +5535,7 @@
         "spacecraft": "",
         "engine_config": "RCS",
         "upgrade": true,
-        "entry_cost_mods": "MMHRCS",
+        "entry_cost_mods": "1000, MMHRCS",
         "identical_part_name": "",
         "module_tags": []
     },
@@ -12185,7 +12185,7 @@
         "spacecraft": "",
         "engine_config": "RCS",
         "upgrade": true,
-        "entry_cost_mods": "BipropRCS",
+        "entry_cost_mods": "1000, BipropRCS",
         "identical_part_name": "",
         "module_tags": []
     },


### PR DESCRIPTION
Add 1000 cost to both to prevent becoming available if parts with MMHRCS or BipropRCS unlocked.