### PR TITLE
Hide default engine configs

### DIFF
--- a/GameData/RP-0/Tree/TREE-Engines.cfg
+++ b/GameData/RP-0/Tree/TREE-Engines.cfg
@@ -221,6 +221,7 @@
             {
                 %techRequired = orbitalRocketry1986
                 %cost = 100
+                *@PARTUPGRADE[RFUpgrade_AJ10-118K]/deleteme -= 1
             }
 
             @CONFIG[AJ10-133-LH]
@@ -1802,18 +1803,21 @@
             {
                 %techRequired = orbitalRocketry2004
                 %cost = -20
+                *@PARTUPGRADE[RFUpgrade_Merlin1C]/deleteme -= 1
             }
 
             @CONFIG[Merlin1CVac]
             {
                 %techRequired = orbitalRocketry2009
                 %cost = 5
+                *@PARTUPGRADE[RFUpgrade_Merlin1CVac]/deleteme -= 1
             }
 
             @CONFIG[Merlin1D]
             {
                 %techRequired = orbitalRocketry2009
                 %cost = -30
+                *@PARTUPGRADE[RFUpgrade_Merlin1D]/deleteme -= 1
             }
 
             @CONFIG[Merlin1D+]
@@ -1834,6 +1838,7 @@
             {
                 %techRequired = orbitalRocketry2009
                 %cost = -5
+                *@PARTUPGRADE[RFUpgrade_Merlin1DVac]/deleteme -= 1
             }
 
             @CONFIG[Merlin1DVac+]
@@ -3210,6 +3215,7 @@
             {
                 %techRequired = hydrolox1992
                 %cost = 1600
+                *@PARTUPGRADE[RFUpgrade_RL10A-4N]/deleteme -= 1
             }
 
             @CONFIG[RL10A-5]
@@ -3223,6 +3229,7 @@
             {
                 %techRequired = hydrolox1998
                 %cost = 2800
+                *@PARTUPGRADE[RFUpgrade_RL10B-2]/deleteme -= 1
             }
 
             @CONFIG[RL10C-1]
@@ -4117,6 +4124,7 @@
             {
                 %techRequired = orbitalRocketry1959
                 %cost = 20
+                *@PARTUPGRADE[RFUpgrade_Viking-4]/deleteme -= 1
             }
 
             @CONFIG[Viking-4B]
@@ -4130,6 +4138,7 @@
             {
                 %techRequired = orbitalRocketry1962
                 %cost = 25
+                *@PARTUPGRADE[RFUpgrade_Viking-5C]/deleteme -= 1
             }
 
             @CONFIG[Viking-6]
@@ -4188,6 +4197,7 @@
                 %techRequired = orbitalRocketry1960
                 %cost = 100
                 %description = Engine for proposed Vega stage for NASA Atlas-Vega LV. Superceded by Atlas-Agena once NASA became aware of the USAF's Agena stage.
+                *@PARTUPGRADE[RFUpgrade_X-405H]/deleteme -= 1
             }
 
             @CONFIG[X-405H-3]
@@ -5073,6 +5083,46 @@ PART
 }
 
 !PART[RFUpgrade_engineConfigSource_AJ10-118E]:AFTER[RealismOverhaulEngines]
+{
+}
+
+PARTUPGRADE
+{
+        name = RFUpgrade_AJ10-118K
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = orbitalRocketry1986
+        entryCost = 0
+        cost = 0      
+        title = AJ10_Adv Engine Upgrade: AJ10-118K Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The AJ10_Adv Engine now supports the AJ10-118K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_AJ10-118K
+    engineType = AJ10_Adv
+}
+
+@PART[RFUpgrade_engineConfigSource_AJ10-118K]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[AJ10-118K] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_AJ10-118K]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-118K]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118K]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_AJ10-118K]:AFTER[RealismOverhaulEngines]
 {
 }
 
