### PR TITLE
Correct Starting Parts node description

### DIFF
--- a/GameData/RP-0/Tree/RP0TechTree.cfg
+++ b/GameData/RP-0/Tree/RP0TechTree.cfg
@@ -19,7 +19,7 @@
 	{
 		id = unlockParts
 		title = Starting Parts
-		description = These are the parts that you start with after accepting the Unlock Parts contract.
+		description = These are the parts that you start with.
 		cost = 999
 		hideEmpty = False
 		nodeName = unlockParts


### PR DESCRIPTION
Remove "after accepting the Unlock Parts contracts" as the contract doesn't exist anymore.