### PR TITLE
Fix HasCrew being sticky in some contracts

### DIFF
--- a/GameData/RP-0/Contracts/Human Records/CrewedAltRecord.cfg
+++ b/GameData/RP-0/Contracts/Human Records/CrewedAltRecord.cfg
@@ -54,19 +54,33 @@ CONTRACT_TYPE
 
         crewedTargetAltitudeKM = @crewedTargetAltitude * 0.001
     }
-
-    PARAMETER
-    {
-        name = ReachState
-        type = ReachState
-
-        minAltitude = @/crewedTargetAltitude
-    }
-	PARAMETER
+	DATA
 	{
-		name = HasCrew
-		type = HasCrew
-		minCrew = 1
+		type = string
+		craft = "crewAltCraft"
+	}
+
+	PARAMETER
+	{ 
+		name = crewAlt
+		type = VesselParameterGroup
+		title = Reach an altitude of @/crewedTargetAltitude
+		define = @/craft
+		dissassociateVesselsOnContractCompletion = true
+		resetChildrenWhenVesselDestroyed = true
+
+		PARAMETER
+		{
+			name = HasCrew
+			type = HasCrew
+			minCrew = 1
+		}
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+			minAltitude = @/crewedTargetAltitude
+		}
 	}
 
     BEHAVIOUR

--- a/GameData/RP-0/Contracts/Human Records/CrewedCountRecord.cfg
+++ b/GameData/RP-0/Contracts/Human Records/CrewedCountRecord.cfg
@@ -48,12 +48,20 @@ CONTRACT_TYPE
 
         crewedTargetCount = @crewCounts.ElementAt(@crewCountsIndex)
     }
+	
+	DATA
+	{
+		type = string
+		craft = "crewCountCraft"
+	}
 	PARAMETER
 	{
 		name = crewCountInSpace
-		type = All
+		type = VesselParameterGroup
 		title = Have @/crewedTargetCount crew on the same vessel while in space in a stable orbit.
-		
+		define = @/craft
+		dissassociateVesselsOnContractCompletion = true
+		resetChildrenWhenVesselDestroyed = true
 		disableOnStateChange = False
 		
 		PARAMETER

--- a/GameData/RP-0/Contracts/Human Records/CrewedDurationRecord.cfg
+++ b/GameData/RP-0/Contracts/Human Records/CrewedDurationRecord.cfg
@@ -80,12 +80,21 @@ CONTRACT_TYPE
         crewedTargetDurationRew = @crewedDurationsRew.ElementAt(@crewedDurationIndex)
     }
 
+	DATA
+	{
+		type = string
+		craft = "crewDurationCraft"
+	}
+
     PARAMETER
     {
         name = VesselGroup
         type = VesselParameterGroup
         title = Stay in space for @/crewedTargetDuration
-        
+        define = @/craft
+		dissassociateVesselsOnContractCompletion = true
+		resetChildrenWhenVesselDestroyed = true
+		
         PARAMETER
         {
             name = durationInSpace

--- a/GameData/RP-0/Contracts/Human Records/CrewedSpeedRecord.cfg
+++ b/GameData/RP-0/Contracts/Human Records/CrewedSpeedRecord.cfg
@@ -48,19 +48,35 @@ CONTRACT_TYPE
 
         crewedTargetSpeed = @crewedSpeeds.ElementAt(@crewedSpeedIndex)
     }
-
-    PARAMETER
-    {
-        name = ReachState
-        type = ReachState
-
-        minSpeed = @/crewedTargetSpeed
-    }
+	
+	DATA
+	{
+		type = string
+		craft = "crewSpeedCraft"
+	}
+	
 	PARAMETER
 	{
-		name = HasCrew
-		type = HasCrew
-		minCrew = 1
+		name = crewSpeed
+		type = VesselParameterGroup
+		title = Reach a speed of @/crewedTargetSpeed
+		define = @/craft
+		dissassociateVesselsOnContractCompletion = true
+		resetChildrenWhenVesselDestroyed = true
+	
+		PARAMETER
+		{
+			name = ReachState
+			type = ReachState
+
+			minSpeed = @/crewedTargetSpeed
+		}
+		PARAMETER
+		{
+			name = HasCrew
+			type = HasCrew
+			minCrew = 1
+		}
 	}
 
     BEHAVIOUR

--- a/GameData/RP-0/Contracts/X-Planes/CrewedFlight.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedFlight.cfg
@@ -49,6 +49,12 @@ CONTRACT_TYPE
 		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 3 - 0.05, 1), 2) / 1.5607
 		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