@@ -10078,6 +10128,126 @@ PART
 
 PARTUPGRADE
 {
+        name = RFUpgrade_Merlin1C
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = orbitalRocketry2004
+        entryCost = 0
+        cost = 0      
+        title = Merlin1 Engine Upgrade: Merlin1C Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The Merlin1 Engine now supports the Merlin1C configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1C
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1C]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1C] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1C]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1C]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1C]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1C]:AFTER[RealismOverhaulEngines]
+{
+}
+
+PARTUPGRADE
+{
+        name = RFUpgrade_Merlin1CVac
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = orbitalRocketry2009
+        entryCost = 0
+        cost = 0      
+        title = Merlin1 Engine Upgrade: Merlin1CVac Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The Merlin1 Engine now supports the Merlin1CVac configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1CVac
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1CVac]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1CVac] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1CVac]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1CVac]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1CVac]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1CVac]:AFTER[RealismOverhaulEngines]
+{
+}
+
+PARTUPGRADE
+{
+        name = RFUpgrade_Merlin1D
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = orbitalRocketry2009
+        entryCost = 0
+        cost = 0      
+        title = Merlin1 Engine Upgrade: Merlin1D Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The Merlin1 Engine now supports the Merlin1D configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1D
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1D]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1D] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1D]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1D]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1D]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1D]:AFTER[RealismOverhaulEngines]
+{
+}
+
+PARTUPGRADE
+{
         name = RFUpgrade_Merlin1D+
         partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
         techRequired = orbitalRocketry2014
@@ -10153,6 +10323,46 @@ PART
 }
 
 !PART[RFUpgrade_engineConfigSource_Merlin1D++]:AFTER[RealismOverhaulEngines]
+{
+}
+
+PARTUPGRADE
+{
+        name = RFUpgrade_Merlin1DVac
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = orbitalRocketry2009
+        entryCost = 0
+        cost = 0      
+        title = Merlin1 Engine Upgrade: Merlin1DVac Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The Merlin1 Engine now supports the Merlin1DVac configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Merlin1DVac
+    engineType = Merlin1
+}
+
+@PART[RFUpgrade_engineConfigSource_Merlin1DVac]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Merlin1DVac] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Merlin1DVac]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1DVac]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1DVac]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Merlin1DVac]:AFTER[RealismOverhaulEngines]
 {
 }
 
@@ -14598,6 +14808,46 @@ PART
 
 PARTUPGRADE
 {
+        name = RFUpgrade_RL10A-4N
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = hydrolox1992
+        entryCost = 0
+        cost = 0      
+        title = RL10 Engine Upgrade: RL10A-4N Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The RL10 Engine now supports the RL10A-4N configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10A-4N
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10A-4N]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10A-4N] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10A-4N]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-4N]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4N]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10A-4N]:AFTER[RealismOverhaulEngines]
+{
+}
+
+PARTUPGRADE
+{
         name = RFUpgrade_RL10A-5
         partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
         techRequired = hydrolox1992
@@ -14633,6 +14883,46 @@ PART
 }
 
 !PART[RFUpgrade_engineConfigSource_RL10A-5]:AFTER[RealismOverhaulEngines]
+{
+}
+
+PARTUPGRADE
+{
+        name = RFUpgrade_RL10B-2
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = hydrolox1998
+        entryCost = 0
+        cost = 0      
+        title = RL10 Engine Upgrade: RL10B-2 Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The RL10 Engine now supports the RL10B-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_RL10B-2
+    engineType = RL10
+}
+
+@PART[RFUpgrade_engineConfigSource_RL10B-2]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[RL10B-2] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_RL10B-2]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10B-2]/MODULE[ModuleEngineConfigs]/CONFIG[RL10B-2]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_RL10B-2]:AFTER[RealismOverhaulEngines]
 {
 }
 
