### PR TITLE
XLR35-RM-1 subconfig price reduction

### DIFF
--- a/GameData/RP-0/Tree/TREE-Engines.cfg
+++ b/GameData/RP-0/Tree/TREE-Engines.cfg
@@ -5096,7 +5096,7 @@
             @CONFIG[XLR35-RM-1]
             {
                 %techRequired = earlyRocketry
-                %cost = -100
+                %cost = 100
                 %description = Modified XLR11 used on RTV-A-2 Hiroc missile in Project MX-774. Higher performance, single use. Includes gimbal assembly.
                 *@PARTUPGRADE[RFUpgrade_XLR35-RM-1]/deleteme -= 1
             }

--- a/GameData/RP-0/Tree/TREE-Engines.cfg
+++ b/GameData/RP-0/Tree/TREE-Engines.cfg
@@ -5096,8 +5096,8 @@
             @CONFIG[XLR35-RM-1]
             {
                 %techRequired = earlyRocketry
-                %cost = 200
-                %description = Modified XLR11 used on RTV-A-2 Hiroc missile in Project MX-774. Higher performance. Includes gimbal assembly.
+                %cost = -100
+                %description = Modified XLR11 used on RTV-A-2 Hiroc missile in Project MX-774. Higher performance, single use. Includes gimbal assembly.
                 *@PARTUPGRADE[RFUpgrade_XLR35-RM-1]/deleteme -= 1
             }
 


### PR DESCRIPTION
Any reason why XLR35-RM-1 XLR11 subconfig should add +200f to the engine price, which already is quite high, sitting at 300 thanks to a human-rated, spaceplane natue of the original config? The combined cost is, like, **more than even RD108 costs**, for a second. If anything, it should be exactly the opposite: disposable variant of the engine, speculatively optimized for mass production.
Looking at similar-ish engines in game RN, like RD-200 or Gamma 4, pricepoint of ~200 cr for a disposable four-chambered gimballed turbopump motor looks plausible. No historical sources exist on real unit price AFAIK, since historically it was a one-off prototype, and they wouldn't account for speculative serial production anyway, so balance takes the point.
And from the point of balance, 500cr disposable motor with less than mediocre parameters looks useless. Completely and utterly. Meanwhile, 200cr engine could be useful in at least some theoretical applications, like building a rocket for downrange milestone?