### PR TITLE
Fix ordering of PF tech level patch

### DIFF
--- a/GameData/RP-0/Tree/PFTechLevels.cfg
+++ b/GameData/RP-0/Tree/PFTechLevels.cfg
@@ -66,7 +66,7 @@ PARTUPGRADE
 	description = You can now use 2010s advanced composite monocoque fairings. The new minimum density is 0.040, compared with 0.042 at the previous tech level. NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock. 
 }
 
-@PART:HAS[@MODULE[ProceduralFairingSide]]:FOR[RealismOverhaul]
+@PART:HAS[@MODULE[ProceduralFairingSide]]:AFTER[RealismOverhaul]
 {
 	@MODULE[ProceduralFairingSide]
 	{


### PR DESCRIPTION
Tested on my system: MM.CC looks right now (`density = 0.18`) and a new career had the correct behaviour.