### PR TITLE
Add speclevel to engine CONFIG PARTUPGRADEs

### DIFF
--- a/GameData/RP-0/Tree/TREE-Engines.cfg
+++ b/GameData/RP-0/Tree/TREE-Engines.cfg
@@ -4348,6 +4348,32 @@ PARTUPGRADE
         description = The RD58 Engine now supports the 11D33 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nDeveloped version of S1.5400 engine for Block L stage of Molniya launch vehicle. Slightly better performance.
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_11D33
+    engineType = RD58
+}
+
+@PART[RFUpgrade_engineConfigSource_11D33]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[11D33] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_11D33]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_11D33]/MODULE[ModuleEngineConfigs]/CONFIG[11D33]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_11D33]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_11D33M
@@ -4360,6 +4386,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD58 Engine now supports the 11D33M configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nThe S1.5400A engine, as used on Block ML on the Molniya M launch vehicle. Further performance improvements to the basic S1.5400/11D33 engine.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_11D33M
+    engineType = RD58
+}
+
+@PART[RFUpgrade_engineConfigSource_11D33M]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[11D33M] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_11D33M]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_11D33M]/MODULE[ModuleEngineConfigs]/CONFIG[11D33M]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_11D33M]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4376,6 +4428,32 @@ PARTUPGRADE
         description = The RD58 Engine now supports the 17D12 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_17D12
+    engineType = RD58
+}
+
+@PART[RFUpgrade_engineConfigSource_17D12]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[17D12] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_17D12]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_17D12]/MODULE[ModuleEngineConfigs]/CONFIG[17D12]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_17D12]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_30x_NK-33
@@ -4388,6 +4466,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The N1_BlockA Engine now supports the 30x_NK-33 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_30x_NK-33
+    engineType = N1_BlockA
+}
+
+@PART[RFUpgrade_engineConfigSource_30x_NK-33]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[30x_NK-33] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_30x_NK-33]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_30x_NK-33]/MODULE[ModuleEngineConfigs]/CONFIG[30x_NK-33]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_30x_NK-33]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4404,6 +4508,32 @@ PARTUPGRADE
         description = The 457M Engine now supports the 457M-V1-K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_457M-V1-K
+    engineType = 457M
+}
+
+@PART[RFUpgrade_engineConfigSource_457M-V1-K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[457M-V1-K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_457M-V1-K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_457M-V1-K]/MODULE[ModuleEngineConfigs]/CONFIG[457M-V1-K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_457M-V1-K]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_457M-V2
@@ -4416,6 +4546,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The 457M Engine now supports the 457M-V2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_457M-V2
+    engineType = 457M
+}
+
+@PART[RFUpgrade_engineConfigSource_457M-V2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[457M-V2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_457M-V2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_457M-V2]/MODULE[ModuleEngineConfigs]/CONFIG[457M-V2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_457M-V2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4432,6 +4588,32 @@ PARTUPGRADE
         description = The N1_BlockV Engine now supports the 4x_NK-39 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_4x_NK-39
+    engineType = N1_BlockV
+}
+
+@PART[RFUpgrade_engineConfigSource_4x_NK-39]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[4x_NK-39] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_4x_NK-39]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_4x_NK-39]/MODULE[ModuleEngineConfigs]/CONFIG[4x_NK-39]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_4x_NK-39]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_8x_NK-43
@@ -4444,6 +4626,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The N1_BlockB Engine now supports the 8x_NK-43 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_8x_NK-43
+    engineType = N1_BlockB
+}
+
+@PART[RFUpgrade_engineConfigSource_8x_NK-43]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[8x_NK-43] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_8x_NK-43]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_8x_NK-43]/MODULE[ModuleEngineConfigs]/CONFIG[8x_NK-43]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_8x_NK-43]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4460,6 +4668,32 @@ PARTUPGRADE
         description = The NAA75_110 Engine now supports the A-6 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nMain production variant for Redstone missile, very similar to USAF XLR43-NA-1 / NAA75-65, except with longer burn time.
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_A-6
+    engineType = NAA75_110
+}
+
+@PART[RFUpgrade_engineConfigSource_A-6]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[A-6] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_A-6]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_A-6]/MODULE[ModuleEngineConfigs]/CONFIG[A-6]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_A-6]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_A-6H
@@ -4472,6 +4706,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The NAA75_110 Engine now supports the A-6H configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nA-6 engine converted to run Hydyne as fuel, used on Jupiter-C sounding rocket and Juno I launch vehicle.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_A-6H
+    engineType = NAA75_110
+}
+
+@PART[RFUpgrade_engineConfigSource_A-6H]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[A-6H] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_A-6H]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_A-6H]/MODULE[ModuleEngineConfigs]/CONFIG[A-6H]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_A-6H]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4488,6 +4748,32 @@ PARTUPGRADE
         description = The NAA75_110 Engine now supports the A-7 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nLater production variant for Redstone missile featuring slightly higher performance, also used on Mercury-Redstone with stretched propellant tanks and extra HTP.
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_A-7
+    engineType = NAA75_110
+}
+
+@PART[RFUpgrade_engineConfigSource_A-7]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[A-7] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_A-7]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_A-7]/MODULE[ModuleEngineConfigs]/CONFIG[A-7]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_A-7]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_A-9
@@ -4500,6 +4786,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The A-4 Engine now supports the A-9 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nDerivate of the A-4/V-2 engine for use with the A-9 upper stage / spaceplane. Fuel mixture is speculative.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_A-9
+    engineType = A-4
+}
+
+@PART[RFUpgrade_engineConfigSource_A-9]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[A-9] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_A-9]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_A-9]/MODULE[ModuleEngineConfigs]/CONFIG[A-9]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_A-9]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4516,6 +4828,32 @@ PARTUPGRADE
         description = The HERMES Engine now supports the AEPS configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_AEPS
+    engineType = HERMES
+}
+
+@PART[RFUpgrade_engineConfigSource_AEPS]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AEPS] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AEPS]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AEPS]/MODULE[ModuleEngineConfigs]/CONFIG[AEPS]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AEPS]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_AJ10-101A
@@ -4528,6 +4866,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The AJ10_Early Engine now supports the AJ10-101A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Able II on Thor and Atlas.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-101A
+    engineType = AJ10_Early
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-101A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-101A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-101A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-101A]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-101A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-101A]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4544,6 +4908,32 @@ PARTUPGRADE
         description = The AJ10_Early Engine now supports the AJ10-118 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Delta A
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-118
+    engineType = AJ10_Early
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-118]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-118] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-118]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-118]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-118]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_AJ10-118D
@@ -4556,6 +4946,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The AJ10_Early Engine now supports the AJ10-118D configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Delta B-D
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-118D
+    engineType = AJ10_Early
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-118D]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-118D] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-118D]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-118D]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118D]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-118D]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4572,6 +4988,32 @@ PARTUPGRADE
         description = The AJ10_Mid Engine now supports the AJ10-118E configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Delta E-N
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-118E
+    engineType = AJ10_Mid
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-118E]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-118E] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-118E]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-118E]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118E]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-118E]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_AJ10-118K
@@ -4584,6 +5026,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The AJ10_Adv Engine now supports the AJ10-118K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-118K
+    engineType = AJ10_Adv
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-118K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-118K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-118K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-118K]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-118K]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4600,6 +5068,32 @@ PARTUPGRADE
         description = The AJ10_Adv Engine now supports the AJ10-133-LH configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-133-LH
+    engineType = AJ10_Adv
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-133-LH]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-133-LH] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-133-LH]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-133-LH]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-133-LH]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-133-LH]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_AJ10-142
@@ -4612,6 +5106,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The AJ10_Early Engine now supports the AJ10-142 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Thor-Delta
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-142
+    engineType = AJ10_Early
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-142]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-142] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-142]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-142]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-142]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-142]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4628,6 +5148,32 @@ PARTUPGRADE
         description = The AJ10_Transtar Engine now supports the AJ10-153 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-153
+    engineType = AJ10_Transtar
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-153]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-153] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-153]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-153]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-153]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-153]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_AJ10-154
@@ -4640,6 +5186,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The AJ10_Transtar Engine now supports the AJ10-154 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-154
+    engineType = AJ10_Transtar
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-154]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-154] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-154]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-154]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-154]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-154]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4656,6 +5228,32 @@ PARTUPGRADE
         description = The AJ10_Transtar Engine now supports the AJ10-156 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-156
+    engineType = AJ10_Transtar
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-156]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-156] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-156]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-156]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-156]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-156]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_AJ10-27
@@ -4668,6 +5266,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Aerobee Engine now supports the AJ10-27 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-27
+    engineType = Aerobee
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-27]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-27] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-27]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-27]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-27]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-27]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4684,6 +5308,32 @@ PARTUPGRADE
         description = The AJ10_Early Engine now supports the AJ10-42 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Able I
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-42
+    engineType = AJ10_Early
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-42]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-42] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-42]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-42]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-42]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-42]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_AJ26-62
@@ -4696,6 +5346,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The NK33 Engine now supports the AJ26-62 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ26-62
+    engineType = NK33
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ26-62]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ26-62] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ26-62]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ26-62]/MODULE[ModuleEngineConfigs]/CONFIG[AJ26-62]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ26-62]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4712,6 +5388,32 @@ PARTUPGRADE
         description = The AJ260SL Engine now supports the AJ260-SL3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ260-SL3
+    engineType = AJ260SL
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ260-SL3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ260-SL3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ260-SL3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ260-SL3]/MODULE[ModuleEngineConfigs]/CONFIG[AJ260-SL3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ260-SL3]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Aeon1-V
@@ -4724,6 +5426,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Aeon1 Engine now supports the Aeon1-V configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Aeon1-V
+    engineType = Aeon1
+}
+
+@PART[RFUpgrade_engineConfigSource_Aeon1-V]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Aeon1-V] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Aeon1-V]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Aeon1-V]/MODULE[ModuleEngineConfigs]/CONFIG[Aeon1-V]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Aeon1-V]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4740,6 +5468,32 @@ PARTUPGRADE
         description = The RCS Engine now supports the Aerozine50+NTO configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Aerozine50+NTO
+    engineType = RCS
+}
+
+@PART[RFUpgrade_engineConfigSource_Aerozine50+NTO]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Aerozine50+NTO] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Aerozine50+NTO]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Aerozine50+NTO]/MODULE[ModuleEngineConfigs]/CONFIG[Aerozine50+NTO]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Aerozine50+NTO]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Aestus-II
@@ -4752,6 +5506,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Aestus Engine now supports the Aestus-II configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Aestus-II
+    engineType = Aestus
+}
+
+@PART[RFUpgrade_engineConfigSource_Aestus-II]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Aestus-II] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Aestus-II]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Aestus-II]/MODULE[ModuleEngineConfigs]/CONFIG[Aestus-II]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Aestus-II]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4768,6 +5548,32 @@ PARTUPGRADE
         description = The Aestus Engine now supports the AestusMod configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_AestusMod
+    engineType = Aestus
+}
+
+@PART[RFUpgrade_engineConfigSource_AestusMod]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AestusMod] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AestusMod]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AestusMod]/MODULE[ModuleEngineConfigs]/CONFIG[AestusMod]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AestusMod]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Agena-2000
@@ -4780,6 +5586,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Agena Engine now supports the Agena-2000 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Agena-2000
+    engineType = Agena
+}
+
+@PART[RFUpgrade_engineConfigSource_Agena-2000]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Agena-2000] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Agena-2000]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Agena-2000]/MODULE[ModuleEngineConfigs]/CONFIG[Agena-2000]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Agena-2000]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4796,6 +5628,32 @@ PARTUPGRADE
         description = The KVD1 Engine now supports the CE-7.5 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_CE-7.5
+    engineType = KVD1
+}
+
+@PART[RFUpgrade_engineConfigSource_CE-7.5]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[CE-7.5] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_CE-7.5]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_CE-7.5]/MODULE[ModuleEngineConfigs]/CONFIG[CE-7.5]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_CE-7.5]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_CECE-Base
@@ -4808,6 +5666,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RL10 Engine now supports the CECE-Base configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_CECE-Base
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_CECE-Base]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[CECE-Base] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_CECE-Base]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_CECE-Base]/MODULE[ModuleEngineConfigs]/CONFIG[CECE-Base]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_CECE-Base]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4824,6 +5708,32 @@ PARTUPGRADE
         description = The RL10 Engine now supports the CECE-High configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_CECE-High
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_CECE-High]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[CECE-High] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_CECE-High]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_CECE-High]/MODULE[ModuleEngineConfigs]/CONFIG[CECE-High]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_CECE-High]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_CECE-Methane
@@ -4836,6 +5746,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RL10 Engine now supports the CECE-Methane configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_CECE-Methane
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_CECE-Methane]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[CECE-Methane] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_CECE-Methane]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_CECE-Methane]/MODULE[ModuleEngineConfigs]/CONFIG[CECE-Methane]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_CECE-Methane]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4852,6 +5788,32 @@ PARTUPGRADE
         description = The Castor-1-SL Engine now supports the Castor-1-SL configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nSea level optimized variant of the Castor 1 SRM.
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Castor-1-SL
+    engineType = Castor-1-SL
+}
+
+@PART[RFUpgrade_engineConfigSource_Castor-1-SL]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Castor-1-SL] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Castor-1-SL]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Castor-1-SL]/MODULE[ModuleEngineConfigs]/CONFIG[Castor-1-SL]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Castor-1-SL]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Castor-1-Vac
@@ -4864,6 +5826,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Castor-1-Vac Engine now supports the Castor-1-Vac configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nVacuum optimized variant of the Castor 1 SRM.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Castor-1-Vac
+    engineType = Castor-1-Vac
+}
+
+@PART[RFUpgrade_engineConfigSource_Castor-1-Vac]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Castor-1-Vac] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Castor-1-Vac]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Castor-1-Vac]/MODULE[ModuleEngineConfigs]/CONFIG[Castor-1-Vac]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Castor-1-Vac]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4880,6 +5868,32 @@ PARTUPGRADE
         description = The RCS Engine now supports the Cavea-B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Cavea-B
+    engineType = RCS
+}
+
+@PART[RFUpgrade_engineConfigSource_Cavea-B]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Cavea-B] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Cavea-B]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Cavea-B]/MODULE[ModuleEngineConfigs]/CONFIG[Cavea-B]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Cavea-B]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_DS4G-25-hi
@@ -4892,6 +5906,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The DS4G Engine now supports the DS4G-25-hi configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_DS4G-25-hi
+    engineType = DS4G
+}
+
+@PART[RFUpgrade_engineConfigSource_DS4G-25-hi]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[DS4G-25-hi] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_DS4G-25-hi]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_DS4G-25-hi]/MODULE[ModuleEngineConfigs]/CONFIG[DS4G-25-hi]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_DS4G-25-hi]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4908,6 +5948,32 @@ PARTUPGRADE
         description = The DS4G Engine now supports the DS4G-25-mid configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_DS4G-25-mid