@@ -16638,6 +16928,46 @@ PART
 
 PARTUPGRADE
 {
+        name = RFUpgrade_Viking-4
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = orbitalRocketry1959
+        entryCost = 0
+        cost = 0      
+        title = Viking Engine Upgrade: Viking-4 Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The Viking Engine now supports the Viking-4 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Viking-4
+    engineType = Viking
+}
+
+@PART[RFUpgrade_engineConfigSource_Viking-4]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Viking-4] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Viking-4]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Viking-4]/MODULE[ModuleEngineConfigs]/CONFIG[Viking-4]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Viking-4]:AFTER[RealismOverhaulEngines]
+{
+}
+
+PARTUPGRADE
+{
         name = RFUpgrade_Viking-4B
         partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
         techRequired = orbitalRocketry1961
@@ -16673,6 +17003,46 @@ PART
 }
 
 !PART[RFUpgrade_engineConfigSource_Viking-4B]:AFTER[RealismOverhaulEngines]
+{
+}
+
+PARTUPGRADE
+{
+        name = RFUpgrade_Viking-5C
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = orbitalRocketry1962
+        entryCost = 0
+        cost = 0      
+        title = Viking Engine Upgrade: Viking-5C Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The Viking Engine now supports the Viking-5C configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_Viking-5C
+    engineType = Viking
+}
+
+@PART[RFUpgrade_engineConfigSource_Viking-5C]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[Viking-5C] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_Viking-5C]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Viking-5C]/MODULE[ModuleEngineConfigs]/CONFIG[Viking-5C]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_Viking-5C]:AFTER[RealismOverhaulEngines]
 {
 }
 
@@ -16793,6 +17163,46 @@ PART
 }
 
 !PART[RFUpgrade_engineConfigSource_Vulcain-2]:AFTER[RealismOverhaulEngines]
+{
+}
+
+PARTUPGRADE
+{
+        name = RFUpgrade_X-405H
+        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
+        techRequired = orbitalRocketry1960
+        entryCost = 0
+        cost = 0      
+        title = X405 Engine Upgrade: X-405H Config
+        basicInfo = Engine Performance Upgrade
+        manufacturer = Engine Upgrade
+        deleteme = 1
+        description = The X405 Engine now supports the X-405H configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nEngine for proposed Vega stage for NASA Atlas-Vega LV. Superceded by Atlas-Agena once NASA became aware of the USAF's Agena stage.
+}
+
+PART
+{
+    name = RFUpgrade_engineConfigSource_X-405H
+    engineType = X405
+}
+
+@PART[RFUpgrade_engineConfigSource_X-405H]:AFTER[RealismOverhaulEngines]
+{
+    %MODULE[Module*EngineConfigs] {
+        @name = ModuleEngineConfigs
+        %CONFIG[X-405H] {
+            &specLevel = operational
+        }
+    }
+}
+
+@PARTUPGRADE[RFUpgrade_X-405H]:AFTER[RealismOverhaulEngines]
+{
+    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_X-405H]/MODULE[ModuleEngineConfigs]/CONFIG[X-405H]/specLevel$
+    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
+}
+
+!PART[RFUpgrade_engineConfigSource_X-405H]:AFTER[RealismOverhaulEngines]
 {
 }
 

--- a/GameData/RP-0/Tree/TREE-Engines.cfg
+++ b/GameData/RP-0/Tree/TREE-Engines.cfg
@@ -221,7 +221,6 @@
             {
                 %techRequired = orbitalRocketry1986
                 %cost = 100
-                *@PARTUPGRADE[RFUpgrade_AJ10-118K]/deleteme -= 1
             }
 
             @CONFIG[AJ10-133-LH]
@@ -1803,21 +1802,18 @@
             {
                 %techRequired = orbitalRocketry2004
                 %cost = -20
-                *@PARTUPGRADE[RFUpgrade_Merlin1C]/deleteme -= 1
             }
 
             @CONFIG[Merlin1CVac]
             {
                 %techRequired = orbitalRocketry2009
                 %cost = 5
-                *@PARTUPGRADE[RFUpgrade_Merlin1CVac]/deleteme -= 1
             }
 
             @CONFIG[Merlin1D]
             {
                 %techRequired = orbitalRocketry2009
                 %cost = -30
-                *@PARTUPGRADE[RFUpgrade_Merlin1D]/deleteme -= 1
             }
 
             @CONFIG[Merlin1D+]
