### PR TITLE
Remove "Uncrewed" Lunar Impactor contract name

### DIFF
--- a/GameData/RP-0/Contracts/Moon Exploration/Lunar Impactor.cfg
+++ b/GameData/RP-0/Contracts/Moon Exploration/Lunar Impactor.cfg
@@ -1,7 +1,7 @@
 CONTRACT_TYPE
 {
 	name = first_MoonImpact
-	title = Lunar Impactor (Uncrewed)
+	title = Lunar Impactor
 	group = MoonExploration
 
 


### PR DESCRIPTION
Put an end to the crewed impactor jokes. When this contract comes up it should be pretty obvious it "should be" done with a probe since you don't have access to capsules yet