+    engineType = DS4G
+}
+
+@PART[RFUpgrade_engineConfigSource_DS4G-25-mid]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[DS4G-25-mid] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_DS4G-25-mid]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_DS4G-25-mid]/MODULE[ModuleEngineConfigs]/CONFIG[DS4G-25-mid]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_DS4G-25-mid]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_DS4G-50-hi
@@ -4920,6 +5986,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The DS4G Engine now supports the DS4G-50-hi configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_DS4G-50-hi
+    engineType = DS4G
+}
+
+@PART[RFUpgrade_engineConfigSource_DS4G-50-hi]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[DS4G-50-hi] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_DS4G-50-hi]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_DS4G-50-hi]/MODULE[ModuleEngineConfigs]/CONFIG[DS4G-50-hi]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_DS4G-50-hi]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4936,6 +6028,32 @@ PARTUPGRADE
         description = The DS4G Engine now supports the DS4G-50-low configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_DS4G-50-low
+    engineType = DS4G
+}
+
+@PART[RFUpgrade_engineConfigSource_DS4G-50-low]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[DS4G-50-low] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_DS4G-50-low]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_DS4G-50-low]/MODULE[ModuleEngineConfigs]/CONFIG[DS4G-50-low]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_DS4G-50-low]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_E-1-Upgrade
@@ -4948,6 +6066,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The E1 Engine now supports the E-1-Upgrade configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_E-1-Upgrade
+    engineType = E1
+}
+
+@PART[RFUpgrade_engineConfigSource_E-1-Upgrade]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[E-1-Upgrade] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_E-1-Upgrade]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_E-1-Upgrade]/MODULE[ModuleEngineConfigs]/CONFIG[E-1-Upgrade]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_E-1-Upgrade]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4964,6 +6108,32 @@ PARTUPGRADE
         description = The E1 Engine now supports the E-1-Upgrade2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_E-1-Upgrade2
+    engineType = E1
+}
+
+@PART[RFUpgrade_engineConfigSource_E-1-Upgrade2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[E-1-Upgrade2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_E-1-Upgrade2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_E-1-Upgrade2]/MODULE[ModuleEngineConfigs]/CONFIG[E-1-Upgrade2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_E-1-Upgrade2]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_E-1A_KS
@@ -4976,6 +6146,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The E1 Engine now supports the E-1A_KS configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_E-1A_KS
+    engineType = E1
+}
+
+@PART[RFUpgrade_engineConfigSource_E-1A_KS]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[E-1A_KS] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_E-1A_KS]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_E-1A_KS]/MODULE[ModuleEngineConfigs]/CONFIG[E-1A_KS]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_E-1A_KS]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -4992,6 +6188,32 @@ PARTUPGRADE
         description = The E2 Engine now supports the Engine-2Vac configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Engine-2Vac
+    engineType = E2
+}
+
+@PART[RFUpgrade_engineConfigSource_Engine-2Vac]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Engine-2Vac] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Engine-2Vac]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Engine-2Vac]/MODULE[ModuleEngineConfigs]/CONFIG[Engine-2Vac]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Engine-2Vac]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_F-1A
@@ -5004,6 +6226,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The F1 Engine now supports the F-1A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_F-1A
+    engineType = F1
+}
+
+@PART[RFUpgrade_engineConfigSource_F-1A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[F-1A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_F-1A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_F-1A]/MODULE[ModuleEngineConfigs]/CONFIG[F-1A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_F-1A]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5020,6 +6268,32 @@ PARTUPGRADE
         description = The RSRM Engine now supports the FWC-SRM configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_FWC-SRM
+    engineType = RSRM
+}
+
+@PART[RFUpgrade_engineConfigSource_FWC-SRM]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[FWC-SRM] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_FWC-SRM]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_FWC-SRM]/MODULE[ModuleEngineConfigs]/CONFIG[FWC-SRM]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_FWC-SRM]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_G-1A
@@ -5032,6 +6306,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The G1 Engine now supports the G-1A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_G-1A
+    engineType = G1
+}
+
+@PART[RFUpgrade_engineConfigSource_G-1A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[G-1A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_G-1A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_G-1A]/MODULE[ModuleEngineConfigs]/CONFIG[G-1A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_G-1A]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5048,6 +6348,32 @@ PARTUPGRADE
         description = The Gamma301 Engine now supports the Gamma-301 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Gamma-301
+    engineType = Gamma301
+}
+
+@PART[RFUpgrade_engineConfigSource_Gamma-301]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Gamma-301] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Gamma-301]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Gamma-301]/MODULE[ModuleEngineConfigs]/CONFIG[Gamma-301]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Gamma-301]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_H-1-188K
@@ -5060,6 +6386,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The H1 Engine now supports the H-1-188K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_H-1-188K
+    engineType = H1
+}
+
+@PART[RFUpgrade_engineConfigSource_H-1-188K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[H-1-188K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_H-1-188K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_H-1-188K]/MODULE[ModuleEngineConfigs]/CONFIG[H-1-188K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_H-1-188K]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5076,6 +6428,32 @@ PARTUPGRADE
         description = The H1 Engine now supports the H-1-200K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_H-1-200K
+    engineType = H1
+}
+
+@PART[RFUpgrade_engineConfigSource_H-1-200K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[H-1-200K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_H-1-200K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_H-1-200K]/MODULE[ModuleEngineConfigs]/CONFIG[H-1-200K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_H-1-200K]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_H-1-205K
@@ -5088,6 +6466,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The H1 Engine now supports the H-1-205K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_H-1-205K
+    engineType = H1
+}
+
+@PART[RFUpgrade_engineConfigSource_H-1-205K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[H-1-205K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_H-1-205K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_H-1-205K]/MODULE[ModuleEngineConfigs]/CONFIG[H-1-205K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_H-1-205K]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5104,6 +6508,32 @@ PARTUPGRADE
         description = The H1 Engine now supports the H-1-250K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_H-1-250K
+    engineType = H1
+}
+
+@PART[RFUpgrade_engineConfigSource_H-1-250K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[H-1-250K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_H-1-250K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_H-1-250K]/MODULE[ModuleEngineConfigs]/CONFIG[H-1-250K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_H-1-250K]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_HG-3-SL
@@ -5116,6 +6546,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The HG3 Engine now supports the HG-3-SL configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_HG-3-SL
+    engineType = HG3
+}
+
+@PART[RFUpgrade_engineConfigSource_HG-3-SL]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HG-3-SL] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HG-3-SL]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HG-3-SL]/MODULE[ModuleEngineConfigs]/CONFIG[HG-3-SL]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HG-3-SL]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5132,6 +6588,32 @@ PARTUPGRADE
         description = The HG3 Engine now supports the HG-3A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_HG-3A
+    engineType = HG3
+}
+
+@PART[RFUpgrade_engineConfigSource_HG-3A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HG-3A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HG-3A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HG-3A]/MODULE[ModuleEngineConfigs]/CONFIG[HG-3A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HG-3A]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_HG-3A-SL
@@ -5144,6 +6626,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The HG3 Engine now supports the HG-3A-SL configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_HG-3A-SL
+    engineType = HG3
+}
+
+@PART[RFUpgrade_engineConfigSource_HG-3A-SL]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HG-3A-SL] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HG-3A-SL]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HG-3A-SL]/MODULE[ModuleEngineConfigs]/CONFIG[HG-3A-SL]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HG-3A-SL]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5160,6 +6668,32 @@ PARTUPGRADE
         description = The HG3 Engine now supports the HG-3B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_HG-3B
+    engineType = HG3
+}
+
+@PART[RFUpgrade_engineConfigSource_HG-3B]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HG-3B] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HG-3B]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HG-3B]/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HG-3B]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_HG-3B-2
@@ -5172,6 +6706,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The HG3 Engine now supports the HG-3B-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_HG-3B-2
+    engineType = HG3
+}
+
+@PART[RFUpgrade_engineConfigSource_HG-3B-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HG-3B-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HG-3B-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HG-3B-2]/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HG-3B-2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5188,6 +6748,32 @@ PARTUPGRADE
         description = The HG3 Engine now supports the HG-3B-SL configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_HG-3B-SL
+    engineType = HG3
+}
+
+@PART[RFUpgrade_engineConfigSource_HG-3B-SL]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HG-3B-SL] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HG-3B-SL]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HG-3B-SL]/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B-SL]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HG-3B-SL]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_HG-3B-SL-2
@@ -5200,6 +6786,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The HG3 Engine now supports the HG-3B-SL-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_HG-3B-SL-2
+    engineType = HG3
+}
+
+@PART[RFUpgrade_engineConfigSource_HG-3B-SL-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HG-3B-SL-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HG-3B-SL-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HG-3B-SL-2]/MODULE[ModuleEngineConfigs]/CONFIG[HG-3B-SL-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HG-3B-SL-2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5216,6 +6828,32 @@ PARTUPGRADE
         description = The HM7 Engine now supports the HM-7B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_HM-7B
+    engineType = HM7
+}
+
+@PART[RFUpgrade_engineConfigSource_HM-7B]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HM-7B] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HM-7B]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HM-7B]/MODULE[ModuleEngineConfigs]/CONFIG[HM-7B]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HM-7B]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_HM-7B+
@@ -5228,6 +6866,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The HM7 Engine now supports the HM-7B+ configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_HM-7B+
+    engineType = HM7
+}
+
+@PART[RFUpgrade_engineConfigSource_HM-7B+]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HM-7B+] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HM-7B+]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HM-7B+]/MODULE[ModuleEngineConfigs]/CONFIG[HM-7B+]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HM-7B+]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5244,6 +6908,32 @@ PARTUPGRADE
         description = The HM7 Engine now supports the HM-7B++ configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_HM-7B++
+    engineType = HM7
+}
+
+@PART[RFUpgrade_engineConfigSource_HM-7B++]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HM-7B++] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HM-7B++]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HM-7B++]/MODULE[ModuleEngineConfigs]/CONFIG[HM-7B++]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HM-7B++]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_HTP
@@ -5256,6 +6946,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RCS Engine now supports the HTP configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_HTP
+    engineType = RCS
+}
+
+@PART[RFUpgrade_engineConfigSource_HTP]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HTP] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HTP]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HTP]/MODULE[ModuleEngineConfigs]/CONFIG[HTP]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HTP]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5272,6 +6988,32 @@ PARTUPGRADE
         description = The R4D11 Engine now supports the HiPAT-445 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_HiPAT-445
+    engineType = R4D11
+}
+
+@PART[RFUpgrade_engineConfigSource_HiPAT-445]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HiPAT-445] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HiPAT-445]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HiPAT-445]/MODULE[ModuleEngineConfigs]/CONFIG[HiPAT-445]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HiPAT-445]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_HiPAT-445-Dual
@@ -5284,6 +7026,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The R4D11 Engine now supports the HiPAT-445-Dual configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_HiPAT-445-Dual
+    engineType = R4D11
+}
+
+@PART[RFUpgrade_engineConfigSource_HiPAT-445-Dual]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[HiPAT-445-Dual] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_HiPAT-445-Dual]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_HiPAT-445-Dual]/MODULE[ModuleEngineConfigs]/CONFIG[HiPAT-445-Dual]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_HiPAT-445-Dual]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5300,6 +7068,32 @@ PARTUPGRADE
         description = The RCS Engine now supports the Hydrazine configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Hydrazine
+    engineType = RCS
+}
+
+@PART[RFUpgrade_engineConfigSource_Hydrazine]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Hydrazine] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Hydrazine]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Hydrazine]/MODULE[ModuleEngineConfigs]/CONFIG[Hydrazine]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Hydrazine]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Isayev-R17
@@ -5312,6 +7106,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The S2_253 Engine now supports the Isayev-R17 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Isayev-R17
+    engineType = S2_253
+}
+
+@PART[RFUpgrade_engineConfigSource_Isayev-R17]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Isayev-R17] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Isayev-R17]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Isayev-R17]/MODULE[ModuleEngineConfigs]/CONFIG[Isayev-R17]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Isayev-R17]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5328,6 +7148,32 @@ PARTUPGRADE
         description = The J2 Engine now supports the J-2-225K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_J-2-225K
+    engineType = J2
+}
+
+@PART[RFUpgrade_engineConfigSource_J-2-225K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[J-2-225K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_J-2-225K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_J-2-225K]/MODULE[ModuleEngineConfigs]/CONFIG[J-2-225K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_J-2-225K]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_J-2-230K
@@ -5340,6 +7186,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The J2 Engine now supports the J-2-230K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_J-2-230K
+    engineType = J2
+}
+
+@PART[RFUpgrade_engineConfigSource_J-2-230K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[J-2-230K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_J-2-230K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_J-2-230K]/MODULE[ModuleEngineConfigs]/CONFIG[J-2-230K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_J-2-230K]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5356,6 +7228,32 @@ PARTUPGRADE
         description = The J2 Engine now supports the J-2S configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_J-2S
+    engineType = J2
+}
+
+@PART[RFUpgrade_engineConfigSource_J-2S]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[J-2S] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_J-2S]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_J-2S]/MODULE[ModuleEngineConfigs]/CONFIG[J-2S]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_J-2S]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_J-2T-250K
@@ -5368,6 +7266,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The J2T Engine now supports the J-2T-250K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_J-2T-250K
+    engineType = J2T
+}
+
+@PART[RFUpgrade_engineConfigSource_J-2T-250K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[J-2T-250K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_J-2T-250K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_J-2T-250K]/MODULE[ModuleEngineConfigs]/CONFIG[J-2T-250K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_J-2T-250K]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5384,6 +7308,32 @@ PARTUPGRADE
         description = The BabySergeant Engine now supports the JPL-532A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_JPL-532A
+    engineType = BabySergeant
+}
+
+@PART[RFUpgrade_engineConfigSource_JPL-532A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[JPL-532A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_JPL-532A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_JPL-532A]/MODULE[ModuleEngineConfigs]/CONFIG[JPL-532A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_JPL-532A]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_KTDU-425A
@@ -5396,6 +7346,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The KTDU425A Engine now supports the KTDU-425A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_KTDU-425A
+    engineType = KTDU425A
+}
+
+@PART[RFUpgrade_engineConfigSource_KTDU-425A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[KTDU-425A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_KTDU-425A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_KTDU-425A]/MODULE[ModuleEngineConfigs]/CONFIG[KTDU-425A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_KTDU-425A]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5412,6 +7388,32 @@ PARTUPGRADE
         description = The KVD1 Engine now supports the KVD-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_KVD-1
+    engineType = KVD1
+}
+
+@PART[RFUpgrade_engineConfigSource_KVD-1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[KVD-1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_KVD-1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_KVD-1]/MODULE[ModuleEngineConfigs]/CONFIG[KVD-1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_KVD-1]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Kestrel-2
@@ -5424,6 +7426,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Kestrel Engine now supports the Kestrel-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Kestrel-2
+    engineType = Kestrel
+}
+
+@PART[RFUpgrade_engineConfigSource_Kestrel-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Kestrel-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Kestrel-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Kestrel-2]/MODULE[ModuleEngineConfigs]/CONFIG[Kestrel-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Kestrel-2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5440,6 +7468,32 @@ PARTUPGRADE
         description = The LE5 Engine now supports the LE-5A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LE-5A
+    engineType = LE5
+}
+
+@PART[RFUpgrade_engineConfigSource_LE-5A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LE-5A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LE-5A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LE-5A]/MODULE[ModuleEngineConfigs]/CONFIG[LE-5A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LE-5A]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LE-5B
@@ -5452,6 +7506,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LE5 Engine now supports the LE-5B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LE-5B
+    engineType = LE5
+}
+
+@PART[RFUpgrade_engineConfigSource_LE-5B]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LE-5B] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LE-5B]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LE-5B]/MODULE[ModuleEngineConfigs]/CONFIG[LE-5B]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LE-5B]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5468,6 +7548,32 @@ PARTUPGRADE
         description = The LE5 Engine now supports the LE-5B-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LE-5B-2