@@ -1838,7 +1834,6 @@
             {
                 %techRequired = orbitalRocketry2009
                 %cost = -5
-                *@PARTUPGRADE[RFUpgrade_Merlin1DVac]/deleteme -= 1
             }
 
             @CONFIG[Merlin1DVac+]
@@ -3139,7 +3134,6 @@
             {
                 %techRequired = prototypeHydrolox
                 %cost = 0
-                *@PARTUPGRADE[RFUpgrade_RL10A-1]/deleteme -= 1
             }
 
             @CONFIG[RL10A-3-1]
@@ -3216,7 +3210,6 @@
             {
                 %techRequired = hydrolox1992
                 %cost = 1600
-                *@PARTUPGRADE[RFUpgrade_RL10A-4N]/deleteme -= 1
             }
 
             @CONFIG[RL10A-5]
@@ -3230,7 +3223,6 @@
             {
                 %techRequired = hydrolox1998
                 %cost = 2800
-                *@PARTUPGRADE[RFUpgrade_RL10B-2]/deleteme -= 1
             }
 
             @CONFIG[RL10C-1]
@@ -3558,14 +3550,12 @@
             {
                 %techRequired = orbitalRocketry2014
                 %cost = 0
-                *@PARTUPGRADE[RFUpgrade_Rutherford-SL]/deleteme -= 1
             }
 
             @CONFIG[RutherfordVac]
             {
                 %techRequired = orbitalRocketry2014
                 %cost = 0
-                *@PARTUPGRADE[RFUpgrade_RutherfordVac]/deleteme -= 1
             }
 
             @CONFIG[S-155]
@@ -4127,7 +4117,6 @@
             {
                 %techRequired = orbitalRocketry1959
                 %cost = 20
-                *@PARTUPGRADE[RFUpgrade_Viking-4]/deleteme -= 1
             }
 
             @CONFIG[Viking-4B]
@@ -4141,7 +4130,6 @@
             {
                 %techRequired = orbitalRocketry1962
                 %cost = 25
-                *@PARTUPGRADE[RFUpgrade_Viking-5C]/deleteme -= 1
             }
 
             @CONFIG[Viking-6]
@@ -4200,7 +4188,6 @@
                 %techRequired = orbitalRocketry1960
                 %cost = 100
                 %description = Engine for proposed Vega stage for NASA Atlas-Vega LV. Superceded by Atlas-Agena once NASA became aware of the USAF's Agena stage.
-                *@PARTUPGRADE[RFUpgrade_X-405H]/deleteme -= 1
             }
 
             @CONFIG[X-405H-3]
@@ -4326,7 +4313,6 @@
                 %techRequired = basicRocketryRP0
                 %cost = -50
                 %description = Improved XLR43 with brazed chamber walls and burning 90% Ethanol.
-                *@PARTUPGRADE[RFUpgrade_XLR43-NA-3]/deleteme -= 1
             }
 
             @CONFIG[XLR81-BA-11]
@@ -5087,46 +5073,6 @@ PART
 }
 
 !PART[RFUpgrade_engineConfigSource_AJ10-118E]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
-        name = RFUpgrade_AJ10-118K
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = orbitalRocketry1986
-        entryCost = 0
-        cost = 0      
-        title = AJ10_Adv Engine Upgrade: AJ10-118K Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The AJ10_Adv Engine now supports the AJ10-118K configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_AJ10-118K
-    engineType = AJ10_Adv
-}
-
-@PART[RFUpgrade_engineConfigSource_AJ10-118K]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[AJ10-118K] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_AJ10-118K]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_AJ10-118K]/MODULE[ModuleEngineConfigs]/CONFIG[AJ10-118K]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_AJ10-118K]:AFTER[RealismOverhaulEngines]
 {
 }
 
