### PR TITLE
Allow early experiments to run when shrouded

### DIFF
--- a/GameData/RP-0/Science/Experiments/Photography.cfg
+++ b/GameData/RP-0/Science/Experiments/Photography.cfg
@@ -61,7 +61,6 @@ EXPERIMENT_DEFINITION
 		%requires = 
 		%resources = 
 		%experiment_desc = Early film flown on V2 rockets, taking the first photos from space. Can also be used as a reconnaissance camera. Requires physical recovery.
-		allow_shrouded = false
 	}
 }
 

--- a/GameData/RP-0/Science/Experiments/Photography.cfg
+++ b/GameData/RP-0/Science/Experiments/Photography.cfg
@@ -61,6 +61,7 @@ EXPERIMENT_DEFINITION
 		%requires = 
 		%resources = 
 		%experiment_desc = Early film flown on V2 rockets, taking the first photos from space. Can also be used as a reconnaissance camera. Requires physical recovery.
+		allow_shrouded = false
 	}
 }
 

--- a/GameData/RP-0/Science/Experiments/Temperature.cfg
+++ b/GameData/RP-0/Science/Experiments/Temperature.cfg
@@ -64,7 +64,6 @@
 		%requires =
 		%resources =
 		%experiment_desc = An ambient temperature sensor.
-		%allow_shrouded = false
 	}
 }
 


### PR DESCRIPTION
Early suborbital rockets had cutouts for their cameras and other sensors. Lets just pretend we can also add cutouts to fairings for the early experiments. This would open up more possibilities for suborbital rocket design beyond either having a 1.25m section or have fairings that need to be jettisoned in the atmosphere before they can start running experiments.