### PR TITLE
Correct typo in ECM for RD-252. Part Two: the JSON file

### DIFF
--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -9665,7 +9665,7 @@
         "spacecraft": "R-36",
         "engine_config": "RD219",
         "upgrade": true,
-        "entry_cost_mods": "5000,RD-219-8D713,R36-TP--1966",
+        "entry_cost_mods": "5000,RD-219-8D713,R36-TP-1966",
         "identical_part_name": "",
         "module_tags": []
     },


### PR DESCRIPTION
I missed the JSON file when fixing this in #1875. Now it will stay fixed.