@@ -10132,126 +10078,6 @@ PART
 
 PARTUPGRADE
 {
-        name = RFUpgrade_Merlin1C
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = orbitalRocketry2004
-        entryCost = 0
-        cost = 0      
-        title = Merlin1 Engine Upgrade: Merlin1C Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The Merlin1 Engine now supports the Merlin1C configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_Merlin1C
-    engineType = Merlin1
-}
-
-@PART[RFUpgrade_engineConfigSource_Merlin1C]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[Merlin1C] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_Merlin1C]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1C]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1C]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_Merlin1C]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
-        name = RFUpgrade_Merlin1CVac
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = orbitalRocketry2009
-        entryCost = 0
-        cost = 0      
-        title = Merlin1 Engine Upgrade: Merlin1CVac Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The Merlin1 Engine now supports the Merlin1CVac configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_Merlin1CVac
-    engineType = Merlin1
-}
-
-@PART[RFUpgrade_engineConfigSource_Merlin1CVac]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[Merlin1CVac] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_Merlin1CVac]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1CVac]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1CVac]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_Merlin1CVac]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
-        name = RFUpgrade_Merlin1D
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = orbitalRocketry2009
-        entryCost = 0
-        cost = 0      
-        title = Merlin1 Engine Upgrade: Merlin1D Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The Merlin1 Engine now supports the Merlin1D configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_Merlin1D
-    engineType = Merlin1
-}
-
-@PART[RFUpgrade_engineConfigSource_Merlin1D]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[Merlin1D] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_Merlin1D]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1D]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1D]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_Merlin1D]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
         name = RFUpgrade_Merlin1D+
         partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
         techRequired = orbitalRocketry2014
@@ -10327,46 +10153,6 @@ PART
 }
 
 !PART[RFUpgrade_engineConfigSource_Merlin1D++]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
-        name = RFUpgrade_Merlin1DVac
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = orbitalRocketry2009
-        entryCost = 0
-        cost = 0      
-        title = Merlin1 Engine Upgrade: Merlin1DVac Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The Merlin1 Engine now supports the Merlin1DVac configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_Merlin1DVac
-    engineType = Merlin1
-}
-
-@PART[RFUpgrade_engineConfigSource_Merlin1DVac]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[Merlin1DVac] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_Merlin1DVac]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Merlin1DVac]/MODULE[ModuleEngineConfigs]/CONFIG[Merlin1DVac]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_Merlin1DVac]:AFTER[RealismOverhaulEngines]
 {
 }
 
@@ -14412,46 +14198,6 @@ PART
 
 PARTUPGRADE
 {
-        name = RFUpgrade_RL10A-1
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = prototypeHydrolox
-        entryCost = 0
-        cost = 0      
-        title = RL10 Engine Upgrade: RL10A-1 Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The RL10 Engine now supports the RL10A-1 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_RL10A-1
-    engineType = RL10
-}
-
-@PART[RFUpgrade_engineConfigSource_RL10A-1]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[RL10A-1] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_RL10A-1]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-1]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-1]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_RL10A-1]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
         name = RFUpgrade_RL10A-3-1
         partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
         techRequired = earlyHydrolox
@@ -14852,46 +14598,6 @@ PART
 
 PARTUPGRADE
 {
-        name = RFUpgrade_RL10A-4N
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = hydrolox1992
-        entryCost = 0
-        cost = 0      
-        title = RL10 Engine Upgrade: RL10A-4N Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The RL10 Engine now supports the RL10A-4N configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_RL10A-4N
-    engineType = RL10
-}
-
-@PART[RFUpgrade_engineConfigSource_RL10A-4N]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[RL10A-4N] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_RL10A-4N]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10A-4N]/MODULE[ModuleEngineConfigs]/CONFIG[RL10A-4N]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_RL10A-4N]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
         name = RFUpgrade_RL10A-5
         partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
         techRequired = hydrolox1992
@@ -14927,46 +14633,6 @@ PART
 }
 
 !PART[RFUpgrade_engineConfigSource_RL10A-5]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