+    engineType = LE5
+}
+
+@PART[RFUpgrade_engineConfigSource_LE-5B-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LE-5B-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LE-5B-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LE-5B-2]/MODULE[ModuleEngineConfigs]/CONFIG[LE-5B-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LE-5B-2]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LE-5B-3
@@ -5480,6 +7586,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LE5 Engine now supports the LE-5B-3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LE-5B-3
+    engineType = LE5
+}
+
+@PART[RFUpgrade_engineConfigSource_LE-5B-3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LE-5B-3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LE-5B-3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LE-5B-3]/MODULE[ModuleEngineConfigs]/CONFIG[LE-5B-3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LE-5B-3]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5496,6 +7628,32 @@ PARTUPGRADE
         description = The LE7 Engine now supports the LE-7A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LE-7A
+    engineType = LE7
+}
+
+@PART[RFUpgrade_engineConfigSource_LE-7A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LE-7A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LE-7A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LE-7A]/MODULE[ModuleEngineConfigs]/CONFIG[LE-7A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LE-7A]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LE-7A-2
@@ -5508,6 +7666,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LE7 Engine now supports the LE-7A-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LE-7A-2
+    engineType = LE7
+}
+
+@PART[RFUpgrade_engineConfigSource_LE-7A-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LE-7A-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LE-7A-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LE-7A-2]/MODULE[ModuleEngineConfigs]/CONFIG[LE-7A-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LE-7A-2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5524,6 +7708,32 @@ PARTUPGRADE
         description = The LEROS-1B Engine now supports the LEROS-1c configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LEROS-1c
+    engineType = LEROS-1B
+}
+
+@PART[RFUpgrade_engineConfigSource_LEROS-1c]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LEROS-1c] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LEROS-1c]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LEROS-1c]/MODULE[ModuleEngineConfigs]/CONFIG[LEROS-1c]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LEROS-1c]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LEROS-2b
@@ -5536,6 +7746,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LEROS-1B Engine now supports the LEROS-2b configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LEROS-2b
+    engineType = LEROS-1B
+}
+
+@PART[RFUpgrade_engineConfigSource_LEROS-2b]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LEROS-2b] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LEROS-2b]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LEROS-2b]/MODULE[ModuleEngineConfigs]/CONFIG[LEROS-2b]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LEROS-2b]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5552,6 +7788,32 @@ PARTUPGRADE
         description = The LMDE Engine now supports the LMDE-J configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LMDE-J
+    engineType = LMDE
+}
+
+@PART[RFUpgrade_engineConfigSource_LMDE-J]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LMDE-J] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LMDE-J]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LMDE-J]/MODULE[ModuleEngineConfigs]/CONFIG[LMDE-J]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LMDE-J]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR101-NA-11
@@ -5564,6 +7826,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR101 Engine now supports the LR101-NA-11 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR101-NA-11
+    engineType = LR101
+}
+
+@PART[RFUpgrade_engineConfigSource_LR101-NA-11]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR101-NA-11] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR101-NA-11]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR101-NA-11]/MODULE[ModuleEngineConfigs]/CONFIG[LR101-NA-11]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR101-NA-11]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5580,6 +7868,32 @@ PARTUPGRADE
         description = The LR101 Engine now supports the LR101-NA-15 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR101-NA-15
+    engineType = LR101
+}
+
+@PART[RFUpgrade_engineConfigSource_LR101-NA-15]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR101-NA-15] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR101-NA-15]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR101-NA-15]/MODULE[ModuleEngineConfigs]/CONFIG[LR101-NA-15]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR101-NA-15]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR105-NA-3
@@ -5592,6 +7906,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR105 Engine now supports the LR105-NA-3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR105-NA-3
+    engineType = LR105
+}
+
+@PART[RFUpgrade_engineConfigSource_LR105-NA-3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR105-NA-3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR105-NA-3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR105-NA-3]/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR105-NA-3]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5608,6 +7948,32 @@ PARTUPGRADE
         description = The LR105 Engine now supports the LR105-NA-5 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR105-NA-5
+    engineType = LR105
+}
+
+@PART[RFUpgrade_engineConfigSource_LR105-NA-5]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR105-NA-5] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR105-NA-5]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR105-NA-5]/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-5]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR105-NA-5]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR105-NA-6
@@ -5620,6 +7986,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR105 Engine now supports the LR105-NA-6 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR105-NA-6
+    engineType = LR105
+}
+
+@PART[RFUpgrade_engineConfigSource_LR105-NA-6]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR105-NA-6] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR105-NA-6]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR105-NA-6]/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-6]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR105-NA-6]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5636,6 +8028,32 @@ PARTUPGRADE
         description = The LR105 Engine now supports the LR105-NA-7.1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR105-NA-7.1
+    engineType = LR105
+}
+
+@PART[RFUpgrade_engineConfigSource_LR105-NA-7.1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR105-NA-7.1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR105-NA-7.1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR105-NA-7.1]/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-7.1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR105-NA-7.1]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR105-NA-7.2
@@ -5648,6 +8066,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR105 Engine now supports the LR105-NA-7.2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR105-NA-7.2
+    engineType = LR105
+}
+
+@PART[RFUpgrade_engineConfigSource_LR105-NA-7.2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR105-NA-7.2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR105-NA-7.2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR105-NA-7.2]/MODULE[ModuleEngineConfigs]/CONFIG[LR105-NA-7.2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR105-NA-7.2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5664,6 +8108,32 @@ PARTUPGRADE
         description = The LR129 Engine now supports the LR129-P-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR129-P-1
+    engineType = LR129
+}
+
+@PART[RFUpgrade_engineConfigSource_LR129-P-1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR129-P-1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR129-P-1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR129-P-1]/MODULE[ModuleEngineConfigs]/CONFIG[LR129-P-1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR129-P-1]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR129-P-2
@@ -5676,6 +8146,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR129 Engine now supports the LR129-P-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR129-P-2
+    engineType = LR129
+}
+
+@PART[RFUpgrade_engineConfigSource_LR129-P-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR129-P-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR129-P-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR129-P-2]/MODULE[ModuleEngineConfigs]/CONFIG[LR129-P-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR129-P-2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5692,6 +8188,32 @@ PARTUPGRADE
         description = The LR129 Engine now supports the LR129-P-3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR129-P-3
+    engineType = LR129
+}
+
+@PART[RFUpgrade_engineConfigSource_LR129-P-3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR129-P-3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR129-P-3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR129-P-3]/MODULE[ModuleEngineConfigs]/CONFIG[LR129-P-3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR129-P-3]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR43-NA-3
@@ -5704,6 +8226,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR89 Engine now supports the LR43-NA-3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nFirst version of the LR89 booster for Atlas.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR43-NA-3
+    engineType = LR89
+}
+
+@PART[RFUpgrade_engineConfigSource_LR43-NA-3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR43-NA-3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR43-NA-3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR43-NA-3]/MODULE[ModuleEngineConfigs]/CONFIG[LR43-NA-3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR43-NA-3]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5720,6 +8268,32 @@ PARTUPGRADE
         description = The LR79 Engine now supports the LR79-NA-11 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nMB-3-2 on Thor.
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR79-NA-11
+    engineType = LR79
+}
+
+@PART[RFUpgrade_engineConfigSource_LR79-NA-11]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR79-NA-11] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR79-NA-11]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR79-NA-11]/MODULE[ModuleEngineConfigs]/CONFIG[LR79-NA-11]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR79-NA-11]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR79-NA-13
@@ -5732,6 +8306,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR79 Engine now supports the LR79-NA-13 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nMB-3-3 on Thor.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR79-NA-13
+    engineType = LR79
+}
+
+@PART[RFUpgrade_engineConfigSource_LR79-NA-13]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR79-NA-13] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR79-NA-13]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR79-NA-13]/MODULE[ModuleEngineConfigs]/CONFIG[LR79-NA-13]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR79-NA-13]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5748,6 +8348,32 @@ PARTUPGRADE
         description = The LR79 Engine now supports the LR79-NA-9 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nMB-3-1 on Thor.
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR79-NA-9
+    engineType = LR79
+}
+
+@PART[RFUpgrade_engineConfigSource_LR79-NA-9]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR79-NA-9] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR79-NA-9]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR79-NA-9]/MODULE[ModuleEngineConfigs]/CONFIG[LR79-NA-9]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR79-NA-9]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR87-AJ-11
@@ -5760,6 +8386,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR87 Engine now supports the LR87-AJ-11 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR87-AJ-11
+    engineType = LR87
+}
+
+@PART[RFUpgrade_engineConfigSource_LR87-AJ-11]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR87-AJ-11] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR87-AJ-11]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR87-AJ-11]/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-11]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR87-AJ-11]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5776,6 +8428,32 @@ PARTUPGRADE
         description = The LR87 Engine now supports the LR87-AJ-11A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR87-AJ-11A
+    engineType = LR87
+}
+
+@PART[RFUpgrade_engineConfigSource_LR87-AJ-11A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR87-AJ-11A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR87-AJ-11A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR87-AJ-11A]/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-11A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR87-AJ-11A]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR87-AJ-5
@@ -5788,6 +8466,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR87 Engine now supports the LR87-AJ-5 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR87-AJ-5
+    engineType = LR87
+}
+
+@PART[RFUpgrade_engineConfigSource_LR87-AJ-5]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR87-AJ-5] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR87-AJ-5]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR87-AJ-5]/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-5]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR87-AJ-5]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5804,6 +8508,32 @@ PARTUPGRADE
         description = The LR87 Engine now supports the LR87-AJ-5-Kero configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR87-AJ-5-Kero
+    engineType = LR87
+}
+
+@PART[RFUpgrade_engineConfigSource_LR87-AJ-5-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR87-AJ-5-Kero] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR87-AJ-5-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR87-AJ-5-Kero]/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-5-Kero]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR87-AJ-5-Kero]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR87-AJ-7
@@ -5816,6 +8546,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR87 Engine now supports the LR87-AJ-7 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR87-AJ-7
+    engineType = LR87
+}
+
+@PART[RFUpgrade_engineConfigSource_LR87-AJ-7]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR87-AJ-7] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR87-AJ-7]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR87-AJ-7]/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-7]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR87-AJ-7]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5832,6 +8588,32 @@ PARTUPGRADE
         description = The LR87 Engine now supports the LR87-AJ-7-Kero configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR87-AJ-7-Kero
+    engineType = LR87
+}
+
+@PART[RFUpgrade_engineConfigSource_LR87-AJ-7-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR87-AJ-7-Kero] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR87-AJ-7-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR87-AJ-7-Kero]/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-7-Kero]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR87-AJ-7-Kero]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR87-AJ-9
@@ -5844,6 +8626,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR87 Engine now supports the LR87-AJ-9 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR87-AJ-9
+    engineType = LR87
+}
+
+@PART[RFUpgrade_engineConfigSource_LR87-AJ-9]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR87-AJ-9] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR87-AJ-9]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR87-AJ-9]/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-9]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR87-AJ-9]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5860,6 +8668,32 @@ PARTUPGRADE
         description = The LR87 Engine now supports the LR87-AJ-9-Kero configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR87-AJ-9-Kero
+    engineType = LR87
+}
+
+@PART[RFUpgrade_engineConfigSource_LR87-AJ-9-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR87-AJ-9-Kero] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR87-AJ-9-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR87-AJ-9-Kero]/MODULE[ModuleEngineConfigs]/CONFIG[LR87-AJ-9-Kero]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR87-AJ-9-Kero]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR87-LH2-SustainerUpgrade
@@ -5872,6 +8706,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR87LH2 Engine now supports the LR87-LH2-SustainerUpgrade configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR87-LH2-SustainerUpgrade
+    engineType = LR87LH2
+}
+
+@PART[RFUpgrade_engineConfigSource_LR87-LH2-SustainerUpgrade]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR87-LH2-SustainerUpgrade] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR87-LH2-SustainerUpgrade]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR87-LH2-SustainerUpgrade]/MODULE[ModuleEngineConfigs]/CONFIG[LR87-LH2-SustainerUpgrade]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR87-LH2-SustainerUpgrade]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5888,6 +8748,32 @@ PARTUPGRADE
         description = The LR87LH2 Engine now supports the LR87-LH2-Vacuum configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR87-LH2-Vacuum
+    engineType = LR87LH2
+}
+
+@PART[RFUpgrade_engineConfigSource_LR87-LH2-Vacuum]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR87-LH2-Vacuum] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR87-LH2-Vacuum]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR87-LH2-Vacuum]/MODULE[ModuleEngineConfigs]/CONFIG[LR87-LH2-Vacuum]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR87-LH2-Vacuum]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR87-LH2-VacuumUpgrade
@@ -5900,6 +8786,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR87LH2 Engine now supports the LR87-LH2-VacuumUpgrade configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR87-LH2-VacuumUpgrade
+    engineType = LR87LH2
+}
+
+@PART[RFUpgrade_engineConfigSource_LR87-LH2-VacuumUpgrade]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR87-LH2-VacuumUpgrade] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR87-LH2-VacuumUpgrade]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR87-LH2-VacuumUpgrade]/MODULE[ModuleEngineConfigs]/CONFIG[LR87-LH2-VacuumUpgrade]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR87-LH2-VacuumUpgrade]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5916,6 +8828,32 @@ PARTUPGRADE
         description = The LR89 Engine now supports the LR89-NA-3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR89-NA-3
+    engineType = LR89
+}
+
+@PART[RFUpgrade_engineConfigSource_LR89-NA-3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR89-NA-3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR89-NA-3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR89-NA-3]/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR89-NA-3]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR89-NA-5
@@ -5928,6 +8866,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR89 Engine now supports the LR89-NA-5 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR89-NA-5
+    engineType = LR89
+}
+
+@PART[RFUpgrade_engineConfigSource_LR89-NA-5]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR89-NA-5] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR89-NA-5]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR89-NA-5]/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-5]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR89-NA-5]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5944,6 +8908,32 @@ PARTUPGRADE
         description = The LR89 Engine now supports the LR89-NA-6 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR89-NA-6
+    engineType = LR89
+}
+
+@PART[RFUpgrade_engineConfigSource_LR89-NA-6]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR89-NA-6] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR89-NA-6]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR89-NA-6]/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-6]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR89-NA-6]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR89-NA-7.1
@@ -5956,6 +8946,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR89 Engine now supports the LR89-NA-7.1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR89-NA-7.1
+    engineType = LR89
+}
+
+@PART[RFUpgrade_engineConfigSource_LR89-NA-7.1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR89-NA-7.1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR89-NA-7.1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR89-NA-7.1]/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-7.1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR89-NA-7.1]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -5972,6 +8988,32 @@ PARTUPGRADE
         description = The LR89 Engine now supports the LR89-NA-7.2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR89-NA-7.2
