### PR TITLE
Support for new BDB parts in ROEngines

### DIFF
--- a/GameData/RP-0/Tree/ECM-Engines.cfg
+++ b/GameData/RP-0/Tree/ECM-Engines.cfg
@@ -85,6 +85,7 @@
     BE-4 = 54000,StagedMethalox
     BE3 = 0
     BNTR = 400000,PEWEE100-Hydrogen,TurbineReactors
+    C-1 = 5000,HydrazineFuel
     CE-7-5 = 0
     CECE-Base = 80000,RL10B-2,throttlingTP
     CECE-High = 80000,RL10B-2

--- a/GameData/RP-0/Tree/ECM-Parts.cfg
+++ b/GameData/RP-0/Tree/ECM-Parts.cfg
@@ -874,6 +874,7 @@
     ROE-BabySergeantX11-RN = T17-E2
     ROE-BabySergeantX3 = T17-E2
     ROE-BabySergeantX3-RN = T17-E2
+    ROE-C1 = C-1
     ROE-Castor1 = XM-20
     ROE-Castor1-RN = XM-20
     ROE-Castor120 = Castor-120
@@ -948,6 +949,8 @@
     ROE-LargeRadialLC-FASA = 1
     ROE-M1 = M-1-Spec
     ROE-M1SL = M-1SL
+    ROE-MB35 = MB-35
+    ROE-MB60 = MB-60
     ROE-MediumApolloLC = 1
     ROE-MediumApolloLC-FASA = 1
     ROE-MediumLC = 1
@@ -959,6 +962,9 @@
     ROE-Merlin1CV = Merlin1CVac
     ROE-Merlin1D = Merlin1D
     ROE-Merlin1DV = Merlin1DVac
+    ROE-NERVA = NERVA-I
+    ROE-NERVAII = NERVA-II
+    ROE-NERVAXE = NERVA-XE-Hydrogen
     ROE-NK33 = NK-15
     ROE-NK33-RE = NK-15
     ROE-NK43 = NK-15V
@@ -1848,6 +1854,7 @@
     restock-engine-125-valiant = Viking-2
     restock-engine-375-corgi = 10000,RL10C-1
     restock-engine-boar = F-1B
+    restock-engine-cherenkov = RD-0410MID-Hydrogen
     restock-engine-torch = H-1-165K
     restock-fairing-base-0625-1 = 1
     restock-fairing-base-1875-1 = 1

--- a/GameData/RP-0/Tree/TREE-Engines.cfg
+++ b/GameData/RP-0/Tree/TREE-Engines.cfg
@@ -512,6 +512,12 @@
                 %cost = 0
             }
 
+            @CONFIG[C-1]
+            {
+                %techRequired = dockingCrewTransfer
+                %cost = 0
+            }
+
             @CONFIG[CE-7.5]
             {
                 %techRequired = hydrolox1998

--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -13535,6 +13535,17 @@
     RP0conf = true
     @description ^=:$: <b><color=green>From ROEngines mod</color></b>
 }
+@PART[ROE-C1]:FOR[xxxRP0]
+{
+    %TechRequired = dockingCrewTransfer
+    %cost = 25
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From ROEngines mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = EngineLiquidPF }
+
+}
 @PART[ROE-Castor1]:FOR[xxxRP0]
 {
     %TechRequired = solids1958
@@ -14393,6 +14404,30 @@
     %MODULE[ModuleTagList] { tag = Hydrolox }
 
 }
+@PART[ROE-MB35]:FOR[xxxRP0]
+{
+    %TechRequired = hydrolox2009
+    %cost = 585
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From ROEngines mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
+    %MODULE[ModuleTagList] { tag = Hydrolox }
+
+}
+@PART[ROE-MB60]:FOR[xxxRP0]
+{
+    %TechRequired = hydrolox2009
+    %cost = 1000
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From ROEngines mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
+    %MODULE[ModuleTagList] { tag = Hydrolox }
+
+}
 @PART[ROE-MR104]:FOR[xxxRP0]
 {
     %TechRequired = earlyFlightControl
@@ -14551,6 +14586,42 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From ROEngines mod</color></b>
+}
+@PART[ROE-NERVA]:FOR[xxxRP0]
+{
+    %TechRequired = basicNuclearPropulsion
+    %cost = 2100
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From ROEngines mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
+    %MODULE[ModuleTagList] { tag = Nuclear }
+
+}
+@PART[ROE-NERVAII]:FOR[xxxRP0]
+{
+    %TechRequired = improvedNuclearPropulsion
+    %cost = 7200
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From ROEngines mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
+    %MODULE[ModuleTagList] { tag = Nuclear }
+
+}
+@PART[ROE-NERVAXE]:FOR[xxxRP0]
+{
+    %TechRequired = earlyNuclearPropulsion
+    %cost = 1969
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From ROEngines mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
+    %MODULE[ModuleTagList] { tag = Nuclear }
+
 }
 @PART[ROE-NK33]:FOR[xxxRP0]
 {
@@ -31594,6 +31665,18 @@
     @description ^=:$: <b><color=green>From ReStock Plus mod</color></b>
 
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
+
+}
+@PART[restock-engine-cherenkov]:FOR[xxxRP0]
+{
+    %TechRequired = improvedNuclearPropulsion
+    %cost = 433
+    %entryCost = 0
+    RP0conf = true
+    @description ^=:$: <b><color=green>From ReStock Plus mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
+    %MODULE[ModuleTagList] { tag = Nuclear }
 
 }
 @PART[restock-engine-torch]:FOR[xxxRP0]