-        name = RFUpgrade_RL10B-2
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = hydrolox1998
-        entryCost = 0
-        cost = 0      
-        title = RL10 Engine Upgrade: RL10B-2 Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The RL10 Engine now supports the RL10B-2 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_RL10B-2
-    engineType = RL10
-}
-
-@PART[RFUpgrade_engineConfigSource_RL10B-2]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[RL10B-2] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_RL10B-2]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RL10B-2]/MODULE[ModuleEngineConfigs]/CONFIG[RL10B-2]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_RL10B-2]:AFTER[RealismOverhaulEngines]
 {
 }
 
@@ -15972,86 +15638,6 @@ PART
 
 PARTUPGRADE
 {
-        name = RFUpgrade_Rutherford-SL
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = orbitalRocketry2014
-        entryCost = 0
-        cost = 0      
-        title = Rutherford-SL Engine Upgrade: Rutherford-SL Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The Rutherford-SL Engine now supports the Rutherford-SL configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_Rutherford-SL
-    engineType = Rutherford-SL
-}
-
-@PART[RFUpgrade_engineConfigSource_Rutherford-SL]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[Rutherford-SL] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_Rutherford-SL]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Rutherford-SL]/MODULE[ModuleEngineConfigs]/CONFIG[Rutherford-SL]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_Rutherford-SL]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
-        name = RFUpgrade_RutherfordVac
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = orbitalRocketry2014
-        entryCost = 0
-        cost = 0      
-        title = RutherfordVac Engine Upgrade: RutherfordVac Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The RutherfordVac Engine now supports the RutherfordVac configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_RutherfordVac
-    engineType = RutherfordVac
-}
-
-@PART[RFUpgrade_engineConfigSource_RutherfordVac]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[RutherfordVac] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_RutherfordVac]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_RutherfordVac]/MODULE[ModuleEngineConfigs]/CONFIG[RutherfordVac]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_RutherfordVac]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
         name = RFUpgrade_S-3D
         partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
         techRequired = orbitalRocketry1958
@@ -17052,46 +16638,6 @@ PART
 
 PARTUPGRADE
 {
-        name = RFUpgrade_Viking-4
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = orbitalRocketry1959
-        entryCost = 0
-        cost = 0      
-        title = Viking Engine Upgrade: Viking-4 Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The Viking Engine now supports the Viking-4 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_Viking-4
-    engineType = Viking
-}
-
-@PART[RFUpgrade_engineConfigSource_Viking-4]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[Viking-4] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_Viking-4]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Viking-4]/MODULE[ModuleEngineConfigs]/CONFIG[Viking-4]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_Viking-4]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
         name = RFUpgrade_Viking-4B
         partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
         techRequired = orbitalRocketry1961
@@ -17127,46 +16673,6 @@ PART
 }
 
 !PART[RFUpgrade_engineConfigSource_Viking-4B]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
-        name = RFUpgrade_Viking-5C
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = orbitalRocketry1962
-        entryCost = 0
-        cost = 0      
-        title = Viking Engine Upgrade: Viking-5C Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The Viking Engine now supports the Viking-5C configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\n
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_Viking-5C
-    engineType = Viking
-}
-
-@PART[RFUpgrade_engineConfigSource_Viking-5C]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[Viking-5C] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_Viking-5C]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_Viking-5C]/MODULE[ModuleEngineConfigs]/CONFIG[Viking-5C]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_Viking-5C]:AFTER[RealismOverhaulEngines]
 {
 }
 
@@ -17287,46 +16793,6 @@ PART
 }
 
 !PART[RFUpgrade_engineConfigSource_Vulcain-2]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
