### PR TITLE
Simple Offset Cone tooling

### DIFF
--- a/Source/Tooling/ModuleToolingPTank.cs
+++ b/Source/Tooling/ModuleToolingPTank.cs
@@ -102,6 +102,7 @@ namespace RP0
                 procShape = shapeName switch
                 {
                     "Smooth Cone" => part.Modules["ProceduralShapeBezierCone"],
+                    "Smooth Cone Offset" => part.Modules["ProceduralShapeBezierOffset"],
                     "Cone" => part.Modules["ProceduralShapeCone"],
                     "Fillet Cylinder" => part.Modules["ProceduralShapePill"],
                     "Polygon" => part.Modules["ProceduralShapePolygon"],


### PR DESCRIPTION
Adds simple tooling to the offset smooth cone from ProcParts. The tooling ignores the offset and only looks at the diameters and length of the part