+    engineType = LR89
+}
+
+@PART[RFUpgrade_engineConfigSource_LR89-NA-7.2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR89-NA-7.2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR89-NA-7.2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR89-NA-7.2]/MODULE[ModuleEngineConfigs]/CONFIG[LR89-NA-7.2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR89-NA-7.2]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR91-AJ-11
@@ -5984,6 +9026,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR91 Engine now supports the LR91-AJ-11 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR91-AJ-11
+    engineType = LR91
+}
+
+@PART[RFUpgrade_engineConfigSource_LR91-AJ-11]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR91-AJ-11] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR91-AJ-11]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR91-AJ-11]/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-11]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR91-AJ-11]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6000,6 +9068,32 @@ PARTUPGRADE
         description = The LR91 Engine now supports the LR91-AJ-11A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR91-AJ-11A
+    engineType = LR91
+}
+
+@PART[RFUpgrade_engineConfigSource_LR91-AJ-11A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR91-AJ-11A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR91-AJ-11A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR91-AJ-11A]/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-11A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR91-AJ-11A]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR91-AJ-5
@@ -6012,6 +9106,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR91 Engine now supports the LR91-AJ-5 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR91-AJ-5
+    engineType = LR91
+}
+
+@PART[RFUpgrade_engineConfigSource_LR91-AJ-5]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR91-AJ-5] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR91-AJ-5]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR91-AJ-5]/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-5]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR91-AJ-5]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6028,6 +9148,32 @@ PARTUPGRADE
         description = The LR91 Engine now supports the LR91-AJ-5-Kero configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR91-AJ-5-Kero
+    engineType = LR91
+}
+
+@PART[RFUpgrade_engineConfigSource_LR91-AJ-5-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR91-AJ-5-Kero] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR91-AJ-5-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR91-AJ-5-Kero]/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-5-Kero]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR91-AJ-5-Kero]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR91-AJ-7
@@ -6040,6 +9186,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR91 Engine now supports the LR91-AJ-7 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR91-AJ-7
+    engineType = LR91
+}
+
+@PART[RFUpgrade_engineConfigSource_LR91-AJ-7]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR91-AJ-7] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR91-AJ-7]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR91-AJ-7]/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-7]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR91-AJ-7]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6056,6 +9228,32 @@ PARTUPGRADE
         description = The LR91 Engine now supports the LR91-AJ-7-Kero configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR91-AJ-7-Kero
+    engineType = LR91
+}
+
+@PART[RFUpgrade_engineConfigSource_LR91-AJ-7-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR91-AJ-7-Kero] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR91-AJ-7-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR91-AJ-7-Kero]/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-7-Kero]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR91-AJ-7-Kero]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_LR91-AJ-9
@@ -6068,6 +9266,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR91 Engine now supports the LR91-AJ-9 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR91-AJ-9
+    engineType = LR91
+}
+
+@PART[RFUpgrade_engineConfigSource_LR91-AJ-9]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR91-AJ-9] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR91-AJ-9]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR91-AJ-9]/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-9]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR91-AJ-9]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6084,6 +9308,32 @@ PARTUPGRADE
         description = The LR91 Engine now supports the LR91-AJ-9-Kero configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_LR91-AJ-9-Kero
+    engineType = LR91
+}
+
+@PART[RFUpgrade_engineConfigSource_LR91-AJ-9-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[LR91-AJ-9-Kero] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_LR91-AJ-9-Kero]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_LR91-AJ-9-Kero]/MODULE[ModuleEngineConfigs]/CONFIG[LR91-AJ-9-Kero]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_LR91-AJ-9-Kero]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Larch-2
@@ -6096,6 +9346,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Gamma2 Engine now supports the Larch-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Larch-2
+    engineType = Gamma2
+}
+
+@PART[RFUpgrade_engineConfigSource_Larch-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Larch-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Larch-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Larch-2]/MODULE[ModuleEngineConfigs]/CONFIG[Larch-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Larch-2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6112,6 +9388,32 @@ PARTUPGRADE
         description = The Gamma301 Engine now supports the Larch-4 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Larch-4
+    engineType = Gamma301
+}
+
+@PART[RFUpgrade_engineConfigSource_Larch-4]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Larch-4] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Larch-4]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Larch-4]/MODULE[ModuleEngineConfigs]/CONFIG[Larch-4]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Larch-4]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Larch-8
@@ -6124,6 +9426,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Gamma8 Engine now supports the Larch-8 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Larch-8
+    engineType = Gamma8
+}
+
+@PART[RFUpgrade_engineConfigSource_Larch-8]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Larch-8] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Larch-8]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Larch-8]/MODULE[ModuleEngineConfigs]/CONFIG[Larch-8]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Larch-8]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6140,6 +9468,32 @@ PARTUPGRADE
         description = The M1 Engine now supports the M-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_M-1
+    engineType = M1
+}
+
+@PART[RFUpgrade_engineConfigSource_M-1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[M-1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_M-1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_M-1]/MODULE[ModuleEngineConfigs]/CONFIG[M-1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_M-1]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_M-1SL
@@ -6152,6 +9506,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The M1 Engine now supports the M-1SL configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_M-1SL
+    engineType = M1
+}
+
+@PART[RFUpgrade_engineConfigSource_M-1SL]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[M-1SL] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_M-1SL]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_M-1SL]/MODULE[ModuleEngineConfigs]/CONFIG[M-1SL]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_M-1SL]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6168,6 +9548,32 @@ PARTUPGRADE
         description = The M1 Engine now supports the M-1U configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_M-1U
+    engineType = M1
+}
+
+@PART[RFUpgrade_engineConfigSource_M-1U]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[M-1U] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_M-1U]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_M-1U]/MODULE[ModuleEngineConfigs]/CONFIG[M-1U]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_M-1U]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_M-1U-SL
@@ -6180,6 +9586,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The M1 Engine now supports the M-1U-SL configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_M-1U-SL
+    engineType = M1
+}
+
+@PART[RFUpgrade_engineConfigSource_M-1U-SL]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[M-1U-SL] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_M-1U-SL]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_M-1U-SL]/MODULE[ModuleEngineConfigs]/CONFIG[M-1U-SL]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_M-1U-SL]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6196,6 +9628,32 @@ PARTUPGRADE
         description = The RCS Engine now supports the MMH+MON10 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_MMH+MON10
+    engineType = RCS
+}
+
+@PART[RFUpgrade_engineConfigSource_MMH+MON10]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[MMH+MON10] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_MMH+MON10]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_MMH+MON10]/MODULE[ModuleEngineConfigs]/CONFIG[MMH+MON10]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_MMH+MON10]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_MMH+MON3
@@ -6208,6 +9666,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RCS Engine now supports the MMH+MON3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_MMH+MON3
+    engineType = RCS
+}
+
+@PART[RFUpgrade_engineConfigSource_MMH+MON3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[MMH+MON3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_MMH+MON3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_MMH+MON3]/MODULE[ModuleEngineConfigs]/CONFIG[MMH+MON3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_MMH+MON3]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6224,6 +9708,32 @@ PARTUPGRADE
         description = The RCS Engine now supports the MMH+NTO configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_MMH+NTO
+    engineType = RCS
+}
+
+@PART[RFUpgrade_engineConfigSource_MMH+NTO]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[MMH+NTO] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_MMH+NTO]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_MMH+NTO]/MODULE[ModuleEngineConfigs]/CONFIG[MMH+NTO]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_MMH+NTO]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Merlin1B
@@ -6236,6 +9746,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Merlin1 Engine now supports the Merlin1B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1B
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1B]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1B] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1B]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1B]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1B]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1B]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6252,6 +9788,32 @@ PARTUPGRADE
         description = The Merlin1 Engine now supports the Merlin1BVac configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1BVac
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1BVac]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1BVac] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1BVac]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1BVac]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1BVac]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1BVac]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Merlin1C
@@ -6264,6 +9826,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Merlin1 Engine now supports the Merlin1C configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1C
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1C]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1C] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1C]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1C]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1C]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1C]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6280,6 +9868,32 @@ PARTUPGRADE
         description = The Merlin1 Engine now supports the Merlin1CVac configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1CVac
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1CVac]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1CVac] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1CVac]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1CVac]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1CVac]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1CVac]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Merlin1D
@@ -6292,6 +9906,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Merlin1 Engine now supports the Merlin1D configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1D
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1D]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1D] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1D]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1D]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1D]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1D]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6308,6 +9948,32 @@ PARTUPGRADE
         description = The Merlin1 Engine now supports the Merlin1D+ configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1D+
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1D+]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1D+] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1D+]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1D+]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1D+]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1D+]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Merlin1D++
@@ -6320,6 +9986,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Merlin1 Engine now supports the Merlin1D++ configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1D++
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1D++]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1D++] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1D++]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1D++]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1D++]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1D++]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6336,6 +10028,32 @@ PARTUPGRADE
         description = The Merlin1 Engine now supports the Merlin1DVac configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1DVac
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1DVac]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1DVac] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1DVac]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1DVac]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1DVac]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1DVac]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Merlin1DVac+
@@ -6348,6 +10066,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Merlin1 Engine now supports the Merlin1DVac+ configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1DVac+
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1DVac+]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1DVac+] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1DVac+]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1DVac+]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1DVac+]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1DVac+]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6364,6 +10108,32 @@ PARTUPGRADE
         description = The Agena Engine now supports the Model8096-39 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Model8096-39
+    engineType = Agena
+}
+
+@PART[RFUpgrade_engineConfigSource_Model8096-39]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Model8096-39] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Model8096-39]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Model8096-39]/MODULE[ModuleEngineConfigs]/CONFIG[Model8096-39]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Model8096-39]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Model8096A
@@ -6376,6 +10146,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Agena Engine now supports the Model8096A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Model8096A
+    engineType = Agena
+}
+
+@PART[RFUpgrade_engineConfigSource_Model8096A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Model8096A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Model8096A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Model8096A]/MODULE[ModuleEngineConfigs]/CONFIG[Model8096A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Model8096A]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6392,6 +10188,32 @@ PARTUPGRADE
         description = The Agena Engine now supports the Model8096C configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Model8096C
+    engineType = Agena
+}
+
+@PART[RFUpgrade_engineConfigSource_Model8096C]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Model8096C] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Model8096C]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Model8096C]/MODULE[ModuleEngineConfigs]/CONFIG[Model8096C]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Model8096C]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Model8096L
@@ -6404,6 +10226,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Agena Engine now supports the Model8096L configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Model8096L
+    engineType = Agena
+}
+
+@PART[RFUpgrade_engineConfigSource_Model8096L]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Model8096L] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Model8096L]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Model8096L]/MODULE[ModuleEngineConfigs]/CONFIG[Model8096L]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Model8096L]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6420,6 +10268,32 @@ PARTUPGRADE
         description = The NK9V Engine now supports the NK-19 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_NK-19
+    engineType = NK9V
+}
+
+@PART[RFUpgrade_engineConfigSource_NK-19]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[NK-19] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_NK-19]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_NK-19]/MODULE[ModuleEngineConfigs]/CONFIG[NK-19]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_NK-19]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_NK-21
@@ -6432,6 +10306,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The NK9V Engine now supports the NK-21 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_NK-21
+    engineType = NK9V
+}
+
+@PART[RFUpgrade_engineConfigSource_NK-21]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[NK-21] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_NK-21]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_NK-21]/MODULE[ModuleEngineConfigs]/CONFIG[NK-21]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_NK-21]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6448,6 +10348,32 @@ PARTUPGRADE
         description = The NK9V Engine now supports the NK-31 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_NK-31
+    engineType = NK9V
+}
+
+@PART[RFUpgrade_engineConfigSource_NK-31]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[NK-31] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_NK-31]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_NK-31]/MODULE[ModuleEngineConfigs]/CONFIG[NK-31]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_NK-31]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_NK-33
@@ -6460,6 +10386,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The NK33 Engine now supports the NK-33 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_NK-33
+    engineType = NK33
+}
+
+@PART[RFUpgrade_engineConfigSource_NK-33]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[NK-33] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_NK-33]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_NK-33]/MODULE[ModuleEngineConfigs]/CONFIG[NK-33]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_NK-33]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6476,6 +10428,32 @@ PARTUPGRADE
         description = The NK9V Engine now supports the NK-39 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_NK-39
+    engineType = NK9V
+}
+
+@PART[RFUpgrade_engineConfigSource_NK-39]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[NK-39] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_NK-39]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_NK-39]/MODULE[ModuleEngineConfigs]/CONFIG[NK-39]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_NK-39]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_NK-43
@@ -6488,6 +10466,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The NK43 Engine now supports the NK-43 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_NK-43
+    engineType = NK43
+}
+
+@PART[RFUpgrade_engineConfigSource_NK-43]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[NK-43] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_NK-43]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_NK-43]/MODULE[ModuleEngineConfigs]/CONFIG[NK-43]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_NK-43]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6504,6 +10508,32 @@ PARTUPGRADE
         description = The RCS Engine now supports the NitrousOxide configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_NitrousOxide
+    engineType = RCS
+}
+
+@PART[RFUpgrade_engineConfigSource_NitrousOxide]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[NitrousOxide] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_NitrousOxide]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_NitrousOxide]/MODULE[ModuleEngineConfigs]/CONFIG[NitrousOxide]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_NitrousOxide]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_NuPIT-7000
@@ -6516,6 +10546,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The NUPIT Engine now supports the NuPIT-7000 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_NuPIT-7000
+    engineType = NUPIT
+}
+
+@PART[RFUpgrade_engineConfigSource_NuPIT-7000]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[NuPIT-7000] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_NuPIT-7000]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_NuPIT-7000]/MODULE[ModuleEngineConfigs]/CONFIG[NuPIT-7000]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_NuPIT-7000]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6532,6 +10588,32 @@ PARTUPGRADE
         description = The PITV Engine now supports the PITV-Ammonia-1200 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_PITV-Ammonia-1200
+    engineType = PITV
+}
+
+@PART[RFUpgrade_engineConfigSource_PITV-Ammonia-1200]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[PITV-Ammonia-1200] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_PITV-Ammonia-1200]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_PITV-Ammonia-1200]/MODULE[ModuleEngineConfigs]/CONFIG[PITV-Ammonia-1200]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_PITV-Ammonia-1200]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_PITV-Hydrazine-1200
@@ -6544,6 +10626,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The PITV Engine now supports the PITV-Hydrazine-1200 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_PITV-Hydrazine-1200
+    engineType = PITV
+}
+
+@PART[RFUpgrade_engineConfigSource_PITV-Hydrazine-1200]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[PITV-Hydrazine-1200] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_PITV-Hydrazine-1200]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_PITV-Hydrazine-1200]/MODULE[ModuleEngineConfigs]/CONFIG[PITV-Hydrazine-1200]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_PITV-Hydrazine-1200]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6560,6 +10668,32 @@ PARTUPGRADE
         description = The PITV Engine now supports the PITV-Hydrazine-40 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_PITV-Hydrazine-40