-        name = RFUpgrade_X-405H
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = orbitalRocketry1960
-        entryCost = 0
-        cost = 0      
-        title = X405 Engine Upgrade: X-405H Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The X405 Engine now supports the X-405H configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nEngine for proposed Vega stage for NASA Atlas-Vega LV. Superceded by Atlas-Agena once NASA became aware of the USAF's Agena stage.
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_X-405H
-    engineType = X405
-}
-
-@PART[RFUpgrade_engineConfigSource_X-405H]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[X-405H] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_X-405H]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_X-405H]/MODULE[ModuleEngineConfigs]/CONFIG[X-405H]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_X-405H]:AFTER[RealismOverhaulEngines]
 {
 }
 
@@ -17687,46 +17153,6 @@ PART
 }
 
 !PART[RFUpgrade_engineConfigSource_XLR35-RM-1]:AFTER[RealismOverhaulEngines]
-{
-}
-
-PARTUPGRADE
-{
-        name = RFUpgrade_XLR43-NA-3
-        partIcon = RO-H1-RS27 // FIXME Once we get dedicated model
-        techRequired = basicRocketryRP0
-        entryCost = 0
-        cost = 0      
-        title = LR89 Engine Upgrade: XLR43-NA-3 Config
-        basicInfo = Engine Performance Upgrade
-        manufacturer = Engine Upgrade
-        deleteme = 1
-        description = The LR89 Engine now supports the XLR43-NA-3 configuration for increased performance. Unlock it in the VAB/SPH through the engine configs interface.\n\nImproved XLR43 with brazed chamber walls and burning 90% Ethanol.
-}
-
-PART
-{
-    name = RFUpgrade_engineConfigSource_XLR43-NA-3
-    engineType = LR89
-}
-
-@PART[RFUpgrade_engineConfigSource_XLR43-NA-3]:AFTER[RealismOverhaulEngines]
-{
-    %MODULE[Module*EngineConfigs] {
-        @name = ModuleEngineConfigs
-        %CONFIG[XLR43-NA-3] {
-            &specLevel = operational
-        }
-    }
-}
-
-@PARTUPGRADE[RFUpgrade_XLR43-NA-3]:AFTER[RealismOverhaulEngines]
-{
-    %description = #$description$\nAvailable at specLevel $@PART[RFUpgrade_engineConfigSource_XLR43-NA-3]/MODULE[ModuleEngineConfigs]/CONFIG[XLR43-NA-3]/specLevel$
-    // TODO: could add any number of other useful fields from the CONFIG here. cost? description?
-}
-
-!PART[RFUpgrade_engineConfigSource_XLR43-NA-3]:AFTER[RealismOverhaulEngines]
 {
 }
 

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -674,7 +674,7 @@
         "rp0_conf": true,
         "spacecraft": "Delta K",
         "engine_config": "AJ10_Adv",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "5000, AJ10-118F",
         "identical_part_name": "",
         "module_tags": []
@@ -6077,7 +6077,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "Merlin1",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "15000,MerlinTP",
         "identical_part_name": "",
         "module_tags": []
@@ -6100,7 +6100,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "Merlin1",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "18000,Merlin1C",
         "identical_part_name": "",
         "module_tags": []
@@ -6123,7 +6123,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "Merlin1",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "20000,MerlinDTP",
         "identical_part_name": "",
         "module_tags": []
@@ -6192,7 +6192,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "Merlin1",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "23000,Merlin1D",
         "identical_part_name": "",
         "module_tags": []
@@ -10560,7 +10560,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "RL10",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "37549, HydroloxPumps",
         "identical_part_name": "",
         "module_tags": []
@@ -10801,7 +10801,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "RL10",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "30000,RL10A-4",
         "identical_part_name": "",
         "module_tags": []
@@ -10847,7 +10847,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "RL10",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "80000,RL10A-4-1-2",
         "identical_part_name": "",
         "module_tags": []
@@ -11937,7 +11937,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "Rutherford-SL",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "15000, ElectricPumps",
         "identical_part_name": "",
         "module_tags": []
@@ -11960,7 +11960,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "RutherfordVac",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "5000, Rutherford-SL",
         "identical_part_name": "",
         "module_tags": []