+	
+	DATA
+	{
+		type = string
+		craft = "lowAirplane"
+	}
 
 	REQUIREMENT
 	{
@@ -104,7 +110,7 @@ CONTRACT_TYPE
 		name = VesselGroup
 		type = VesselParameterGroup
 		title = Maintain between @ReachAlt/minAltitude and @ReachAlt/maxAltitude m with a crewed aircraft.
-		define = lowAirplane
+		define = @/craft
 		dissassociateVesselsOnContractCompletion = true
 		resetChildrenWhenVesselDestroyed = true
 
@@ -153,7 +159,7 @@ CONTRACT_TYPE
 		name = ReturnVesselGroup
 		type = VesselParameterGroup
 		title = Land/splashdown anywhere
-		vessel = lowAirplane
+		vessel = @/craft
 		hideChildren = true
 
 		PARAMETER
@@ -174,7 +180,7 @@ CONTRACT_TYPE
 		title = Land on the runway with descent angle lower than 10 degrees
 		rewardFunds = Round(@/advanceFunds * 0.3, 100)
 		optional = true
-		vessel = lowAirplane
+		vessel = @/craft
 		hideChildren = true
 
 		PARAMETER

--- a/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmo.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmo.cfg
@@ -60,6 +60,12 @@ CONTRACT_TYPE
 		nextAltHighCrew = (30000 + Min(@/XPlaneHighDifficulty, (@RP0:maxXPlaneDifficultyLevels - 1)) * 5000) / 1000
 		title = Get Altitude
 	}
+	
+	DATA
+	{
+		type = string
+		craft = "crewedSuborbitalCraft"
+	}
 
 	REQUIREMENT
 	{
@@ -135,7 +141,7 @@ CONTRACT_TYPE
 		name = VesselGroup
 		type = VesselParameterGroup
 		title = Reach @/altHighCrew.Print() km with a crewed vessel.
-		define = crewedSuborbitalCraft
+		define = @/craft
 		dissassociateVesselsOnContractCompletion = true
 		resetChildrenWhenVesselDestroyed = true
 
@@ -171,7 +177,7 @@ CONTRACT_TYPE
 		name = ReturnVesselGroup
 		type = VesselParameterGroup
 		title = Land/splashdown anywhere
-		vessel = crewedSuborbitalCraft
+		vessel = @/craft
 		hideChildren = true
 
 		PARAMETER
@@ -192,7 +198,7 @@ CONTRACT_TYPE
 		title = Land on the runway with descent angle lower than 10 degrees
 		rewardFunds = Round(@/advanceFunds * 0.3, 100)
 		optional = true
-		vessel = crewedSuborbitalCraft
+		vessel = @/craft
 		hideChildren = true
 
 		PARAMETER

--- a/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoDifficult.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedHighAtmoDifficult.cfg
@@ -60,6 +60,12 @@ CONTRACT_TYPE
 		nextAltHighCrew = (30000 + Min(@/XPlaneHighDifficulty, (@RP0:maxXPlaneDifficultyLevels - 1)) * 5000) / 1000
 		title = Get Altitude
 	}
