### PR TITLE
Add to the Earth Space Station Program

### DIFF
--- a/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
@@ -41,7 +41,7 @@ CONTRACT_TYPE
 		name = ProgramActive
 		type = ProgramActive
 		program = EarthSpaceStation
-	
+	}
 	DATA
 	{
 		type = string

--- a/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
@@ -29,7 +29,7 @@ CONTRACT_TYPE
 	prestige = Exceptional   // 1.5x
 	advanceFunds = 0
 	rewardScience = 0
-	rewardReputation = 200
+	rewardReputation = 300
 	rewardFunds =  0
 	failureReputation = @rewardReputation
 	failureFunds = 0

--- a/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
@@ -113,7 +113,8 @@ CONTRACT_TYPE
 		define = crewCapsule
 		
 		completeInSequence = true
-
+		resetChildrenWhenVesselDestroyed = true
+		
 		PARAMETER 
 		{
 			name = Crewmembers
@@ -137,7 +138,7 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Keep at least 2 crew aboard the station for 30 days.
 		vessel = @/craft
-
+		notes = You can work on other contracts while your crew are working. You are safe to return to Mission Control
 		completeInSequence = true
 		
 		PARAMETER
@@ -183,6 +184,7 @@ CONTRACT_TYPE
 		vessel = crewCapsule
 
 		completeInSequence = true
+		resetChildrenWhenVesselDestroyed = true
 		
 		PARAMETER 
 		{

--- a/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
@@ -2,10 +2,10 @@ CONTRACT_TYPE
 {
 	name = first_spaceStation
 	title = First Space Station
-	group = EarthSpaceStation
+	group = SpaceStations
 	agent = Stations
 
-	description = Design, build, and launch a space station into Earth orbit, Then crew it for a month with at least two crew, and bring the crew safely home. Once you're done, you'll get missions to perform further crew rotations and resupply missions, as well as expansion or replacement missions.
+	description = Design, build, and launch a space station into Earth orbit, Then crew it for a month with at least two crew, and bring the crew safely home. 
 
 	synopsis = Launch a space station and crew it for a month
 
@@ -24,41 +24,41 @@ CONTRACT_TYPE
 
 	targetBody = HomeWorld()
 
-
+	// ************ REWARDS ************
 
 	prestige = Exceptional   // 1.5x
-	advanceFunds = 575000 * @RP0:globalHardContractMultiplier
+	advanceFunds = 0
 	rewardScience = 0
-	rewardReputation = 500
-	rewardFunds = 250000 * @RP0:globalHardContractMultiplier
-	failureReputation = 750
-	failureFunds = @advanceFunds * 0.5
+	rewardReputation = 200
+	rewardFunds =  0
+	failureReputation = @rewardReputation
+	failureFunds = 0
 
 	// ************ REQUIREMENTS ************
 
 	REQUIREMENT
 	{
-		name = CompleteContract
-		type = CompleteContract
-		contractType = first_Docking
-	}
-	REQUIREMENT
+		name = ProgramActive
+		type = ProgramActive
+		program = EarthSpaceStation
+	
+	DATA
 	{
-		name = CompleteContract
-		type = CompleteContract
-		contractType = first_EVA
+		type = string
+		craft = "firstSpaceStation"
+		hidden = true
 	}
-
+	
 	// ************ PARAMETERS ************
-
+	
 	PARAMETER
 	{
 		name = vesselGroupLaunch
 		type = VesselParameterGroup
 		title = Put your first Space Station in Orbit
 		notes = The station must include at least 1 Docking Port and support for at least 3 Crew
-		define = spaceStation
-		defineList = spaceStationsEarth
+		define = @/craft
+		defineList = basicEarthStations
 
 		PARAMETER
 		{
@@ -111,7 +111,7 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Bring at least 2 crew to the station
 		define = crewCapsule
-
+		
 		completeInSequence = true
 
 		PARAMETER 
@@ -126,8 +126,9 @@ CONTRACT_TYPE
 		{
 			name = Rendezvous
 			type = Rendezvous
-			vessel = spaceStation
-			distance = 1000
+			vessel = @/craft
+			distance = 100
+			title = Rendezvous with the station and dock.
 		}
 	}
 	PARAMETER
@@ -135,18 +136,20 @@ CONTRACT_TYPE
 		name = stayOnStation
 		type = VesselParameterGroup
 		title = Keep at least 2 crew aboard the station for 30 days.
-		vessel = spaceStation
+		vessel = @/craft
 
 		completeInSequence = true
-
-		PARAMETER 
+		
+		PARAMETER
 		{
-			name = Crewmembers
-			type = HasCrew
+			name = HasCrew
+			type  = HasCrew
 			minCrew = 2
-			title = Have at least 2 crewmembers on board
+			maxCrew = 99
+			title = Has at least 2 crew members on the station.
 			hideChildren = true
-		}
+			completeInSequence = true
+		}	
 		PARAMETER
 		{
 			name = Orbit
@@ -154,18 +157,23 @@ CONTRACT_TYPE
 			minPeA = 250000
 			maxApA = 2000000
 			targetBody = HomeWorld()
-			disableOnStateChange = true
+			disableOnStateChange = false
 			title = Remain in a Stable Orbit
-			PARAMETER
-			{
-				name = Duration
-				type = Duration
-				duration =  30d
-				preWaitText = Transfer to the station in the specified orbit.
-				waitingText = Orbiting...
-				completionText = Stay completed, you may return home now.
-			}
-		}	
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = Duration
+			type = Duration
+			title = Must be crewed for 30 days
+			duration = 30d
+			preWaitText = Transfer to the station in the specified orbit.
+			waitingText = Orbiting...
+			completionText = Stay completed, you may return home now.
+			completeInSequence = true
+		}
+		
+		disableOnStateChange = true
 	}
 	PARAMETER
 	{
@@ -175,7 +183,7 @@ CONTRACT_TYPE
 		vessel = crewCapsule
 
 		completeInSequence = true
-
+		
 		PARAMETER 
 		{
 			name = Crewmembers
@@ -198,10 +206,10 @@ CONTRACT_TYPE
 		name = vesselGroupStationPersist
 		type = VesselParameterGroup
 		title = Keep the station in orbit
-		vessel = spaceStation
-
+		vessel = @/craft
+		
 		completeInSequence = true
-
+		
 		PARAMETER
 		{
 			name = Orbit
@@ -211,15 +219,7 @@ CONTRACT_TYPE
 			targetBody = HomeWorld()
 			title = Keep the station in a stable orbit with a Perigee greater than 250 km and an Apogee less than 2,000 km
 			
-			PARAMETER
-			{
-				name = Duration
-				type = Duration
-				duration =  2m
-				preWaitText = Transfer to the station in the specified orbit.
-				waitingText = Orbiting...
-				completionText = Your station is in a stable orbit.
-			}
 		}
 	}
+
 }

--- a/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/First Space Station.cfg
@@ -2,7 +2,7 @@ CONTRACT_TYPE
 {
 	name = first_spaceStation
 	title = First Space Station
-	group = SpaceStations
+	group = EarthSpaceStation
 	agent = Stations
 
 	description = Design, build, and launch a space station into Earth orbit, Then crew it for a month with at least two crew, and bring the crew safely home. 
@@ -59,7 +59,8 @@ CONTRACT_TYPE
 		notes = The station must include at least 1 Docking Port and support for at least 3 Crew
 		define = @/craft
 		defineList = basicEarthStations
-
+		disableOnStateChange = true
+		
 		PARAMETER
 		{
 			name = NewVessel
@@ -103,7 +104,6 @@ CONTRACT_TYPE
 			title = Reach Orbit with a Perigee greater than 250 km and an Apogee less than 2,000 km
 			hideChildren = true
 		}
-		disableOnStateChange = true
 	}
 	PARAMETER
 	{
@@ -111,7 +111,6 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Bring at least 2 crew to the station
 		define = crewCapsule
-		
 		completeInSequence = true
 		resetChildrenWhenVesselDestroyed = true
 		
@@ -140,6 +139,7 @@ CONTRACT_TYPE
 		vessel = @/craft
 		notes = You can work on other contracts while your crew are working. You are safe to return to Mission Control
 		completeInSequence = true
+		disableOnStateChange = true
 		
 		PARAMETER
 		{
@@ -173,8 +173,6 @@ CONTRACT_TYPE
 			completionText = Stay completed, you may return home now.
 			completeInSequence = true
 		}
-		
-		disableOnStateChange = true
 	}
 	PARAMETER
 	{
@@ -182,7 +180,6 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Return the crew home
 		vessel = crewCapsule
-
 		completeInSequence = true
 		resetChildrenWhenVesselDestroyed = true
 		
@@ -209,7 +206,6 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Keep the station in orbit
 		vessel = @/craft
-		
 		completeInSequence = true
 		
 		PARAMETER

--- a/GameData/RP-0/Contracts/Space Stations/Improved Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Improved Space Station.cfg
@@ -2,7 +2,7 @@ CONTRACT_TYPE
 {
 	name = improved_spaceStation
 	title = Improved Space Station
-	group = SpaceStations
+	group = EarthSpaceStation
 	agent = Stations
 	
 	description = Design, build, and launch an improved space station with power generation, a science lab, and science experiments into Earth orbit. Once this contract is complete, missions to crew this station will be unlocked. This contract is based off of the Skylab and Second Generation Salyut space stations. 
@@ -18,7 +18,7 @@ CONTRACT_TYPE
 	autoAccept = false
 	minExpiry = 0
 	maxExpiry = 0
-	maxCompletions = 0 //Note: Despite maxCompletions being infinite, the advance/reward funds can only be obtained once.
+	maxCompletions = 0 
 	maxSimultaneous = 1
 	deadline = 730 * RP1DeadlineMult() // 2 Years
 	
@@ -55,7 +55,6 @@ CONTRACT_TYPE
 		minCount = 2
 		invertRequirement = true
 	}
-	
 	REQUIREMENT
 	{
 		name = noStation
@@ -64,13 +63,13 @@ CONTRACT_TYPE
 		vessel = @/craft
 		invertRequirement = true
 	}
-	
 	DATA
 	{
 		type = string
 		craft = "improvedSpaceStation"
 		hidden = true
 	}
+	
 	// ************ PARAMETERS ************
 	
 	PARAMETER
@@ -81,6 +80,8 @@ CONTRACT_TYPE
 		notes = The station must include at least 1 Docking Port, have support for at least 3 Crew, a Science Lab, and can generate power.
 		define = @/craft
 		defineList = basicEarthStations
+		
+		disableOnStateChange = true
 		
 		PARAMETER
 		{
@@ -134,7 +135,6 @@ CONTRACT_TYPE
 			title = Reach Orbit with a Perigee greater than 400 km and an Apogee less than 500 km 
 			hideChildren = true
 		}
-		disableOnStateChange = true
 	}
 	
 	PARAMETER
@@ -174,6 +174,7 @@ CONTRACT_TYPE
 		notes = You can work on other contracts while your crew are working. You are safe to return to Mission Control
 
 		completeInSequence = true
+		disableOnStateChange = true
 		
 		PARAMETER 
 		{
@@ -206,7 +207,6 @@ CONTRACT_TYPE
 			completionText = Stay completed, you may return home now.
 			completeInSequence = true
 		}
-		disableOnStateChange = true
 		
 	}
 	PARAMETER
@@ -243,7 +243,7 @@ CONTRACT_TYPE
 {
 	name = first_ISScrew
 	title = Crew your Improved Space Station for 60 days and collect science
-	group = SpaceStations
+	group = EarthSpaceStation
 	agent = Stations
 	
 	description = You have succeeded in crewing your station for a month. Now it's time for you to crew it for longer. Crew your station for 60 days and then return safely. You'll be staying for longer intervals in the future. This mission can be completed 2 times. &br;<b><color=red>Do NOT deorbit the station while you are completing this contract. Otherwise, this contract will fail and you will be forced to redo the Improved Space Station contract</color></b> &br;&br;<b>Number of Contracts Completed: $first_ISScrew_Count</b>
@@ -343,7 +343,8 @@ CONTRACT_TYPE
 		notes = You can work on other contracts while your crew are working. You are safe to return to Mission Control
 
 		completeInSequence = true
-
+		disableOnStateChange = true
+		
 		PARAMETER 
 		{
 			name = Crewmembers
@@ -381,7 +382,6 @@ CONTRACT_TYPE
 			situation = InSpaceLow
 			recoveryMethod = RecoverOrTransmit
 		}
-		disableOnStateChange = true
 	}
 	PARAMETER
 	{
@@ -428,7 +428,7 @@ CONTRACT_TYPE
 {
 	name = second_ISScrew
 	title = Crew your Improved Space Station for 90 days and collect science
-	group = SpaceStations
+	group = EarthSpaceStation
 	agent = Stations
 	
 	description = You have succeeded in crewing your station for 2 months. Now it's time for you to crew it for longer. Crew your station for 90 days and then return safely. This mission can be completed 2 times. Afterwards, you are free to deorbit the station. &br;<b><color=red>Do NOT deorbit the station while you are completing this contract. Otherwise, this contract will fail and you will be forced to redo the Improved Space Station contract</color></b> &br;&br;<b>Number of Contracts Completed: $second_ISScrew_Count</b> 
@@ -447,7 +447,7 @@ CONTRACT_TYPE
 	maxExpiry = 0
 	maxCompletions = 2
 	maxSimultaneous = 1
-	deadline = 365 * RP1DeadlineMult() // 1 year
+	deadline = 0
 	
 	targetBody = HomeWorld()
 	
@@ -476,7 +476,7 @@ CONTRACT_TYPE
 		contractType = first_ISScrew
 		minCount = 2
 	}
-	RREQUIREMENT
+	REQUIREMENT
 	{
 		name = StationExists
 		type = ValidVessel
@@ -532,7 +532,8 @@ CONTRACT_TYPE
 		notes = You can work on other contracts while your crew are working. You are safe to return to Mission Control
 		
 		completeInSequence = true
-
+		disableOnStateChange = true
+		
 		PARAMETER 
 		{
 			name = Crewmembers
@@ -570,7 +571,7 @@ CONTRACT_TYPE
 			situation = InSpaceLow
 			recoveryMethod = RecoverOrTransmit
 		}
-		disableOnStateChange = true
+
 	}
 	PARAMETER
 	{

--- a/GameData/RP-0/Contracts/Space Stations/Improved Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Improved Space Station.cfg
@@ -145,7 +145,8 @@ CONTRACT_TYPE
 		define = crewCapsule
 
 		completeInSequence = true
-
+		resetChildrenWhenVesselDestroyed = true
+		
 		PARAMETER 
 		{
 			name = Crewmembers
@@ -170,6 +171,7 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Keep at least 3 crew aboard the station for 30 days.
 		vessel = @/craft
+		notes = You can work on other contracts while your crew are working. You are safe to return to Mission Control
 
 		completeInSequence = true
 		
@@ -215,7 +217,8 @@ CONTRACT_TYPE
 		vessel = crewCapsule
 
 		completeInSequence = true
-
+		resetChildrenWhenVesselDestroyed = true
+		
 		PARAMETER 
 		{
 			name = Crewmembers
@@ -311,7 +314,8 @@ CONTRACT_TYPE
 		define = crewCapsule
 
 		completeInSequence = true
-
+		resetChildrenWhenVesselDestroyed = true
+		
 		PARAMETER 
 		{
 			name = Crewmembers
@@ -336,6 +340,7 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Keep at least 3 crew aboard the station for 60 days and collect science.
 		vessel = @/station
+		notes = You can work on other contracts while your crew are working. You are safe to return to Mission Control
 
 		completeInSequence = true
 
@@ -386,7 +391,8 @@ CONTRACT_TYPE
 		vessel = crewCapsule
 
 		completeInSequence = true
-
+		resetChildrenWhenVesselDestroyed = true
+		
 		PARAMETER 
 		{
 			name = Crewmembers
@@ -497,7 +503,8 @@ CONTRACT_TYPE
 		define = crewCapsule
 
 		completeInSequence = true
-
+		resetChildrenWhenVesselDestroyed = true
+		
 		PARAMETER 
 		{
 			name = Crewmembers
@@ -522,7 +529,8 @@ CONTRACT_TYPE
 		type = VesselParameterGroup
 		title = Keep at least 3 crew aboard the station for 90 days and collect science.
 		vessel = @/station
-
+		notes = You can work on other contracts while your crew are working. You are safe to return to Mission Control
+		
 		completeInSequence = true
 
 		PARAMETER 
@@ -572,7 +580,8 @@ CONTRACT_TYPE
 		vessel = crewCapsule
 
 		completeInSequence = true
-
+		resetChildrenWhenVesselDestroyed = true
+		
 		PARAMETER 
 		{
 			name = Crewmembers

--- a/GameData/RP-0/Contracts/Space Stations/Improved Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Improved Space Station.cfg
@@ -1,0 +1,606 @@
+CONTRACT_TYPE
+{
+	name = improved_spaceStation
+	title = Improved Space Station
+	group = SpaceStations
+	agent = Stations
+	
+	description = Design, build, and launch an improved space station with power generation, a science lab, and science experiments into Earth orbit. Once this contract is complete, missions to crew this station will be unlocked. This contract is based off of the Skylab and Second Generation Salyut space stations. 
+	
+	synopsis = Launch a larger space station with power generation, a science lab, and science experiments
+	
+	completedMessage = Congratulations! You have proven the viability of larger space stations in Earth Orbit.
+	
+	sortKey = 1510
+	
+	cancellable = true
+	declinable = false
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 0 //Note: Despite maxCompletions being infinite, the advance/reward funds can only be obtained once.
+	maxSimultaneous = 1
+	deadline = 730 * RP1DeadlineMult() // 2 Years
+	
+	targetBody = HomeWorld()
+	
+	// ************ REWARDS ************
+	
+	prestige = Significant // 1.25x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardReputation = 150
+	rewardFunds = 0
+	failureReputation = @rewardReputation
+	failureFunds = @advanceFunds * 0.5
+	
+	// ************ REQUIREMENTS ************
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = EarthSpaceStation
+	}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = first_spaceStation
+	}
+	REQUIREMENT
+	{
+		name = IncompleteContract
+		type = CompleteContract
+		contractType = second_ISScrew
+		minCount = 2
+		invertRequirement = true
+	}
+	
+	REQUIREMENT
+	{
+		name = noStation
+		type = ValidVessel
+		title = Station does not exist
+		vessel = @/craft
+		invertRequirement = true
+	}
+	
+	DATA
+	{
+		type = string
+		craft = "improvedSpaceStation"
+		hidden = true
+	}
+	// ************ PARAMETERS ************
+	
+	PARAMETER
+	{
+		name = vesselGroupLaunch
+		type = VesselParameterGroup
+		title = Put your improved Space Station in Orbit
+		notes = The station must include at least 1 Docking Port, have support for at least 3 Crew, a Science Lab, and can generate power.
+		define = @/craft
+		defineList = basicEarthStations
+		
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Station
+			hideChildren = true
+		}
+		
+		PARAMETER
+		{
+			name = HasCapacity
+			type = HasCrewCapacity
+			minCapacity = 3
+			title = Space for at least 3 crew
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = DockingPort
+			type = PartValidation
+			partModule = ModuleDockingNode
+			minCount = 1
+			title = Have at least 1 Docking Ports
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = HasPower
+			title = Have a positive energy balance
+			type = RP1FixedResourceConsumption
+			resource = ElectricCharge
+			minRate = -1.0
+		}
+		PARAMETER
+		{
+			name = HasScienceLab
+			title = Has a Science Lab
+			type = PartValidation
+			hideChildren = true
+			partModule = ModuleScienceLab
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = 400000
+			maxApA = 500000
+			targetBody = HomeWorld()
+			disableOnStateChange = false
+			title = Reach Orbit with a Perigee greater than 400 km and an Apogee less than 500 km 
+			hideChildren = true
+		}
+		disableOnStateChange = true
+	}
+	
+	PARAMETER
+	{
+		name = vesselGroupCrew
+		type = VesselParameterGroup
+		title = Bring at least 3 crew to the station
+		define = crewCapsule
+
+		completeInSequence = true
+
+		PARAMETER 
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 3
+			title = Have at least 3 crewmembers on board
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Rendezvous
+			type = Rendezvous
+			vessel = @/craft
+			distance = 100
+			title = Rendezvous with the station and dock.
+		}
+	}
+	
+	PARAMETER
+	{
+		name = stayOnStation
+		type = VesselParameterGroup
+		title = Keep at least 3 crew aboard the station for 30 days.
+		vessel = @/craft
+
+		completeInSequence = true
+		
+		PARAMETER 
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 3
+			title = Have at least 3 crewmembers on board
+			hideChildren = true
+			disableOnStateChange = false
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = 400000
+			maxApA = 500000
+			targetBody = HomeWorld()
+			disableOnStateChange = false
+			title = Remain in a Stable Orbit
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = Duration
+			type = Duration
+			duration =  30d
+			preWaitText = Transfer to the station in the specified orbit.
+			waitingText = Orbiting...
+			completionText = Stay completed, you may return home now.
+			completeInSequence = true
+		}
+		disableOnStateChange = true
+		
+	}
+	PARAMETER
+	{
+		name = vesselGroupCrewReturn
+		type = VesselParameterGroup
+		title = Return the crew home
+		vessel = crewCapsule
+
+		completeInSequence = true
+
+		PARAMETER 
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 3
+			title = Have at least 3 crewmembers on board
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = ReturnHome
+			type = ReturnHome
+			targetBody = HomeWorld()
+			title = Return Home Safely
+			hideChildren = true
+			completeInSequence = true
+		}
+	}
+}
+
+CONTRACT_TYPE
+{
+	name = first_ISScrew
+	title = Crew your Improved Space Station for 60 days and collect science
+	group = SpaceStations
+	agent = Stations
+	
+	description = You have succeeded in crewing your station for a month. Now it's time for you to crew it for longer. Crew your station for 60 days and then return safely. You'll be staying for longer intervals in the future. This mission can be completed 2 times. &br;<b><color=red>Do NOT deorbit the station while you are completing this contract. Otherwise, this contract will fail and you will be forced to redo the Improved Space Station contract</color></b> &br;&br;<b>Number of Contracts Completed: $first_ISScrew_Count</b>
+	genericDescription = Crew your station for 60 days and collect science, then return safely.
+	
+	synopsis = Crew your station for 2 months.
+	
+	completedMessage = Congratulations! You have lived on a space station for 60 days. This has given us good data on long term crew survivability in space.
+	
+	sortKey = 1511
+	
+	cancellable = true
+	declinable = false
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 2
+	maxSimultaneous = 1
+	deadline = 0
+	
+	targetBody = HomeWorld()
+	
+	// ************ REWARDS ************
+	
+	prestige = Significant // 1.25x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardReputation = 25
+	rewardFunds = 0
+	failureReputation = @rewardReputation
+	failureFunds = 0
+	
+	// ************ REQUIREMENTS ************
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = EarthSpaceStation
+	}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = improved_spaceStation
+	}
+	REQUIREMENT
+	{
+		name = StationExists
+		type = ValidVessel
+		title = Station exists
+		vessel = @/station
+		checkOnActiveContract = true
+	}
+	DATA
+	{
+		type = string
+		requiredValue = true
+		station = $improvedStation
+		title = The Station exists
+	}
+	// ************ PARAMETERS ************
+	
+	PARAMETER
+	{
+		name = vesselGroupCrew
+		type = VesselParameterGroup
+		title = Bring at least 3 crew to the station
+		define = crewCapsule
+
+		completeInSequence = true
+
+		PARAMETER 
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 3
+			title = Have at least 3 crewmembers on board
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Rendezvous
+			type = Rendezvous
+			vessel = @/station
+			distance = 100
+			title = Rendezvous with the station and dock.
+		}
+	}
+	
+	PARAMETER
+	{
+		name = stayOnStation
+		type = VesselParameterGroup
+		title = Keep at least 3 crew aboard the station for 60 days and collect science.
+		vessel = @/station
+
+		completeInSequence = true
+
+		PARAMETER 
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 3
+			title = Have at least 3 crewmembers on board
+			hideChildren = true
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = 400000
+			maxApA = 500000
+			targetBody = HomeWorld()
+			disableOnStateChange = false
+			title = Remain in a Stable Orbit
+			completeInSequence = true
+		}	
+		PARAMETER
+		{
+			name = Duration
+			type = Duration
+			duration =  60d
+			preWaitText = Transfer to the station in the specified orbit.
+			waitingText = Orbiting...
+			completionText = Stay completed, you may return home now.
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = CollectSci
+			type = CollectScience
+			situation = InSpaceLow
+			recoveryMethod = RecoverOrTransmit
+		}
+		disableOnStateChange = true
+	}
+	PARAMETER
+	{
+		name = vesselGroupCrewReturn
+		type = VesselParameterGroup
+		title = Return the crew home
+		vessel = crewCapsule
+
+		completeInSequence = true
+
+		PARAMETER 
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 3
+			title = Have at least 3 crewmembers on board
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = ReturnHome
+			type = ReturnHome
+			targetBody = HomeWorld()
+			title = Return Home Safely
+			hideChildren = true
+			completeInSequence = true
+		}
+	}
+	
+	BEHAVIOUR
+	{
+		name = IncrementCompletions
+		type = Expression
+		
+		CONTRACT_COMPLETED_SUCCESS
+        {
+            first_ISScrew_Count = $first_ISScrew_Count + 1
+        }
+	}
+}
+
+CONTRACT_TYPE
+{
+	name = second_ISScrew
+	title = Crew your Improved Space Station for 90 days and collect science
+	group = SpaceStations
+	agent = Stations
+	
+	description = You have succeeded in crewing your station for 2 months. Now it's time for you to crew it for longer. Crew your station for 90 days and then return safely. This mission can be completed 2 times. Afterwards, you are free to deorbit the station. &br;<b><color=red>Do NOT deorbit the station while you are completing this contract. Otherwise, this contract will fail and you will be forced to redo the Improved Space Station contract</color></b> &br;&br;<b>Number of Contracts Completed: $second_ISScrew_Count</b> 
+	genericDescription = Crew your station for 90 days and collect science, then return safely.
+	
+	synopsis = Crew your station for 3 months.
+	
+	completedMessage = Congratulations! You have lived on a space station for 90 days. This has given us good data on long term crew survivability in space.
+	
+	sortKey = 1512
+	
+	cancellable = true
+	declinable = false
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 2
+	maxSimultaneous = 1
+	deadline = 365 * RP1DeadlineMult() // 1 year
+	
+	targetBody = HomeWorld()
+	
+	// ************ REWARDS ************
+	
+	prestige = Significant // 1.25x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardReputation = 50
+	rewardFunds = 0
+	failureReputation = @rewardReputation
+	failureFunds = 0
+	
+	// ************ REQUIREMENTS ************
+	
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = EarthSpaceStation
+	}
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = first_ISScrew
+		minCount = 2
+	}
+	RREQUIREMENT
+	{
+		name = StationExists
+		type = ValidVessel
+		title = Station exists
+		vessel = @/station
+		checkOnActiveContract = true
+	}
+
+
+	DATA
+	{
+		type = string
+		requiredValue = true
+		station = $improvedStation
+		title = The Station exists
+	}
+	// ************ PARAMETERS ************
+	
+	PARAMETER
+	{
+		name = vesselGroupCrew
+		type = VesselParameterGroup
+		title = Bring at least 3 crew to the station
+		define = crewCapsule
+
+		completeInSequence = true
+
+		PARAMETER 
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 3
+			title = Have at least 3 crewmembers on board
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Rendezvous
+			type = Rendezvous
+			vessel = @/station
+			distance = 100
+			title = Rendezvous with the station and dock.
+		}
+	}
+	
+	PARAMETER
+	{
+		name = stayOnStation
+		type = VesselParameterGroup
+		title = Keep at least 3 crew aboard the station for 90 days and collect science.
+		vessel = @/station
+
+		completeInSequence = true
+
+		PARAMETER 
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 3
+			title = Have at least 3 crewmembers on board
+			hideChildren = true
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = 400000
+			maxApA = 500000
+			targetBody = HomeWorld()
+			disableOnStateChange = false
+			title = Remain in a Stable Orbit
+			completeInSequence = true
+		}	
+		PARAMETER
+		{
+			name = Duration
+			type = Duration
+			duration =  90d
+			preWaitText = Transfer to the station in the specified orbit.
+			waitingText = Orbiting...
+			completionText = Stay completed, you may return home now.
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = CollectSci
+			type = CollectScience
+			situation = InSpaceLow
+			recoveryMethod = RecoverOrTransmit
+		}
+		disableOnStateChange = true
+	}
+	PARAMETER
+	{
+		name = vesselGroupCrewReturn
+		type = VesselParameterGroup
+		title = Return the crew home
+		vessel = crewCapsule
+
+		completeInSequence = true
+
+		PARAMETER 
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 3
+			title = Have at least 3 crewmembers on board
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = ReturnHome
+			type = ReturnHome
+			targetBody = HomeWorld()
+			title = Return Home Safely
+			hideChildren = true
+			completeInSequence = true
+		}
+	}
+	
+	
+	BEHAVIOUR
+	{
+		name = IncrementCompletions
+		type = Expression
+		
+		CONTRACT_COMPLETED_SUCCESS
+        {
+            second_ISScrew_Count = $second_ISScrew_Count + 1
+        }
+	}
+}