+    engineType = PITV
+}
+
+@PART[RFUpgrade_engineConfigSource_PITV-Hydrazine-40]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[PITV-Hydrazine-40] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_PITV-Hydrazine-40]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_PITV-Hydrazine-40]/MODULE[ModuleEngineConfigs]/CONFIG[PITV-Hydrazine-40]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_PITV-Hydrazine-40]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_R-42DM
@@ -6572,6 +10706,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The R42 Engine now supports the R-42DM configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_R-42DM
+    engineType = R42
+}
+
+@PART[RFUpgrade_engineConfigSource_R-42DM]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[R-42DM] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_R-42DM]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_R-42DM]/MODULE[ModuleEngineConfigs]/CONFIG[R-42DM]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_R-42DM]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6588,6 +10748,32 @@ PARTUPGRADE
         description = The R42 Engine now supports the R-42DM-NTO configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_R-42DM-NTO
+    engineType = R42
+}
+
+@PART[RFUpgrade_engineConfigSource_R-42DM-NTO]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[R-42DM-NTO] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_R-42DM-NTO]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_R-42DM-NTO]/MODULE[ModuleEngineConfigs]/CONFIG[R-42DM-NTO]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_R-42DM-NTO]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-0109
@@ -6600,6 +10786,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD0105 Engine now supports the RD-0109 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0109
+    engineType = RD0105
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0109]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0109] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0109]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0109]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0109]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0109]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6616,6 +10828,32 @@ PARTUPGRADE
         description = The RD0110 Engine now supports the RD-0110 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0110
+    engineType = RD0110
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0110]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0110] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0110]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0110]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0110]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0110]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-0126A
@@ -6628,6 +10866,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD0131 Engine now supports the RD-0126A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0126A
+    engineType = RD0131
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0126A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0126A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0126A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0126A]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0126A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0126A]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6644,6 +10908,32 @@ PARTUPGRADE
         description = The RD0162 Engine now supports the RD-0162A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0162A
+    engineType = RD0162
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0162A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0162A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0162A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0162A]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0162A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0162A]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-0203U
@@ -6656,6 +10946,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD0203 Engine now supports the RD-0203U configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0203U
+    engineType = RD0203
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0203U]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0203U] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0203U]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0203U]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0203U]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0203U]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6672,6 +10988,32 @@ PARTUPGRADE
         description = The RD0210 Engine now supports the RD-0210 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0210
+    engineType = RD0210
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0210]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0210] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0210]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0210]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0210]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0210]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-0210-Mk2
@@ -6684,6 +11026,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD0210 Engine now supports the RD-0210-Mk2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0210-Mk2
+    engineType = RD0210
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0210-Mk2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0210-Mk2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0210-Mk2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0210-Mk2]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0210-Mk2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0210-Mk2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6700,6 +11068,32 @@ PARTUPGRADE
         description = The RD0210 Engine now supports the RD-0210-Mk3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0210-Mk3
+    engineType = RD0210
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0210-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0210-Mk3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0210-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0210-Mk3]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0210-Mk3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0210-Mk3]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-0212
@@ -6712,6 +11106,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD0212 Engine now supports the RD-0212 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0212
+    engineType = RD0212
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0212]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0212] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0212]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0212]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0212]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0212]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6728,6 +11148,32 @@ PARTUPGRADE
         description = The RD0212 Engine now supports the RD-0212-Mk2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0212-Mk2
+    engineType = RD0212
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0212-Mk2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0212-Mk2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0212-Mk2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0212-Mk2]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0212-Mk2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0212-Mk2]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-0212-Mk3
@@ -6740,6 +11186,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD0212 Engine now supports the RD-0212-Mk3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0212-Mk3
+    engineType = RD0212
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0212-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0212-Mk3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0212-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0212-Mk3]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0212-Mk3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0212-Mk3]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6756,6 +11228,32 @@ PARTUPGRADE
         description = The RD0213 Engine now supports the RD-0213 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0213
+    engineType = RD0213
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0213]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0213] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0213]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0213]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0213]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0213]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-0213-Mk2
@@ -6768,6 +11266,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD0213 Engine now supports the RD-0213-Mk2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0213-Mk2
+    engineType = RD0213
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0213-Mk2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0213-Mk2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0213-Mk2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0213-Mk2]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0213-Mk2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0213-Mk2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6784,6 +11308,32 @@ PARTUPGRADE
         description = The RD0213 Engine now supports the RD-0213-Mk3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0213-Mk3
+    engineType = RD0213
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0213-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0213-Mk3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0213-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0213-Mk3]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0213-Mk3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0213-Mk3]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-0214
@@ -6796,6 +11346,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD0214 Engine now supports the RD-0214 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0214
+    engineType = RD0214
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0214]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0214] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0214]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0214]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0214]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0214]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6812,6 +11388,32 @@ PARTUPGRADE
         description = The RD0216 Engine now supports the RD-0235 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0235
+    engineType = RD0216
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0235]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0235] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0235]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0235]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0235]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0235]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-0255
@@ -6824,6 +11426,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD0228 Engine now supports the RD-0255 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0255
+    engineType = RD0228
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0255]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0255] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0255]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0255]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0255]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0255]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6840,6 +11468,32 @@ PARTUPGRADE
         description = The RD0229 Engine now supports the RD-0256 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0256
+    engineType = RD0229
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0256]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0256] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0256]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0256]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0256]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0256]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-0257
@@ -6852,6 +11506,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD0230 Engine now supports the RD-0257 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-0257
+    engineType = RD0230
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-0257]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-0257] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-0257]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-0257]/MODULE[ModuleEngineConfigs]/CONFIG[RD-0257]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-0257]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6868,6 +11548,32 @@ PARTUPGRADE
         description = The RD100 Engine now supports the RD-101 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-101
+    engineType = RD100
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-101]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-101] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-101]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-101]/MODULE[ModuleEngineConfigs]/CONFIG[RD-101]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-101]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-102
@@ -6880,6 +11586,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD100 Engine now supports the RD-102 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-102
+    engineType = RD100
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-102]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-102] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-102]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-102]/MODULE[ModuleEngineConfigs]/CONFIG[RD-102]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-102]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6896,6 +11628,32 @@ PARTUPGRADE
         description = The RD100 Engine now supports the RD-103 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-103
+    engineType = RD100
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-103]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-103] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-103]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-103]/MODULE[ModuleEngineConfigs]/CONFIG[RD-103]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-103]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-103M
@@ -6908,6 +11666,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD100 Engine now supports the RD-103M configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-103M
+    engineType = RD100
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-103M]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-103M] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-103M]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-103M]/MODULE[ModuleEngineConfigs]/CONFIG[RD-103M]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-103M]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6924,6 +11708,32 @@ PARTUPGRADE
         description = The RD107-117 Engine now supports the RD-107-11D511 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Soyuz-U 11A511U (also known as RD-117)
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-107-11D511
+    engineType = RD107-117
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-107-11D511]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-107-11D511] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-107-11D511]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-107-11D511]/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-11D511]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-107-11D511]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-107-11D511P
@@ -6936,6 +11746,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD107-117 Engine now supports the RD-107-11D511P configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Soyuz-U2 11A511U2 (also known as RD-117)
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-107-11D511P
+    engineType = RD107-117
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-107-11D511P]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-107-11D511P] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-107-11D511P]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-107-11D511P]/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-11D511P]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-107-11D511P]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6952,6 +11788,32 @@ PARTUPGRADE
         description = The RD107-117 Engine now supports the RD-107-8D728 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Molniya-M 8K78M and Soyuz 11A511
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-107-8D728
+    engineType = RD107-117
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-107-8D728]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-107-8D728] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-107-8D728]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-107-8D728]/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D728]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-107-8D728]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-107-8D74-1958
@@ -6964,6 +11826,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD107-117 Engine now supports the RD-107-8D74-1958 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Luna 8K72
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-107-8D74-1958
+    engineType = RD107-117
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-107-8D74-1958]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-107-8D74-1958] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-107-8D74-1958]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-107-8D74-1958]/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74-1958]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-107-8D74-1958]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -6980,6 +11868,32 @@ PARTUPGRADE
         description = The RD107-117 Engine now supports the RD-107-8D74-1959 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Vostok 8K72K
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-107-8D74-1959
+    engineType = RD107-117
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-107-8D74-1959]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-107-8D74-1959] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-107-8D74-1959]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-107-8D74-1959]/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74-1959]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-107-8D74-1959]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-107-8D74K
@@ -6992,6 +11906,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD107-117 Engine now supports the RD-107-8D74K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Molniya 8K78 and Voskhod11A57-1
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-107-8D74K
+    engineType = RD107-117
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-107-8D74K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-107-8D74K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-107-8D74K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-107-8D74K]/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-107-8D74K]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7008,6 +11948,32 @@ PARTUPGRADE
         description = The RD107-117 Engine now supports the RD-107-8D74PS configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Sputnik 8K71PS
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-107-8D74PS
+    engineType = RD107-117
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-107-8D74PS]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-107-8D74PS] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-107-8D74PS]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-107-8D74PS]/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D74PS]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-107-8D74PS]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-107-8D76
@@ -7020,6 +11986,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD107-117 Engine now supports the RD-107-8D76 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Sputnik 8A91
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-107-8D76
+    engineType = RD107-117
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-107-8D76]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-107-8D76] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-107-8D76]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-107-8D76]/MODULE[ModuleEngineConfigs]/CONFIG[RD-107-8D76]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-107-8D76]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7036,6 +12028,32 @@ PARTUPGRADE
         description = The RD107-117 Engine now supports the RD-107A-14D22 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Soyuz-FG
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-107A-14D22
+    engineType = RD107-117
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-107A-14D22]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-107A-14D22] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-107A-14D22]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-107A-14D22]/MODULE[ModuleEngineConfigs]/CONFIG[RD-107A-14D22]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-107A-14D22]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-108-11D512
@@ -7048,6 +12066,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD108-118 Engine now supports the RD-108-11D512 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Soyuz-U 11A511U (also known as RD-118)
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-108-11D512
+    engineType = RD108-118
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-108-11D512]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-108-11D512] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-108-11D512]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-108-11D512]/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-11D512]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-108-11D512]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7064,6 +12108,32 @@ PARTUPGRADE
         description = The RD108-118 Engine now supports the RD-108-11D512P configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Soyuz-U2 11A511U2 (also known as RD-118)
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-108-11D512P
+    engineType = RD108-118
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-108-11D512P]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-108-11D512P] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-108-11D512P]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-108-11D512P]/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-11D512P]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-108-11D512P]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-108-8D727
@@ -7076,6 +12146,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD108-118 Engine now supports the RD-108-8D727 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Molniya-M 8K78M and Soyuz 11A511
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-108-8D727
+    engineType = RD108-118
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-108-8D727]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-108-8D727] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-108-8D727]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-108-8D727]/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D727]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-108-8D727]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7092,6 +12188,32 @@ PARTUPGRADE
         description = The RD108-118 Engine now supports the RD-108-8D75-1958 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Luna 8K72
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-108-8D75-1958
+    engineType = RD108-118
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-108-8D75-1958]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-108-8D75-1958] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-108-8D75-1958]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-108-8D75-1958]/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75-1958]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-108-8D75-1958]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-108-8D75-1959
@@ -7104,6 +12226,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD108-118 Engine now supports the RD-108-8D75-1959 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Vostok 8K72K
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-108-8D75-1959
+    engineType = RD108-118
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-108-8D75-1959]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-108-8D75-1959] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-108-8D75-1959]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-108-8D75-1959]/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75-1959]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-108-8D75-1959]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7120,6 +12268,32 @@ PARTUPGRADE
         description = The RD108-118 Engine now supports the RD-108-8D75K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Molniya 8K78 and Voskhod11A57-1
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-108-8D75K
+    engineType = RD108-118
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-108-8D75K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-108-8D75K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-108-8D75K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-108-8D75K]/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-108-8D75K]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-108-8D75PS
@@ -7132,6 +12306,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD108-118 Engine now supports the RD-108-8D75PS configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Sputnik 8K71PS
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-108-8D75PS
+    engineType = RD108-118
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-108-8D75PS]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-108-8D75PS] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-108-8D75PS]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-108-8D75PS]/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D75PS]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-108-8D75PS]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7148,6 +12348,32 @@ PARTUPGRADE
         description = The RD108-118 Engine now supports the RD-108-8D77 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Sputnik 8A91
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-108-8D77
+    engineType = RD108-118
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-108-8D77]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-108-8D77] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-108-8D77]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-108-8D77]/MODULE[ModuleEngineConfigs]/CONFIG[RD-108-8D77]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-108-8D77]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-108A-14D21
@@ -7160,6 +12386,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD108-118 Engine now supports the RD-108A-14D21 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUsed on Soyuz-FG
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-108A-14D21
+    engineType = RD108-118
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-108A-14D21]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-108A-14D21] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-108A-14D21]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-108A-14D21]/MODULE[ModuleEngineConfigs]/CONFIG[RD-108A-14D21]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-108A-14D21]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7176,6 +12428,32 @@ PARTUPGRADE
         description = The RD109 Engine now supports the RD-119-8D710 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-119-8D710
+    engineType = RD109
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-119-8D710]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-119-8D710] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-119-8D710]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-119-8D710]/MODULE[ModuleEngineConfigs]/CONFIG[RD-119-8D710]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-119-8D710]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-120F
@@ -7188,6 +12466,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD120 Engine now supports the RD-120F configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-120F
+    engineType = RD120
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-120F]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-120F] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-120F]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-120F]/MODULE[ModuleEngineConfigs]/CONFIG[RD-120F]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-120F]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7204,6 +12508,32 @@ PARTUPGRADE
         description = The RD120 Engine now supports the RD-120K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-120K
+    engineType = RD120
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-120K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-120K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-120K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-120K]/MODULE[ModuleEngineConfigs]/CONFIG[RD-120K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-120K]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-171
@@ -7216,6 +12546,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD170 Engine now supports the RD-171 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-171
+    engineType = RD170
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-171]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-171] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-171]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-171]/MODULE[ModuleEngineConfigs]/CONFIG[RD-171]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-171]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7232,6 +12588,32 @@ PARTUPGRADE
         description = The RD170 Engine now supports the RD-171M configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-171M
+    engineType = RD170
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-171M]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-171M] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-171M]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-171M]/MODULE[ModuleEngineConfigs]/CONFIG[RD-171M]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-171M]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-172-173
@@ -7244,6 +12626,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD170 Engine now supports the RD-172-173 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-172-173
+    engineType = RD170
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-172-173]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-172-173] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-172-173]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-172-173]/MODULE[ModuleEngineConfigs]/CONFIG[RD-172-173]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-172-173]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7260,6 +12668,32 @@ PARTUPGRADE
         description = The RD191 Engine now supports the RD-181 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-181
+    engineType = RD191
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-181]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-181] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-181]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-181]/MODULE[ModuleEngineConfigs]/CONFIG[RD-181]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-181]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-191
@@ -7272,6 +12706,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD191 Engine now supports the RD-191 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-191
+    engineType = RD191
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-191]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-191] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-191]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-191]/MODULE[ModuleEngineConfigs]/CONFIG[RD-191]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-191]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7288,6 +12748,32 @@ PARTUPGRADE
         description = The RD191 Engine now supports the RD-193 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-193
