### PR TITLE
X-15 altitude limits

### DIFF
--- a/GameData/RP-0/Tree/CockpitUpgrades.cfg
+++ b/GameData/RP-0/Tree/CockpitUpgrades.cfg
@@ -10,10 +10,29 @@ PARTUPGRADE
 	description = Upgrades the X-1 cockpit to X-2 specification. Service ceiling is increased to 75km.\nAfter paying the entry cost of this upgrade, all freshly built and KCT-edited vessels will acquire it automatically.
 }
 
+PARTUPGRADE
+{
+	name = X15CockpitUpgrade
+	partIcon = Mark1Cockpit
+	// mercury and vostok's node: all the prereqs make sense (life support, flight control, heat shielding,
+	// material science) plus "whatever extra is needed to build an orbit-capable spacecraft".
+	// Could instead add an extra node between hypersonic flight and prototype spaceplanes,
+	// but the idea isn't to encourage orbital X-15 as a viable alternate path; it's to acknowledge
+	// that after unlocking the capsule node AND the x-15 node, an orbital x-15 cockpit won't hurt
+	// game balance that much.
+	techRequired = basicCapsules
+	entryCost = 40000
+	cost = 0
+	title = X-15 cockpit upgrade
+	manufacturer = Generic
+	description = Upgrades the X-15 cockpit for space operation. Service ceiling is (mostly) removed.\nAfter paying the entry cost of this upgrade, all freshly built and KCT-edited vessels will acquire it automatically.
+}
+
 @PART[RP0Nose-Cockpit|X1_Crew|RO-X1Cockpit]:FOR[zRP-0]
 {
 	@MODULE[ModuleUnpressurizedCockpit],*
 	{
+		// X-1A altitude record 27km
 		%crewDeathAltitude = 30000
 
 		UPGRADES
@@ -21,7 +40,30 @@ PARTUPGRADE
 			UPGRADE
 			{
 				name__ = X2CockpitUpgrade
+				// X-2 altitude record 38km: +10km isn't much of an upgrade. We'll step on X-15's territory
+				// a little, it still keeps its spot as karman-line-beater.
 				crewDeathAltitude = 75000
+			}
+		}
+	}
+}
+
+@PART[Mark1Cockpit|Mark2Cockpit]:FOR[zRP-0]
+{
+	@MODULE[ModuleUnpressurizedCockpit],*
+	{
+		// Historical X-15 altitude record is 108km. Give it a bit more, but low enough below 140km
+		// to keep "space low" mostly out of reach.
+		%crewDeathAltitude = 125000
+
+		UPGRADES
+		{
+			UPGRADE
+			{
+				name__ = X15CockpitUpgrade
+				// No way to remove the limit altogether, so just raise it to 1Gm, enough to go anywhere in Earth's SOI.
+				// Nobody would try going interplanetary with it, right?
+				crewDeathAltitude = 1000000000
 			}
 		}
 	}

--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -7132,6 +7132,8 @@
     MODULE
     { name = ModuleNoEVA }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
+    MODULE
+    { name = ModuleUnpressurizedCockpit }
 
 }
 @PART[Mark2Cockpit]:FOR[xxxRP0]
@@ -7146,6 +7148,8 @@
     MODULE
     { name = ModuleNoEVA }
     %MODULE[ModuleTagList] { tag = NoResourceCostMult }
+    MODULE
+    { name = ModuleUnpressurizedCockpit }
 
 }
 @PART[Mars_CO2_Intake_10]:FOR[xxxRP0]

--- a/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
@@ -1108,7 +1108,8 @@
         "module_tags": [
             "Cockpit",
             "NoEVA",
-            "NoResourceCostMult"
+            "NoResourceCostMult",
+            "UnpressurizedCockpit"
         ]
     },
     {
@@ -1135,7 +1136,8 @@
         "module_tags": [
             "Cockpit",
             "NoEVA",
-            "NoResourceCostMult"
+            "NoResourceCostMult",
+            "UnpressurizedCockpit"
         ]
     },
     {


### PR DESCRIPTION
125km to begin with, roughly matching history.
1Gm (because the partmodule has no off switch) in the mercury node, to more or less represent the extra r&d assumed to be necessary to "orbit-rate" a x-15.

Would be nicer if the partmodule did support getting turned off; as is, the in-game info will still say "unpressurized cockpit, crew will die above 1Gm" which is pretty silly.

extra notes:
- x-15 has no 'human-rated' tag, which maybe makes orbital-x15 too much cheaper than mercury; but adding it would also punish "real" x-15.
- x-15 should maybe also get the no-reentry-rated tag to discourage cockpit+shield contraptions; but it'd be a placebo (tested long ago: even with the tag, the shield was enough to let the cockpit survive, probably just thanks to the extra drag)