+	
+	DATA
+	{
+		type = string
+		craft = "crewedSuborbitalCraft"
+	}
 
 	REQUIREMENT
 	{
@@ -142,7 +148,7 @@ CONTRACT_TYPE
 		name = VesselGroup
 		type = VesselParameterGroup
 		title = Reach @/altHighCrew.Print() km with a crewed vessel.
-		define = crewedSuborbitalCraft
+		define = @/craft
 		dissassociateVesselsOnContractCompletion = true
 		resetChildrenWhenVesselDestroyed = true
 
@@ -178,7 +184,7 @@ CONTRACT_TYPE
 		name = ReturnVesselGroup
 		type = VesselParameterGroup
 		title = Land/splashdown anywhere
-		vessel = crewedSuborbitalCraft
+		vessel = @/craft
 		hideChildren = true
 
 		PARAMETER
@@ -199,7 +205,7 @@ CONTRACT_TYPE
 		title = Land on the runway with descent angle lower than 10 degrees
 		rewardFunds = Round(@/advanceFunds * 0.3, 100)
 		optional = true
-		vessel = crewedSuborbitalCraft
+		vessel = @/craft
 		hideChildren = true
 
 		PARAMETER

--- a/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/CrewedSupersonic.cfg
@@ -47,6 +47,12 @@ CONTRACT_TYPE
 		rewardFactor = Log(Max(@elapsedDays / @expectedDays * 20 - 9, 1), 2) / 3.46
 		rewardFactorPercent = Round(@rewardFactor * 100, 1)
 	}
+	
+	DATA
+	{
+		type = string
+		craft = "supersonicCraft"
+	}
 
 	REQUIREMENT
 	{
@@ -84,7 +90,7 @@ CONTRACT_TYPE
 		name = VesselGroup
 		type = VesselParameterGroup
 		title = Maintain between @HoldSituation/minSpeed m/s and @HoldSituation/maxSpeed m/s in level flight with a crewed jet aircraft.
-		define = supersonicCraft
+		define = @/craft
 		dissassociateVesselsOnContractCompletion = true
 		resetChildrenWhenVesselDestroyed = true
 
@@ -142,7 +148,7 @@ CONTRACT_TYPE
 		name = ReturnVesselGroup
 		type = VesselParameterGroup
 		title = Land/splashdown anywhere
-		vessel = supersonicCraft
+		vessel = @/craft
 		hideChildren = true
 
 		PARAMETER
@@ -163,7 +169,7 @@ CONTRACT_TYPE
 		title = Land on the runway with descent angle lower than 10 degrees
 		rewardFunds = Round(@/advanceFunds * 0.3, 100)
 		optional = true
-		vessel = supersonicCraft
+		vessel = @/craft
 		hideChildren = true
 
 		PARAMETER

--- a/GameData/RP-0/Contracts/X-Planes/RocketPlaneDevelopment.cfg
+++ b/GameData/RP-0/Contracts/X-Planes/RocketPlaneDevelopment.cfg
@@ -156,12 +156,17 @@ CONTRACT_TYPE
 		velocity = @velocities.ElementAt(@index)
 	}
 
+	DATA
+	{
+		type = string
+		craft = "crewedSuborbitalCraft"
+	}
 	PARAMETER
 	{
 		name = VesselGroup
 		type = VesselParameterGroup
 		title = Reach @/altitudeKm km with a crewed vessel.
-		define = crewedSuborbitalCraft
+		define = @/craft
 		dissassociateVesselsOnContractCompletion = true
 		resetChildrenWhenVesselDestroyed = true
 
@@ -220,7 +225,7 @@ CONTRACT_TYPE
 		name = ReturnVesselGroup
 		type = VesselParameterGroup
 		title = Land/splashdown anywhere
-		vessel = crewedSuborbitalCraft
+		vessel = @/craft
 		hideChildren = true
 
 		PARAMETER
@@ -241,7 +246,7 @@ CONTRACT_TYPE
 		title = Land on the runway with descent angle lower than 10 degrees
 		rewardFunds = Round(@/advanceFunds * 0.3, 100)
 		optional = true
-		vessel = crewedSuborbitalCraft
+		vessel = @/craft
 		hideChildren = true
 
 		PARAMETER


### PR DESCRIPTION
Addresses issue in #1722, which was present in both Human Records and X-Plane Contracts. 

Ideally, a change to CC's code in how it deals with in-flight state changes should be implemented, since that is what's causing erroneous parameter completions (which afaik only seems to affect HasCrew). Using `DATA` to store the vessel fixes this without touching CC's code, but I am not sure why it works. 