+    engineType = RD191
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-193]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-193] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-193]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-193]/MODULE[ModuleEngineConfigs]/CONFIG[RD-193]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-193]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-212-8D41
@@ -7300,6 +12786,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD211 Engine now supports the RD-212-8D41 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-212-8D41
+    engineType = RD211
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-212-8D41]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-212-8D41] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-212-8D41]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-212-8D41]/MODULE[ModuleEngineConfigs]/CONFIG[RD-212-8D41]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-212-8D41]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7316,6 +12828,32 @@ PARTUPGRADE
         description = The RD211 Engine now supports the RD-213-8D13 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-213-8D13
+    engineType = RD211
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-213-8D13]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-213-8D13] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-213-8D13]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-213-8D13]/MODULE[ModuleEngineConfigs]/CONFIG[RD-213-8D13]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-213-8D13]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-214-8D59
@@ -7328,6 +12866,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD211 Engine now supports the RD-214-8D59 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-214-8D59
+    engineType = RD211
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-214-8D59]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-214-8D59] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-214-8D59]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-214-8D59]/MODULE[ModuleEngineConfigs]/CONFIG[RD-214-8D59]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-214-8D59]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7344,6 +12908,32 @@ PARTUPGRADE
         description = The RD211 Engine now supports the RD-214U-8D59U configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-214U-8D59U
+    engineType = RD211
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-214U-8D59U]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-214U-8D59U] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-214U-8D59U]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-214U-8D59U]/MODULE[ModuleEngineConfigs]/CONFIG[RD-214U-8D59U]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-214U-8D59U]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-215M-8D613
@@ -7356,6 +12946,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD215 Engine now supports the RD-215M-8D613 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-215M-8D613
+    engineType = RD215
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-215M-8D613]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-215M-8D613] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-215M-8D613]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-215M-8D613]/MODULE[ModuleEngineConfigs]/CONFIG[RD-215M-8D613]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-215M-8D613]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7372,6 +12988,32 @@ PARTUPGRADE
         description = The RD215 Engine now supports the RD-217-8D515 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-217-8D515
+    engineType = RD215
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-217-8D515]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-217-8D515] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-217-8D515]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-217-8D515]/MODULE[ModuleEngineConfigs]/CONFIG[RD-217-8D515]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-217-8D515]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-225-8D721
@@ -7384,6 +13026,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD215 Engine now supports the RD-225-8D721 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-225-8D721
+    engineType = RD215
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-225-8D721]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-225-8D721] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-225-8D721]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-225-8D721]/MODULE[ModuleEngineConfigs]/CONFIG[RD-225-8D721]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-225-8D721]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7400,6 +13068,32 @@ PARTUPGRADE
         description = The RD215 Engine now supports the RD-250-8D518 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-250-8D518
+    engineType = RD215
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-250-8D518]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-250-8D518] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-250-8D518]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-250-8D518]/MODULE[ModuleEngineConfigs]/CONFIG[RD-250-8D518]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-250-8D518]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-250PM
@@ -7412,6 +13106,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD215 Engine now supports the RD-250PM configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-250PM
+    engineType = RD215
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-250PM]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-250PM] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-250PM]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-250PM]/MODULE[ModuleEngineConfigs]/CONFIG[RD-250PM]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-250PM]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7428,6 +13148,32 @@ PARTUPGRADE
         description = The RD219 Engine now supports the RD-252-8D724 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-252-8D724
+    engineType = RD219
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-252-8D724]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-252-8D724] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-252-8D724]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-252-8D724]/MODULE[ModuleEngineConfigs]/CONFIG[RD-252-8D724]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-252-8D724]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-253-Mk2
@@ -7440,6 +13186,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD253 Engine now supports the RD-253-Mk2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-253-Mk2
+    engineType = RD253
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-253-Mk2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-253-Mk2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-253-Mk2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-253-Mk2]/MODULE[ModuleEngineConfigs]/CONFIG[RD-253-Mk2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-253-Mk2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7456,6 +13228,32 @@ PARTUPGRADE
         description = The RD253 Engine now supports the RD-253-Mk3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-253-Mk3
+    engineType = RD253
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-253-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-253-Mk3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-253-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-253-Mk3]/MODULE[ModuleEngineConfigs]/CONFIG[RD-253-Mk3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-253-Mk3]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-253-Mk4
@@ -7468,6 +13266,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD253 Engine now supports the RD-253-Mk4 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-253-Mk4
+    engineType = RD253
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-253-Mk4]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-253-Mk4] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-253-Mk4]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-253-Mk4]/MODULE[ModuleEngineConfigs]/CONFIG[RD-253-Mk4]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-253-Mk4]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7484,6 +13308,32 @@ PARTUPGRADE
         description = The RD254 Engine now supports the RD-254-11D44-Mk2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-254-11D44-Mk2
+    engineType = RD254
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-254-11D44-Mk2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-254-11D44-Mk2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-254-11D44-Mk2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-254-11D44-Mk2]/MODULE[ModuleEngineConfigs]/CONFIG[RD-254-11D44-Mk2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-254-11D44-Mk2]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-254-11D44-Mk3
@@ -7496,6 +13346,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD254 Engine now supports the RD-254-11D44-Mk3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-254-11D44-Mk3
+    engineType = RD254
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-254-11D44-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-254-11D44-Mk3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-254-11D44-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-254-11D44-Mk3]/MODULE[ModuleEngineConfigs]/CONFIG[RD-254-11D44-Mk3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-254-11D44-Mk3]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7512,6 +13388,32 @@ PARTUPGRADE
         description = The RD254 Engine now supports the RD-254-11D44-Mk4 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-254-11D44-Mk4
+    engineType = RD254
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-254-11D44-Mk4]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-254-11D44-Mk4] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-254-11D44-Mk4]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-254-11D44-Mk4]/MODULE[ModuleEngineConfigs]/CONFIG[RD-254-11D44-Mk4]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-254-11D44-Mk4]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-262-11D26
@@ -7524,6 +13426,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD219 Engine now supports the RD-262-11D26 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-262-11D26
+    engineType = RD219
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-262-11D26]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-262-11D26] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-262-11D26]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-262-11D26]/MODULE[ModuleEngineConfigs]/CONFIG[RD-262-11D26]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-262-11D26]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7540,6 +13468,32 @@ PARTUPGRADE
         description = The RD263 Engine now supports the RD-268-15D168 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-268-15D168
+    engineType = RD263
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-268-15D168]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-268-15D168] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-268-15D168]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-268-15D168]/MODULE[ModuleEngineConfigs]/CONFIG[RD-268-15D168]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-268-15D168]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-273-15D286
@@ -7552,6 +13506,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD263 Engine now supports the RD-273-15D286 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-273-15D286
+    engineType = RD263
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-273-15D286]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-273-15D286] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-273-15D286]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-273-15D286]/MODULE[ModuleEngineConfigs]/CONFIG[RD-273-15D286]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-273-15D286]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7568,6 +13548,32 @@ PARTUPGRADE
         description = The RD253 Engine now supports the RD-275 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-275
+    engineType = RD253
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-275]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-275] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-275]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-275]/MODULE[ModuleEngineConfigs]/CONFIG[RD-275]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-275]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-275M
@@ -7580,6 +13586,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD253 Engine now supports the RD-275M configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-275M
+    engineType = RD253
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-275M]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-275M] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-275M]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-275M]/MODULE[ModuleEngineConfigs]/CONFIG[RD-275M]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-275M]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7596,6 +13628,32 @@ PARTUPGRADE
         description = The RD254 Engine now supports the RD-277-14D16 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-277-14D16
+    engineType = RD254
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-277-14D16]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-277-14D16] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-277-14D16]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-277-14D16]/MODULE[ModuleEngineConfigs]/CONFIG[RD-277-14D16]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-277-14D16]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-277M-14D16M
@@ -7608,6 +13666,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD254 Engine now supports the RD-277M-14D16M configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-277M-14D16M
+    engineType = RD254
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-277M-14D16M]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-277M-14D16M] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-277M-14D16M]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-277M-14D16M]/MODULE[ModuleEngineConfigs]/CONFIG[RD-277M-14D16M]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-277M-14D16M]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7624,6 +13708,32 @@ PARTUPGRADE
         description = The RD57 Engine now supports the RD-57M configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-57M
+    engineType = RD57
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-57M]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-57M] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-57M]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-57M]/MODULE[ModuleEngineConfigs]/CONFIG[RD-57M]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-57M]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-58
@@ -7636,6 +13746,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD58 Engine now supports the RD-58 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-58
+    engineType = RD58
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-58]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-58] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-58]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-58]/MODULE[ModuleEngineConfigs]/CONFIG[RD-58]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-58]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7652,6 +13788,32 @@ PARTUPGRADE
         description = The RD58 Engine now supports the RD-58M configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-58M
+    engineType = RD58
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-58M]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-58M] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-58M]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-58M]/MODULE[ModuleEngineConfigs]/CONFIG[RD-58M]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-58M]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-58M-CCN
@@ -7664,6 +13826,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD58 Engine now supports the RD-58M-CCN configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-58M-CCN
+    engineType = RD58
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-58M-CCN]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-58M-CCN] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-58M-CCN]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-58M-CCN]/MODULE[ModuleEngineConfigs]/CONFIG[RD-58M-CCN]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-58M-CCN]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7680,6 +13868,32 @@ PARTUPGRADE
         description = The RD58 Engine now supports the RD-58S configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-58S
+    engineType = RD58
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-58S]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-58S] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-58S]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-58S]/MODULE[ModuleEngineConfigs]/CONFIG[RD-58S]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-58S]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-855
@@ -7692,6 +13906,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD855 Engine now supports the RD-855 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-855
+    engineType = RD855
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-855]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-855] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-855]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-855]/MODULE[ModuleEngineConfigs]/CONFIG[RD-855]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-855]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7708,6 +13948,32 @@ PARTUPGRADE
         description = The RD856 Engine now supports the RD-856 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-856
+    engineType = RD856
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-856]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-856] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-856]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-856]/MODULE[ModuleEngineConfigs]/CONFIG[RD-856]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-856]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RD-869-15D300
@@ -7720,6 +13986,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RD864 Engine now supports the RD-869-15D300 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RD-869-15D300
+    engineType = RD864
+}
+
+@PART[RFUpgrade_engineConfigSource_RD-869-15D300]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RD-869-15D300] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RD-869-15D300]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RD-869-15D300]/MODULE[ModuleEngineConfigs]/CONFIG[RD-869-15D300]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RD-869-15D300]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7736,6 +14028,32 @@ PARTUPGRADE
         description = The ORM65 Engine now supports the RDA-1-150 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUpgraded for use in RP-318 rocket powered aircraft
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RDA-1-150
+    engineType = ORM65
+}
+
+@PART[RFUpgrade_engineConfigSource_RDA-1-150]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RDA-1-150] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RDA-1-150]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RDA-1-150]/MODULE[ModuleEngineConfigs]/CONFIG[RDA-1-150]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RDA-1-150]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RDA-1-300
@@ -7748,6 +14066,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The ORM65 Engine now supports the RDA-1-300 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUprated RDA-1-150, to allow the RP-318 to take off under its own power. 
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RDA-1-300
+    engineType = ORM65
+}
+
+@PART[RFUpgrade_engineConfigSource_RDA-1-300]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RDA-1-300] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RDA-1-300]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RDA-1-300]/MODULE[ModuleEngineConfigs]/CONFIG[RDA-1-300]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RDA-1-300]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7764,6 +14108,32 @@ PARTUPGRADE
         description = The RL10 Engine now supports the RL10A-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-1
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-1]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-1]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RL10A-3-1
@@ -7776,6 +14146,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RL10 Engine now supports the RL10A-3-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-3-1
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-3-1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-3-1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-3-1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-3-1]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-3-1]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7792,6 +14188,32 @@ PARTUPGRADE
         description = The RL10 Engine now supports the RL10A-3-3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-3-3
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-3-3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-3-3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-3-3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-3-3]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-3-3]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RL10A-3-3-Lunex
@@ -7804,6 +14226,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RL10 Engine now supports the RL10A-3-3-Lunex configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-3-3-Lunex
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-3-3-Lunex]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-3-3-Lunex] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-3-3-Lunex]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-3-3-Lunex]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-3-Lunex]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-3-3-Lunex]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7820,6 +14268,32 @@ PARTUPGRADE
         description = The RL10 Engine now supports the RL10A-3-3A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-3-3A
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-3-3A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-3-3A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-3-3A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-3-3A]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-3-3A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-3-3A]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RL10A-4
@@ -7832,6 +14306,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RL10 Engine now supports the RL10A-4 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-4
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-4]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-4] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-4]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-4]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-4]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7848,6 +14348,32 @@ PARTUPGRADE
         description = The RL10 Engine now supports the RL10A-4-1-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-4-1-2
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-4-1-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-4-1-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-4-1-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-4-1-2]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4-1-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-4-1-2]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RL10A-4-1N
@@ -7860,6 +14386,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RL10 Engine now supports the RL10A-4-1N configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-4-1N
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-4-1N]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-4-1N] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-4-1N]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-4-1N]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4-1N]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-4-1N]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7876,6 +14428,32 @@ PARTUPGRADE
         description = The RL10 Engine now supports the RL10A-4-2N configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-4-2N
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-4-2N]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-4-2N] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-4-2N]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-4-2N]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4-2N]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-4-2N]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RL10A-4N
@@ -7888,6 +14466,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RL10 Engine now supports the RL10A-4N configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-4N
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-4N]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-4N] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-4N]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-4N]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4N]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-4N]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7904,6 +14508,32 @@ PARTUPGRADE
         description = The RL10 Engine now supports the RL10A-5 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-5
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-5]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-5] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-5]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-5]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-5]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-5]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RL10B-2
@@ -7916,6 +14546,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RL10 Engine now supports the RL10B-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10B-2
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10B-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10B-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10B-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10B-2]/MODULE[ModuleEngineConfigs]/CONFIG[RL10B-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10B-2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7932,6 +14588,32 @@ PARTUPGRADE
         description = The RL10 Engine now supports the RL10C-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10C-1
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10C-1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10C-1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10C-1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10C-1]/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10C-1]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RL10C-1-1
@@ -7944,6 +14626,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RL10 Engine now supports the RL10C-1-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10C-1-1
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10C-1-1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10C-1-1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10C-1-1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10C-1-1]/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-1-1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10C-1-1]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7960,6 +14668,32 @@ PARTUPGRADE
         description = The RL10 Engine now supports the RL10C-2-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10C-2-1
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10C-2-1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10C-2-1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10C-2-1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10C-2-1]/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-2-1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10C-2-1]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RL10C-3
@@ -7972,6 +14706,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RL10 Engine now supports the RL10C-3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10C-3
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10C-3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10C-3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10C-3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10C-3]/MODULE[ModuleEngineConfigs]/CONFIG[RL10C-3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10C-3]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -7988,6 +14748,32 @@ PARTUPGRADE
         description = The RL200 Engine now supports the RL200-225k configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL200-225k