@@ -13938,7 +13938,7 @@
         "rp0_conf": true,
         "spacecraft": "Ariane 1",
         "engine_config": "Viking",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "10000, Viking-2",
         "identical_part_name": "",
         "module_tags": []
@@ -13980,7 +13980,7 @@
         "rp0_conf": true,
         "spacecraft": "Ariane 4",
         "engine_config": "Viking",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "5000, Viking-2B",
         "identical_part_name": "",
         "module_tags": []
@@ -14185,7 +14185,7 @@
         "rp0_conf": true,
         "spacecraft": "",
         "engine_config": "X405",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "10000, PumpReignition, X-405",
         "identical_part_name": "",
         "module_tags": []
@@ -14579,7 +14579,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "LR89",
-        "upgrade": true,
+        "upgrade": false,
         "entry_cost_mods": "5000,Navaho-PhaseIV-TP",
         "identical_part_name": "",
         "module_tags": []

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -674,7 +674,7 @@
         "rp0_conf": true,
         "spacecraft": "Delta K",
         "engine_config": "AJ10_Adv",
-        "upgrade": false,
+        "upgrade": true,
         "entry_cost_mods": "5000, AJ10-118F",
         "identical_part_name": "",
         "module_tags": []
@@ -6077,7 +6077,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "Merlin1",
-        "upgrade": false,
+        "upgrade": true,
         "entry_cost_mods": "15000,MerlinTP",
         "identical_part_name": "",
         "module_tags": []
@@ -6100,7 +6100,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "Merlin1",
-        "upgrade": false,
+        "upgrade": true,
         "entry_cost_mods": "18000,Merlin1C",
         "identical_part_name": "",
         "module_tags": []
@@ -6123,7 +6123,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "Merlin1",
-        "upgrade": false,
+        "upgrade": true,
         "entry_cost_mods": "20000,MerlinDTP",
         "identical_part_name": "",
         "module_tags": []
@@ -6192,7 +6192,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "Merlin1",
-        "upgrade": false,
+        "upgrade": true,
         "entry_cost_mods": "23000,Merlin1D",
         "identical_part_name": "",
         "module_tags": []
@@ -10801,7 +10801,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "RL10",
-        "upgrade": false,
+        "upgrade": true,
         "entry_cost_mods": "30000,RL10A-4",
         "identical_part_name": "",
         "module_tags": []
@@ -10847,7 +10847,7 @@
         "rp0_conf": false,
         "spacecraft": "",
         "engine_config": "RL10",
-        "upgrade": false,
+        "upgrade": true,
         "entry_cost_mods": "80000,RL10A-4-1-2",
         "identical_part_name": "",
         "module_tags": []
@@ -13938,7 +13938,7 @@
         "rp0_conf": true,
         "spacecraft": "Ariane 1",
         "engine_config": "Viking",
-        "upgrade": false,
+        "upgrade": true,
         "entry_cost_mods": "10000, Viking-2",
         "identical_part_name": "",
         "module_tags": []
@@ -13980,7 +13980,7 @@
         "rp0_conf": true,
         "spacecraft": "Ariane 4",
         "engine_config": "Viking",
-        "upgrade": false,
+        "upgrade": true,
         "entry_cost_mods": "5000, Viking-2B",
         "identical_part_name": "",
         "module_tags": []
@@ -14185,7 +14185,7 @@
         "rp0_conf": true,
         "spacecraft": "",
         "engine_config": "X405",
-        "upgrade": false,
+        "upgrade": true,
         "entry_cost_mods": "10000, PumpReignition, X-405",
         "identical_part_name": "",
         "module_tags": []


### PR DESCRIPTION
New ROTank parts were added to the start node instead of unlockParts and have been moved.

Hide engine configs from the tech tree if they are the default config for an engine part from an RO mod. An inconsistency with the Viking-5C is addressed in another open PR. The RD-170 and RD-191 still have some inconsistencies. 

The rest appeared from running the Part Browser. I guess it wasn't properly synced in before?