--- a/GameData/RP-0/Tree/identicalParts.cfg
+++ b/GameData/RP-0/Tree/identicalParts.cfg
@@ -483,8 +483,11 @@
 @PART[ca_argo-mk2]:FOR[xxxRP0] { %identicalParts = SXTHECSRanger,ca_argo-mk2,rn_mariner1_2 }
 @PART[rn_mariner1_2]:FOR[xxxRP0] { %identicalParts = SXTHECSRanger,ca_argo-mk2,rn_mariner1_2 }
 @PART[SXTHECSRanger]:FOR[xxxRP0] { %identicalParts = SXTHECSRanger,ca_argo-mk2,rn_mariner1_2 }
-@PART[ROEE-MB35]:FOR[xxxRP0] { %identicalParts = ROEE-MB35 }
+@PART[ROE-MB35]:FOR[xxxRP0] { %identicalParts = ROE-MB35,ROEE-MB35 }
+@PART[ROEE-MB35]:FOR[xxxRP0] { %identicalParts = ROE-MB35,ROEE-MB35 }
 @PART[ROEE-MB45]:FOR[xxxRP0] { %identicalParts = ROEE-MB45 }
+@PART[ROE-MB60]:FOR[xxxRP0] { %identicalParts = ROE-MB60,ROEE-MB60 }
+@PART[ROEE-MB60]:FOR[xxxRP0] { %identicalParts = ROE-MB60,ROEE-MB60 }
 @PART[FASA_Mercury_LES]:FOR[xxxRP0] { %identicalParts = FASA_Mercury_LES,ROC-MercuryLES,RO_mk1_LES }
 @PART[RO_mk1_LES]:FOR[xxxRP0] { %identicalParts = FASA_Mercury_LES,ROC-MercuryLES,RO_mk1_LES }
 @PART[ROC-MercuryLES]:FOR[xxxRP0] { %identicalParts = FASA_Mercury_LES,ROC-MercuryLES,RO_mk1_LES }

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -1689,6 +1689,27 @@
         "module_tags": []
     },
     {
+        "name": "C-1",
+        "title": "C-1",
+        "description": "",
+        "mod": "Engine_Config",
+        "cost": "0",
+        "entry_cost": "0",
+        "category": "RCS",
+        "info": "",
+        "year": "1968",
+        "technology": "dockingCrewTransfer",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "C1",
+        "upgrade": false,
+        "entry_cost_mods": "5000,HydrazineFuel",
+        "identical_part_name": "",
+        "module_tags": []
+    },
+    {
         "name": "CE-7.5",
         "title": "CE-7.5",
         "description": "",

--- a/Source/Tech Tree/Parts Browser/data/ROEngines.json
+++ b/Source/Tech Tree/Parts Browser/data/ROEngines.json
@@ -1744,6 +1744,29 @@
         "module_tags": []
     },
     {
+        "name": "ROE-C1",
+        "title": "C-1",
+        "description": "",
+        "mod": "ROEngines",
+        "cost": "25",
+        "entry_cost": "0",
+        "category": "RCS",
+        "info": "",
+        "year": "1968",
+        "technology": "dockingCrewTransfer",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "C1",
+        "upgrade": false,
+        "entry_cost_mods": "C-1",
+        "identical_part_name": "",
+        "module_tags": [
+            "EngineLiquidPF"
+        ]
+    },
+    {
         "name": "ROE-Castor1",
         "title": "Castor 1 Radial SRB",
         "description": "Radial Boosters for the TAT and Delta Launch Vehicles",
@@ -3791,6 +3814,54 @@
         ]
     },
     {
+        "name": "ROE-MB35",
+        "title": "MB-35",
+        "description": "",
+        "mod": "ROEngines",
+        "cost": "585",
+        "entry_cost": "0",
+        "category": "HYDROLOX",
+        "info": "",
+        "year": "2009",
+        "technology": "hydrolox2009",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "MB35",
+        "upgrade": false,
+        "entry_cost_mods": "MB-35",
+        "identical_part_name": "MB35",
+        "module_tags": [
+            "EngineLiquidTurbo",
+            "Hydrolox"
+        ]
+    },
+    {
+        "name": "ROE-MB60",
+        "title": "MB-60",
+        "description": "",
+        "mod": "ROEngines",
+        "cost": "1000",
+        "entry_cost": "0",
+        "category": "HYDROLOX",
+        "info": "",
+        "year": "2009",
+        "technology": "hydrolox2009",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "MB60",
+        "upgrade": false,
+        "entry_cost_mods": "MB-60",
+        "identical_part_name": "MB60",
+        "module_tags": [
+            "EngineLiquidTurbo",
+            "Hydrolox"
+        ]
+    },
+    {
         "name": "ROE-MR104",
         "title": "0.44kN Engine (MR-104)",
         "description": "MR-104 Monopropellant Engine family originally provided in-space propulsion for the Voyager 1 and 2 and Magellan missions. Subsequent MR-104 variants provided propulsion for Landsat and NOAA as well as for other U.S. government programs. A variation of this engine (MR-104G) is to be used on the Orion Deep Space Exploration Vehicle.",
@@ -4211,6 +4282,78 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": []
+    },
+    {
+        "name": "ROE-NERVA",
+        "title": "NERVA",
+        "description": "",
+        "mod": "ROEngines",
+        "cost": "2100",
+        "entry_cost": "0",
+        "category": "NTR",
+        "info": "Engine",
+        "year": "1981",
+        "technology": "basicNuclearPropulsion",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "NERVA",
+        "upgrade": false,
+        "entry_cost_mods": "NERVA-I",
+        "identical_part_name": "",
+        "module_tags": [
+            "EngineLiquidTurbo",
+            "Nuclear"
+        ]
+    },
+    {
+        "name": "ROE-NERVAII",
+        "title": "NERVA II",
+        "description": "",
+        "mod": "ROEngines",
+        "cost": "7200",
+        "entry_cost": "0",
+        "category": "NTR",
+        "info": "Engine",
+        "year": "1986",
+        "technology": "improvedNuclearPropulsion",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "NERVAII",
+        "upgrade": false,
+        "entry_cost_mods": "NERVA-II",
+        "identical_part_name": "",
+        "module_tags": [
+            "EngineLiquidTurbo",
+            "Nuclear"
+        ]
+    },
+    {
+        "name": "ROE-NERVAXE",
+        "title": "NERVA XE",
+        "description": "",
+        "mod": "ROEngines",
+        "cost": "1969",
+        "entry_cost": "0",
+        "category": "NTR",
+        "info": "Engine",
+        "year": "1972",
+        "technology": "earlyNuclearPropulsion",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "NERVA_XE",
+        "upgrade": false,
+        "entry_cost_mods": "NERVA-XE-Hydrogen",
+        "identical_part_name": "",
+        "module_tags": [
+            "EngineLiquidTurbo",
+            "Nuclear"
+        ]
     },
     {
         "name": "ROE-NK33",

--- a/Source/Tech Tree/Parts Browser/data/ROEnginesExtended.json
+++ b/Source/Tech Tree/Parts Browser/data/ROEnginesExtended.json
@@ -314,7 +314,7 @@
         "cost": "585",
         "entry_cost": "0",
         "category": "HYDROLOX",
-        "info": "",
+        "info": "Deprecated",
         "year": "2009",
         "technology": "hydrolox2009",
         "ro": true,
@@ -362,7 +362,7 @@
         "cost": "1000",
         "entry_cost": "0",
         "category": "HYDROLOX",
-        "info": "",
+        "info": "Deprecated",
         "year": "2009",
         "technology": "hydrolox2009",
         "ro": true,
@@ -372,7 +372,7 @@
         "engine_config": "MB60",
         "upgrade": false,
         "entry_cost_mods": "MB-60",
-        "identical_part_name": "",
+        "identical_part_name": "MB60",
         "module_tags": [
             "EngineLiquidTurbo",
             "Hydrolox"

--- a/Source/Tech Tree/Parts Browser/data/ReStock_Plus.json
+++ b/Source/Tech Tree/Parts Browser/data/ReStock_Plus.json
@@ -564,6 +564,30 @@
         ]
     },
     {
+        "name": "restock-engine-cherenkov",
+        "title": "RD-0410",
+        "description": "",
+        "mod": "ReStock Plus",
+        "cost": "433",
+        "entry_cost": "0",
+        "category": "NTR",
+        "info": "Engine",
+        "year": "1986",
+        "technology": "improvedNuclearPropulsion",
+        "ro": true,
+        "orphan": false,
+        "rp0_conf": true,
+        "spacecraft": "",
+        "engine_config": "RD0410MID",
+        "upgrade": false,
+        "entry_cost_mods": "RD-0410MID-Hydrogen",
+        "identical_part_name": "",
+        "module_tags": [
+            "EngineLiquidTurbo",
+            "Nuclear"
+        ]
+    },
+    {
         "name": "restock-engine-torch",
         "title": "H-1/RS-27 Series Engine",
         "description": "",


### PR DESCRIPTION
Add support for the new C-1, MB-35/60, NERVA, NERVA II, and NERVA XE parts in ROEngines.

Also config a really nice RD0410 model from RestockPlus.

For https://github.com/KSP-RO/ROEngines/pull/186