### PR TITLE
Give Early Film Camera all the slots

### DIFF
--- a/GameData/RP-0/Science/HardDriveConfigs.cfg
+++ b/GameData/RP-0/Science/HardDriveConfigs.cfg
@@ -206,8 +206,7 @@ KERBALISM_HDD_SIZES
 		Photography1
 		{
 			data = 0
-			samples = 3
-			
+			samples = 22
 		}
 
 		Photography2


### PR DESCRIPTION
22 slots covers 11 earth biomes, flying high + space low.

Because it's silly that a camera can't take pictures of trees after having taken pictures of water, grass and rocks; as long as there's film, let it take pictures.

Also because juggling slots is too micromanagey.
There will still be micromanagement if the camera isn't recovered and the recovery part has too few slots, but this won't make it any worse?

(per https://discord.com/channels/319857228905447436/620690446540341261/1048371772753449031 )