+    engineType = RL200
+}
+
+@PART[RFUpgrade_engineConfigSource_RL200-225k]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL200-225k] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL200-225k]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL200-225k]/MODULE[ModuleEngineConfigs]/CONFIG[RL200-225k]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL200-225k]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RL200-230k
@@ -8000,6 +14786,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RL200 Engine now supports the RL200-230k configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL200-230k
+    engineType = RL200
+}
+
+@PART[RFUpgrade_engineConfigSource_RL200-230k]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL200-230k] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL200-230k]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL200-230k]/MODULE[ModuleEngineConfigs]/CONFIG[RL200-230k]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL200-230k]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8016,6 +14828,32 @@ PARTUPGRADE
         description = The RL200 Engine now supports the RL200S configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL200S
+    engineType = RL200
+}
+
+@PART[RFUpgrade_engineConfigSource_RL200S]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL200S] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL200S]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL200S]/MODULE[ModuleEngineConfigs]/CONFIG[RL200S]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL200S]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RS-18
@@ -8028,6 +14866,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LMAE Engine now supports the RS-18 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-18
+    engineType = LMAE
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-18]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-18] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-18]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-18]/MODULE[ModuleEngineConfigs]/CONFIG[RS-18]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-18]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8044,6 +14908,32 @@ PARTUPGRADE
         description = The SSME Engine now supports the RS-25A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-25A
+    engineType = SSME
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-25A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-25A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-25A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-25A]/MODULE[ModuleEngineConfigs]/CONFIG[RS-25A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-25A]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RS-25C
@@ -8056,6 +14946,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The SSME Engine now supports the RS-25C configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-25C
+    engineType = SSME
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-25C]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-25C] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-25C]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-25C]/MODULE[ModuleEngineConfigs]/CONFIG[RS-25C]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-25C]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8072,6 +14988,32 @@ PARTUPGRADE
         description = The SSME Engine now supports the RS-25D-E configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-25D-E
+    engineType = SSME
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-25D-E]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-25D-E] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-25D-E]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-25D-E]/MODULE[ModuleEngineConfigs]/CONFIG[RS-25D-E]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-25D-E]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RS-27
@@ -8084,6 +15026,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The H1 Engine now supports the RS-27 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-27
+    engineType = H1
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-27]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-27] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-27]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-27]/MODULE[ModuleEngineConfigs]/CONFIG[RS-27]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-27]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8100,6 +15068,32 @@ PARTUPGRADE
         description = The H1 Engine now supports the RS-27A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-27A
+    engineType = H1
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-27A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-27A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-27A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-27A]/MODULE[ModuleEngineConfigs]/CONFIG[RS-27A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-27A]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RS-44-Full
@@ -8112,6 +15106,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RS44 Engine now supports the RS-44-Full configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-44-Full
+    engineType = RS44
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-44-Full]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-44-Full] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-44-Full]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-44-Full]/MODULE[ModuleEngineConfigs]/CONFIG[RS-44-Full]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-44-Full]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8128,6 +15148,32 @@ PARTUPGRADE
         description = The RS44 Engine now supports the RS-44-Incremental configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-44-Incremental
+    engineType = RS44
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-44-Incremental]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-44-Incremental] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-44-Incremental]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-44-Incremental]/MODULE[ModuleEngineConfigs]/CONFIG[RS-44-Incremental]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-44-Incremental]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RS-56-OBA
@@ -8140,6 +15186,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LR89 Engine now supports the RS-56-OBA configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUpgraded using H-1/RS-27 components.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-56-OBA
+    engineType = LR89
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-56-OBA]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-56-OBA] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-56-OBA]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-56-OBA]/MODULE[ModuleEngineConfigs]/CONFIG[RS-56-OBA]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-56-OBA]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8156,6 +15228,32 @@ PARTUPGRADE
         description = The LR105 Engine now supports the RS-56-OSA configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUpgraded using H-1/RS-27 components.
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-56-OSA
+    engineType = LR105
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-56-OSA]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-56-OSA] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-56-OSA]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-56-OSA]/MODULE[ModuleEngineConfigs]/CONFIG[RS-56-OSA]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-56-OSA]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RS-68A
@@ -8168,6 +15266,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RS68 Engine now supports the RS-68A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-68A
+    engineType = RS68
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-68A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-68A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-68A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-68A]/MODULE[ModuleEngineConfigs]/CONFIG[RS-68A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-68A]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8184,6 +15308,32 @@ PARTUPGRADE
         description = The RS68 Engine now supports the RS-68K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-68K
+    engineType = RS68
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-68K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-68K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-68K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-68K]/MODULE[ModuleEngineConfigs]/CONFIG[RS-68K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-68K]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RS-76A
@@ -8196,6 +15346,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RS76 Engine now supports the RS-76A configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-76A
+    engineType = RS76
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-76A]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-76A] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-76A]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-76A]/MODULE[ModuleEngineConfigs]/CONFIG[RS-76A]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-76A]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8212,6 +15388,32 @@ PARTUPGRADE
         description = The RS68 Engine now supports the RS-800 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RS-800
+    engineType = RS68
+}
+
+@PART[RFUpgrade_engineConfigSource_RS-800]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RS-800] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RS-800]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RS-800]/MODULE[ModuleEngineConfigs]/CONFIG[RS-800]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RS-800]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RSRM-1986
@@ -8224,6 +15426,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RSRM Engine now supports the RSRM-1986 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RSRM-1986
+    engineType = RSRM
+}
+
+@PART[RFUpgrade_engineConfigSource_RSRM-1986]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RSRM-1986] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RSRM-1986]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RSRM-1986]/MODULE[ModuleEngineConfigs]/CONFIG[RSRM-1986]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RSRM-1986]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8240,6 +15468,32 @@ PARTUPGRADE
         description = The RZ.2 Engine now supports the RZ.2-Mk3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_RZ.2-Mk3
+    engineType = RZ.2
+}
+
+@PART[RFUpgrade_engineConfigSource_RZ.2-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RZ.2-Mk3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RZ.2-Mk3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RZ.2-Mk3]/MODULE[ModuleEngineConfigs]/CONFIG[RZ.2-Mk3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RZ.2-Mk3]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RZ.2-Mk4
@@ -8252,6 +15506,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RZ.2 Engine now supports the RZ.2-Mk4 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RZ.2-Mk4
+    engineType = RZ.2
+}
+
+@PART[RFUpgrade_engineConfigSource_RZ.2-Mk4]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RZ.2-Mk4] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RZ.2-Mk4]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RZ.2-Mk4]/MODULE[ModuleEngineConfigs]/CONFIG[RZ.2-Mk4]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RZ.2-Mk4]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8268,6 +15548,32 @@ PARTUPGRADE
         description = The Rutherford-SL Engine now supports the Rutherford-SL configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Rutherford-SL
+    engineType = Rutherford-SL
+}
+
+@PART[RFUpgrade_engineConfigSource_Rutherford-SL]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Rutherford-SL] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Rutherford-SL]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Rutherford-SL]/MODULE[ModuleEngineConfigs]/CONFIG[Rutherford-SL]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Rutherford-SL]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_RutherfordVac
@@ -8280,6 +15586,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RutherfordVac Engine now supports the RutherfordVac configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RutherfordVac
+    engineType = RutherfordVac
+}
+
+@PART[RFUpgrade_engineConfigSource_RutherfordVac]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RutherfordVac] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RutherfordVac]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RutherfordVac]/MODULE[ModuleEngineConfigs]/CONFIG[RutherfordVac]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RutherfordVac]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8296,6 +15628,32 @@ PARTUPGRADE
         description = The LR79 Engine now supports the S-3D configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nProduction version of the LR79 engine, used on Thor and Jupiter.
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_S-3D
+    engineType = LR79
+}
+
+@PART[RFUpgrade_engineConfigSource_S-3D]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[S-3D] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_S-3D]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_S-3D]/MODULE[ModuleEngineConfigs]/CONFIG[S-3D]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_S-3D]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_S3.42T
@@ -8308,6 +15666,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The S2_253 Engine now supports the S3.42T configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_S3.42T
+    engineType = S2_253
+}
+
+@PART[RFUpgrade_engineConfigSource_S3.42T]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[S3.42T] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_S3.42T]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_S3.42T]/MODULE[ModuleEngineConfigs]/CONFIG[S3.42T]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_S3.42T]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8324,6 +15708,32 @@ PARTUPGRADE
         description = The S2_253 Engine now supports the S5.2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_S5.2
+    engineType = S2_253
+}
+
+@PART[RFUpgrade_engineConfigSource_S5.2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[S5.2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_S5.2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_S5.2]/MODULE[ModuleEngineConfigs]/CONFIG[S5.2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_S5.2]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_SNTPPFE100
@@ -8336,6 +15746,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The SNTPPFE100 Engine now supports the SNTPPFE100 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_SNTPPFE100
+    engineType = SNTPPFE100
+}
+
+@PART[RFUpgrade_engineConfigSource_SNTPPFE100]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[SNTPPFE100] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_SNTPPFE100]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_SNTPPFE100]/MODULE[ModuleEngineConfigs]/CONFIG[SNTPPFE100]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_SNTPPFE100]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8352,6 +15788,32 @@ PARTUPGRADE
         description = The SPT100 Engine now supports the SPT-100B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_SPT-100B
+    engineType = SPT100
+}
+
+@PART[RFUpgrade_engineConfigSource_SPT-100B]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[SPT-100B] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_SPT-100B]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_SPT-100B]/MODULE[ModuleEngineConfigs]/CONFIG[SPT-100B]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_SPT-100B]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_SPT-100D
@@ -8364,6 +15826,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The SPT100 Engine now supports the SPT-100D configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_SPT-100D
+    engineType = SPT100
+}
+
+@PART[RFUpgrade_engineConfigSource_SPT-100D]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[SPT-100D] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_SPT-100D]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_SPT-100D]/MODULE[ModuleEngineConfigs]/CONFIG[SPT-100D]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_SPT-100D]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8380,6 +15868,32 @@ PARTUPGRADE
         description = The SPT100 Engine now supports the SPT-100M configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_SPT-100M
+    engineType = SPT100
+}
+
+@PART[RFUpgrade_engineConfigSource_SPT-100M]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[SPT-100M] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_SPT-100M]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_SPT-100M]/MODULE[ModuleEngineConfigs]/CONFIG[SPT-100M]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_SPT-100M]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_TR-201
@@ -8392,6 +15906,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The LMDE Engine now supports the TR-201 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_TR-201
+    engineType = LMDE
+}
+
+@PART[RFUpgrade_engineConfigSource_TR-201]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[TR-201] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_TR-201]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_TR-201]/MODULE[ModuleEngineConfigs]/CONFIG[TR-201]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_TR-201]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8408,6 +15948,32 @@ PARTUPGRADE
         description = The TR308 Engine now supports the TR-312-100MN configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_TR-312-100MN
+    engineType = TR308
+}
+
+@PART[RFUpgrade_engineConfigSource_TR-312-100MN]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[TR-312-100MN] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_TR-312-100MN]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_TR-312-100MN]/MODULE[ModuleEngineConfigs]/CONFIG[TR-312-100MN]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_TR-312-100MN]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_TR-312-100YN
@@ -8420,6 +15986,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The TR308 Engine now supports the TR-312-100YN configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_TR-312-100YN
+    engineType = TR308
+}
+
+@PART[RFUpgrade_engineConfigSource_TR-312-100YN]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[TR-312-100YN] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_TR-312-100YN]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_TR-312-100YN]/MODULE[ModuleEngineConfigs]/CONFIG[TR-312-100YN]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_TR-312-100YN]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8436,6 +16028,32 @@ PARTUPGRADE
         description = The BNTR Engine now supports the TRITON configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_TRITON
+    engineType = BNTR
+}
+
+@PART[RFUpgrade_engineConfigSource_TRITON]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[TRITON] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_TRITON]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_TRITON]/MODULE[ModuleEngineConfigs]/CONFIG[TRITON]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_TRITON]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_U-1700
@@ -8448,6 +16066,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The U1250 Engine now supports the U-1700 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_U-1700
+    engineType = U1250
+}
+
+@PART[RFUpgrade_engineConfigSource_U-1700]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[U-1700] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_U-1700]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_U-1700]/MODULE[ModuleEngineConfigs]/CONFIG[U-1700]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_U-1700]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8464,6 +16108,32 @@ PARTUPGRADE
         description = The U1250 Engine now supports the U-2000 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_U-2000
+    engineType = U1250
+}
+
+@PART[RFUpgrade_engineConfigSource_U-2000]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[U-2000] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_U-2000]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_U-2000]/MODULE[ModuleEngineConfigs]/CONFIG[U-2000]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_U-2000]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_UDMH+NTO
@@ -8476,6 +16146,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The RCS Engine now supports the UDMH+NTO configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_UDMH+NTO
+    engineType = RCS
+}
+
+@PART[RFUpgrade_engineConfigSource_UDMH+NTO]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[UDMH+NTO] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_UDMH+NTO]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_UDMH+NTO]/MODULE[ModuleEngineConfigs]/CONFIG[UDMH+NTO]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_UDMH+NTO]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8492,6 +16188,32 @@ PARTUPGRADE
         description = The VF200 Engine now supports the VF-200-Kr configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_VF-200-Kr
+    engineType = VF200
+}
+
+@PART[RFUpgrade_engineConfigSource_VF-200-Kr]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[VF-200-Kr] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_VF-200-Kr]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_VF-200-Kr]/MODULE[ModuleEngineConfigs]/CONFIG[VF-200-Kr]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_VF-200-Kr]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_VX-200SS-Kr
@@ -8504,6 +16226,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The VX200SS Engine now supports the VX-200SS-Kr configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_VX-200SS-Kr
+    engineType = VX200SS
+}
+
+@PART[RFUpgrade_engineConfigSource_VX-200SS-Kr]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[VX-200SS-Kr] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_VX-200SS-Kr]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_VX-200SS-Kr]/MODULE[ModuleEngineConfigs]/CONFIG[VX-200SS-Kr]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_VX-200SS-Kr]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8520,6 +16268,32 @@ PARTUPGRADE
         description = The Vexin Engine now supports the Valois configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Valois
+    engineType = Vexin
+}
+
+@PART[RFUpgrade_engineConfigSource_Valois]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Valois] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Valois]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Valois]/MODULE[ModuleEngineConfigs]/CONFIG[Valois]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Valois]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Veronique61
@@ -8532,6 +16306,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Veronique Engine now supports the Veronique61 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Veronique61
+    engineType = Veronique
+}
+
+@PART[RFUpgrade_engineConfigSource_Veronique61]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Veronique61] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Veronique61]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Veronique61]/MODULE[ModuleEngineConfigs]/CONFIG[Veronique61]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Veronique61]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8548,6 +16348,32 @@ PARTUPGRADE
         description = The Veronique Engine now supports the VeroniqueAGI configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_VeroniqueAGI
+    engineType = Veronique
+}
+
+@PART[RFUpgrade_engineConfigSource_VeroniqueAGI]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[VeroniqueAGI] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_VeroniqueAGI]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_VeroniqueAGI]/MODULE[ModuleEngineConfigs]/CONFIG[VeroniqueAGI]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_VeroniqueAGI]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Vexin
@@ -8560,6 +16386,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Vexin Engine now supports the Vexin configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Vexin
+    engineType = Vexin
+}
+
+@PART[RFUpgrade_engineConfigSource_Vexin]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Vexin] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Vexin]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Vexin]/MODULE[ModuleEngineConfigs]/CONFIG[Vexin]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Vexin]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8576,6 +16428,32 @@ PARTUPGRADE
         description = The Vikas Engine now supports the Vikas-1+ configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Vikas-1+
