### PR TITLE
Correct Phobos and Deimos flyby contract descriptions

### DIFF
--- a/GameData/RP-0/Contracts/Flyby Contracts/Deimos Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Deimos Flyby.cfg
@@ -5,11 +5,11 @@ CONTRACT_TYPE
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Deimos with a closest approach of 45 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Deimos with a closest approach of 45 km or closer.
 
-	synopsis = Flyby Deimos closer than 45 km and transmit science
+	synopsis = Flyby Deimos closer than 45 km
 
-	completedMessage = Congratulations on the flyby! The data is coming in now.
+	completedMessage = Congratulations on the flyby!
 
 	sortKey = 809
 

--- a/GameData/RP-0/Contracts/Flyby Contracts/Phobos Flyby.cfg
+++ b/GameData/RP-0/Contracts/Flyby Contracts/Phobos Flyby.cfg
@@ -5,11 +5,11 @@ CONTRACT_TYPE
 	group = Flybys
 	agent = Federation Aeronautique Internationale
 
-	description = Design and successfully launch a probe on a flyby of Phobos with a closest approach of 45 km or closer, then record observations and transmit.
+	description = Design and successfully launch a probe on a flyby of Phobos with a closest approach of 45 km or closer.
 
-	synopsis = Flyby Phobos closer than 45 km and transmit science
+	synopsis = Flyby Phobos closer than 45 km
 
-	completedMessage = Congratulations on the flyby! The data is coming in now.
+	completedMessage = Congratulations on the flyby!
 
 	sortKey = 808
 


### PR DESCRIPTION
Remove "transmit science" from contract descriptions