--- a/GameData/RP-0/Contracts/Space Stations/Improved Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Improved Space Station.cfg
@@ -29,7 +29,7 @@ CONTRACT_TYPE
 	prestige = Significant // 1.25x
 	advanceFunds = 0
 	rewardScience = 0
-	rewardReputation = 150
+	rewardReputation = 200
 	rewardFunds = 0
 	failureReputation = @rewardReputation
 	failureFunds = 0
@@ -271,7 +271,7 @@ CONTRACT_TYPE
 	prestige = Significant // 1.25x
 	advanceFunds = 0
 	rewardScience = 0
-	rewardReputation = 25
+	rewardReputation = 100
 	rewardFunds = 0
 	failureReputation = @rewardReputation
 	failureFunds = 0
@@ -456,7 +456,7 @@ CONTRACT_TYPE
 	prestige = Significant // 1.25x
 	advanceFunds = 0
 	rewardScience = 0
-	rewardReputation = 50
+	rewardReputation = 150
 	rewardFunds = 0
 	failureReputation = @rewardReputation
 	failureFunds = 0

--- a/GameData/RP-0/Contracts/Space Stations/Improved Space Station.cfg
+++ b/GameData/RP-0/Contracts/Space Stations/Improved Space Station.cfg
@@ -20,7 +20,7 @@ CONTRACT_TYPE
 	maxExpiry = 0
 	maxCompletions = 0 
 	maxSimultaneous = 1
-	deadline = 730 * RP1DeadlineMult() // 2 Years
+	deadline = 0
 	
 	targetBody = HomeWorld()
 	
@@ -32,7 +32,7 @@ CONTRACT_TYPE
 	rewardReputation = 150
 	rewardFunds = 0
 	failureReputation = @rewardReputation
-	failureFunds = @advanceFunds * 0.5
+	failureFunds = 0
 	
 	// ************ REQUIREMENTS ************
 	REQUIREMENT


### PR DESCRIPTION
Adds a set of 3 contracts based on the Skylab station. 1st contract requires launching a more advanced station and crewing it with 3 crew for 30d. 2nd contract involves crewing for 60d, and 3rd contract involves crewing for 90d. Both 2nd & 3rd contract can be completed twice, with the former intended to be required and the latter optional.

Also allows `Duration` timers to count down while outside the vessel scene, allowing for players to focus on other contracts. (Should a note/popup be added to let players know they can focus on other contracts?)