### PR TITLE
Add Apollo drive configs to ROC BDB Apollo parts

### DIFF
--- a/GameData/RP-0/Science/HardDriveConfigs.cfg
+++ b/GameData/RP-0/Science/HardDriveConfigs.cfg
@@ -418,7 +418,7 @@ KERBALISM_HDD_SIZES
 	}
 }
 
-@PART[mk1-3pod|SSTU-SC-B-CM|SSTU-SC-B-CMX|SSTU-LC2-POD|APOLLO_CM|FASAApollo_CM|bluedog_Apollo_Block2_Capsule|LEM_ASCENT_STAGE|FASALM_AscentStage|bluedog_LEM_Ascent_Cockpit|landerCabinMedium|mk2LanderCan|mk2LanderCabin_v2|SXTLander|mk2Cockpit_Inline|mk2Cockpit_Standard|mk2CrewCabin|rn_va_capsule|t_af_bo|ROC-ApolloCMBlockIII|ROC-ApolloCM|ROC-LEMAscent|ROC-D2MissionModule2]:FOR[RO-KerbalismHardDrives]
+@PART[mk1-3pod|SSTU-SC-B-CM|SSTU-SC-B-CMX|SSTU-LC2-POD|APOLLO_CM|FASAApollo_CM|bluedog_Apollo_Block2_Capsule|LEM_ASCENT_STAGE|FASALM_AscentStage|bluedog_LEM_Ascent_Cockpit|landerCabinMedium|mk2LanderCan|mk2LanderCabin_v2|SXTLander|mk2Cockpit_Inline|mk2Cockpit_Standard|mk2CrewCabin|rn_va_capsule|t_af_bo|ROC-ApolloCMBlockIII|ROC-ApolloCMBDBBlockIII|ROC-ApolloCM|ROC-ApolloCMBDB|ROC-LEMAscent|ROC-LEMAscentBDB|ROC-D2MissionModule2]:FOR[RO-KerbalismHardDrives]
 {
 	!MODULE[HardDrive] {}
 	MODULE


### PR DESCRIPTION
The CMs are already getting sample slots set from crew experiments config but the LEM has no sample slots without this.