### PR TITLE
Remove unused Offset cone tooling

### DIFF
--- a/Source/Tooling/ModuleToolingPTank.cs
+++ b/Source/Tooling/ModuleToolingPTank.cs
@@ -73,7 +73,6 @@ namespace RP0
                 procShape = shapeName switch
                 {
                     "Smooth Cone" => part.Modules["ProceduralShapeBezierCone"],
-                    "Smooth Cone Offset" => part.Modules["ProceduralShapeBezierOffset"],
                     "Cone" => part.Modules["ProceduralShapeCone"],
                     "Fillet Cylinder" => part.Modules["ProceduralShapePill"],
                     "Polygon" => part.Modules["ProceduralShapePolygon"],


### PR DESCRIPTION
The offset cone in ProcParts was merged into the normal smooth cone, so the tooling for that version isn't needed now.

(See https://github.com/KSP-RO/ProceduralParts/pull/328)