+    engineType = Vikas
+}
+
+@PART[RFUpgrade_engineConfigSource_Vikas-1+]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Vikas-1+] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Vikas-1+]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Vikas-1+]/MODULE[ModuleEngineConfigs]/CONFIG[Vikas-1+]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Vikas-1+]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Vikas-2
@@ -8588,6 +16466,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Vikas Engine now supports the Vikas-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Vikas-2
+    engineType = Vikas
+}
+
+@PART[RFUpgrade_engineConfigSource_Vikas-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Vikas-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Vikas-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Vikas-2]/MODULE[ModuleEngineConfigs]/CONFIG[Vikas-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Vikas-2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8604,6 +16508,32 @@ PARTUPGRADE
         description = The Vikas Engine now supports the Vikas-2B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Vikas-2B
+    engineType = Vikas
+}
+
+@PART[RFUpgrade_engineConfigSource_Vikas-2B]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Vikas-2B] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Vikas-2B]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Vikas-2B]/MODULE[ModuleEngineConfigs]/CONFIG[Vikas-2B]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Vikas-2B]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Viking-2B
@@ -8616,6 +16546,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Viking Engine now supports the Viking-2B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Viking-2B
+    engineType = Viking
+}
+
+@PART[RFUpgrade_engineConfigSource_Viking-2B]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Viking-2B] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Viking-2B]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Viking-2B]/MODULE[ModuleEngineConfigs]/CONFIG[Viking-2B]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Viking-2B]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8632,6 +16588,32 @@ PARTUPGRADE
         description = The Viking Engine now supports the Viking-4 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Viking-4
+    engineType = Viking
+}
+
+@PART[RFUpgrade_engineConfigSource_Viking-4]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Viking-4] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Viking-4]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Viking-4]/MODULE[ModuleEngineConfigs]/CONFIG[Viking-4]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Viking-4]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Viking-4B
@@ -8644,6 +16626,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Viking Engine now supports the Viking-4B configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Viking-4B
+    engineType = Viking
+}
+
+@PART[RFUpgrade_engineConfigSource_Viking-4B]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Viking-4B] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Viking-4B]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Viking-4B]/MODULE[ModuleEngineConfigs]/CONFIG[Viking-4B]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Viking-4B]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8660,6 +16668,32 @@ PARTUPGRADE
         description = The Viking Engine now supports the Viking-5C configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Viking-5C
+    engineType = Viking
+}
+
+@PART[RFUpgrade_engineConfigSource_Viking-5C]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Viking-5C] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Viking-5C]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Viking-5C]/MODULE[ModuleEngineConfigs]/CONFIG[Viking-5C]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Viking-5C]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Viking-6
@@ -8672,6 +16706,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Viking Engine now supports the Viking-6 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Viking-6
+    engineType = Viking
+}
+
+@PART[RFUpgrade_engineConfigSource_Viking-6]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Viking-6] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Viking-6]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Viking-6]/MODULE[ModuleEngineConfigs]/CONFIG[Viking-6]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Viking-6]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8688,6 +16748,32 @@ PARTUPGRADE
         description = The RL60 Engine now supports the Vinci-180 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_Vinci-180
+    engineType = RL60
+}
+
+@PART[RFUpgrade_engineConfigSource_Vinci-180]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Vinci-180] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Vinci-180]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Vinci-180]/MODULE[ModuleEngineConfigs]/CONFIG[Vinci-180]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Vinci-180]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_Vulcain-2
@@ -8700,6 +16786,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Vulcain Engine now supports the Vulcain-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Vulcain-2
+    engineType = Vulcain
+}
+
+@PART[RFUpgrade_engineConfigSource_Vulcain-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Vulcain-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Vulcain-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Vulcain-2]/MODULE[ModuleEngineConfigs]/CONFIG[Vulcain-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Vulcain-2]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8716,6 +16828,32 @@ PARTUPGRADE
         description = The X405 Engine now supports the X-405H configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nEngine for proposed Vega stage for NASA Atlas-Vega LV. Superceded by Atlas-Agena once NASA became aware of the USAF's Agena stage.
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_X-405H
+    engineType = X405
+}
+
+@PART[RFUpgrade_engineConfigSource_X-405H]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[X-405H] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_X-405H]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_X-405H]/MODULE[ModuleEngineConfigs]/CONFIG[X-405H]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_X-405H]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_X-405H-3
@@ -8728,6 +16866,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The X405 Engine now supports the X-405H-3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_X-405H-3
+    engineType = X405
+}
+
+@PART[RFUpgrade_engineConfigSource_X-405H-3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[X-405H-3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_X-405H-3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_X-405H-3]/MODULE[ModuleEngineConfigs]/CONFIG[X-405H-3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_X-405H-3]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8744,6 +16908,32 @@ PARTUPGRADE
         description = The X405 Engine now supports the X-405H-4 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_X-405H-4
+    engineType = X405
+}
+
+@PART[RFUpgrade_engineConfigSource_X-405H-4]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[X-405H-4] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_X-405H-4]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_X-405H-4]/MODULE[ModuleEngineConfigs]/CONFIG[X-405H-4]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_X-405H-4]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_X3-HV
@@ -8756,6 +16946,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The X3 Engine now supports the X3-HV configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_X3-HV
+    engineType = X3
+}
+
+@PART[RFUpgrade_engineConfigSource_X3-HV]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[X3-HV] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_X3-HV]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_X3-HV]/MODULE[ModuleEngineConfigs]/CONFIG[X3-HV]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_X3-HV]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8772,6 +16988,32 @@ PARTUPGRADE
         description = The X3 Engine now supports the X3-HV-K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_X3-HV-K
+    engineType = X3
+}
+
+@PART[RFUpgrade_engineConfigSource_X3-HV-K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[X3-HV-K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_X3-HV-K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_X3-HV-K]/MODULE[ModuleEngineConfigs]/CONFIG[X3-HV-K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_X3-HV-K]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_XASR-1
@@ -8784,6 +17026,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Aerobee Engine now supports the XASR-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_XASR-1
+    engineType = Aerobee
+}
+
+@PART[RFUpgrade_engineConfigSource_XASR-1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XASR-1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XASR-1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XASR-1]/MODULE[ModuleEngineConfigs]/CONFIG[XASR-1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XASR-1]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8800,6 +17068,32 @@ PARTUPGRADE
         description = The XLR11 Engine now supports the XLR11-RM-13-10K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUprated for use on X-24B flights
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_XLR11-RM-13-10K
+    engineType = XLR11
+}
+
+@PART[RFUpgrade_engineConfigSource_XLR11-RM-13-10K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XLR11-RM-13-10K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XLR11-RM-13-10K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR11-RM-13-10K]/MODULE[ModuleEngineConfigs]/CONFIG[XLR11-RM-13-10K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XLR11-RM-13-10K]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_XLR11-RM-13-8K
@@ -8812,6 +17106,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The XLR11 Engine now supports the XLR11-RM-13-8K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nUprated XLR11 used in pairs on early X-15 flights before the XLR99 was ready.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_XLR11-RM-13-8K
+    engineType = XLR11
+}
+
+@PART[RFUpgrade_engineConfigSource_XLR11-RM-13-8K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XLR11-RM-13-8K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XLR11-RM-13-8K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR11-RM-13-8K]/MODULE[ModuleEngineConfigs]/CONFIG[XLR11-RM-13-8K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XLR11-RM-13-8K]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8828,6 +17148,32 @@ PARTUPGRADE
         description = The XLR11 Engine now supports the XLR11-RM-5 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nPump-fed version used on X-1 #3 and later aircraft
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_XLR11-RM-5
+    engineType = XLR11
+}
+
+@PART[RFUpgrade_engineConfigSource_XLR11-RM-5]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XLR11-RM-5] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XLR11-RM-5]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR11-RM-5]/MODULE[ModuleEngineConfigs]/CONFIG[XLR11-RM-5]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XLR11-RM-5]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_XLR35-RM-1
@@ -8840,6 +17186,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The XLR11 Engine now supports the XLR35-RM-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nModified XLR11 used on RTV-A-2 Hiroc missile in Project MX-774. Higher performance. Includes gimbal assembly.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_XLR35-RM-1
+    engineType = XLR11
+}
+
+@PART[RFUpgrade_engineConfigSource_XLR35-RM-1]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XLR35-RM-1] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XLR35-RM-1]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR35-RM-1]/MODULE[ModuleEngineConfigs]/CONFIG[XLR35-RM-1]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XLR35-RM-1]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8856,6 +17228,32 @@ PARTUPGRADE
         description = The LR89 Engine now supports the XLR43-NA-3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nImproved XLR43 with brazed chamber walls and burning 90% Ethanol.
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_XLR43-NA-3
+    engineType = LR89
+}
+
+@PART[RFUpgrade_engineConfigSource_XLR43-NA-3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XLR43-NA-3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XLR43-NA-3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR43-NA-3]/MODULE[ModuleEngineConfigs]/CONFIG[XLR43-NA-3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XLR43-NA-3]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_XLR81-BA-11
@@ -8868,6 +17266,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Agena Engine now supports the XLR81-BA-11 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nAgena D
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_XLR81-BA-11
+    engineType = Agena
+}
+
+@PART[RFUpgrade_engineConfigSource_XLR81-BA-11]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XLR81-BA-11] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XLR81-BA-11]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR81-BA-11]/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-11]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XLR81-BA-11]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8884,6 +17308,32 @@ PARTUPGRADE
         description = The Agena Engine now supports the XLR81-BA-13 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nGATV
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_XLR81-BA-13
+    engineType = Agena
+}
+
+@PART[RFUpgrade_engineConfigSource_XLR81-BA-13]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XLR81-BA-13] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XLR81-BA-13]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR81-BA-13]/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-13]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XLR81-BA-13]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_XLR81-BA-3
@@ -8896,6 +17346,32 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Agena Engine now supports the XLR81-BA-3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_XLR81-BA-3
+    engineType = Agena
+}
+
+@PART[RFUpgrade_engineConfigSource_XLR81-BA-3]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XLR81-BA-3] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XLR81-BA-3]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR81-BA-3]/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-3]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XLR81-BA-3]:AFTER[RealismOverhaulEngines]
+{
 }
 
 PARTUPGRADE
@@ -8912,6 +17388,32 @@ PARTUPGRADE
         description = The Agena Engine now supports the XLR81-BA-5 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nAgena A
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_XLR81-BA-5
+    engineType = Agena
+}
+
+@PART[RFUpgrade_engineConfigSource_XLR81-BA-5]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XLR81-BA-5] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XLR81-BA-5]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR81-BA-5]/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-5]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XLR81-BA-5]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_XLR81-BA-7
@@ -8926,6 +17428,32 @@ PARTUPGRADE
         description = The Agena Engine now supports the XLR81-BA-7 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nAgena B
 }
 
+PART
+{
+    name = RFUpgrade_engineConfigSource_XLR81-BA-7
+    engineType = Agena
+}
+
+@PART[RFUpgrade_engineConfigSource_XLR81-BA-7]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XLR81-BA-7] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XLR81-BA-7]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR81-BA-7]/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-BA-7]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XLR81-BA-7]:AFTER[RealismOverhaulEngines]
+{
+}
+
 PARTUPGRADE
 {
         name = RFUpgrade_XLR81-LF2-SPS
@@ -8938,4 +17466,30 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The Agena Engine now supports the XLR81-LF2-SPS configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nLiquid Fluorine based design, proposed for use on the GE D-2 Apollo vehicle, and later high performance Agena tugs.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_XLR81-LF2-SPS
+    engineType = Agena
+}
+
+@PART[RFUpgrade_engineConfigSource_XLR81-LF2-SPS]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[XLR81-LF2-SPS] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_XLR81-LF2-SPS]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR81-LF2-SPS]/MODULE[ModuleEngineConfigs]/CONFIG[XLR81-LF2-SPS]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_XLR81-LF2-SPS]:AFTER[RealismOverhaulEngines]
+{
 }

--- a/GameData/RP-0/Tree/TREE-Engines.cfg
+++ b/GameData/RP-0/Tree/TREE-Engines.cfg
@@ -4228,6 +4228,7 @@
                 %techRequired = earlyRocketry
                 %cost = 200
                 %description = Modified XLR11 used on RTV-A-2 Hiroc missile in Project MX-774. Higher performance. Includes gimbal assembly.
+                *@PARTUPGRADE[RFUpgrade_XLR35-RM-1]/deleteme -= 1
             }
 
             @CONFIG[XLR41]
@@ -8825,6 +8826,20 @@ PARTUPGRADE
         manufacturer = Engine Upgrade
         deleteme = 1
         description = The XLR11 Engine now supports the XLR11-RM-5 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nPump-fed version used on X-1 #3 and later aircraft
+}
+
+PARTUPGRADE
+{
+        name = RFUpgrade_XLR35-RM-1
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = earlyRocketry
+        entryCost = 0
+        cost = 0      
+        title = XLR11 Engine Upgrade: XLR35-RM-1 Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The XLR11 Engine now supports the XLR35-RM-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nModified XLR11 used on RTV-A-2 Hiroc missile in Project MX-774. Higher performance. Includes gimbal assembly.
 }
 
 PARTUPGRADE

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -14286,7 +14286,7 @@
         "rp0_conf": false,
         "spacecraft": "X-1",
         "engine_config": "XLR11",
-        "upgrade": false,
+        "upgrade": true,
         "entry_cost_mods": "8000,XLR11-RM-5",
         "identical_part_name": "",
         "module_tags": []

--- a/Source/Tech Tree/Parts Browser/tree_engine_cfg_generator.py
+++ b/Source/Tech Tree/Parts Browser/tree_engine_cfg_generator.py
@@ -47,6 +47,32 @@ PARTUPGRADE
         deleteme = 1
         description = The ${engine_config} Engine now supports the ${name} configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\\n\\n${description}
 }
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_${name}
+    engineType = ${engine_config}
+}
+
+@PART[RFUpgrade_engineConfigSource_${name}]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[${name}] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_${name}]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$$description$$\\nAvailable at specLevel $$@PART[RFUpgrade_engineConfigSource_${name}]/MODULE[ModuleEngineConfigs]/CONFIG[${name}]/specLevel$$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_${name}]:AFTER[RealismOverhaulEngines]
+{
+}
 """)
 
 def generate_engine_tree(parts):


### PR DESCRIPTION
Mostly to give a clue why a config isn't actually available despite
the tree showing a PARTUPGRADE for it

(also includes a partupgrade for xlr35, forgot I had that in my tree)

Modifies the parts browser, which possibly means we don't want to merge this without also updating the .exe, and I'm not going to do that.

![Screen Shot 2022-11-05 at 14 20 14](https://user-images.githubusercontent.com/5061230/200135134-627a3921-790a-47d5-8bdb-070df27403e3.png)
