### PR TITLE
First draft of spaceplane program and contracts

### DIFF
--- a/GameData/RP-0/Contracts/Groups.cfg
+++ b/GameData/RP-0/Contracts/Groups.cfg
@@ -113,10 +113,18 @@ CONTRACT_GROUP
 	}
 	CONTRACT_GROUP
 	{
+		name = EarlySpacePlanes
+		displayName = Spaceplane Development
+		minVersion = 1.12.2
+		sortKey = 23
+		agent = Exploration
+	}
+	CONTRACT_GROUP
+	{
 		name = CrewedLunar
 		displayName = Crewed Lunar Exploration
 		minVersion = 1.12.2
-		sortKey = 23
+		sortKey = 24
 		agent = Federation Aeronautique Internationale
 	}
 	CONTRACT_GROUP
@@ -124,7 +132,7 @@ CONTRACT_GROUP
 		name = EarthSpaceStation
 		displayName = Earth Space Station
 		minVersion = 1.12.2
-		sortKey = 24
+		sortKey = 25
 		agent = Stations
 	}
 	CONTRACT_GROUP
@@ -132,7 +140,7 @@ CONTRACT_GROUP
 		name = MartianSurfaceExploration
 		displayName = Mars Surface Exploration
 		minVersion = 1.12.2
-		sortKey = 25
+		sortKey = 26
 		agent = Exploration
 	}
 	CONTRACT_GROUP
@@ -140,7 +148,7 @@ CONTRACT_GROUP
 		name = VenusSurfaceExp
 		displayName = Venus Surface Exploration
 		minVersion = 1.12.2
-		sortKey = 26
+		sortKey = 27
 		agent = Exploration
 	}
 	CONTRACT_GROUP
@@ -149,14 +157,14 @@ CONTRACT_GROUP
 		displayName = Small Bodies Flyby
 		agent = Exploration
 		minVersion = 1.12.2
-		sortKey = 27
+		sortKey = 28
 	}
 	CONTRACT_GROUP
 	{
 		name = MercuryExploration
 		displayName = Mercury Exploration
 		minVersion = 1.12.2
-		sortKey = 28
+		sortKey = 29
 		agent = Exploration
 	}
 	CONTRACT_GROUP
@@ -164,7 +172,7 @@ CONTRACT_GROUP
 		name = AsteroidExploration
 		displayName = Asteroid Exploration
 		minVersion = 1.12.2
-		sortKey = 29
+		sortKey = 30
 		agent = Exploration
 	}
 	CONTRACT_GROUP
@@ -172,7 +180,7 @@ CONTRACT_GROUP
 		name = JupiterObservation
 		displayName = Jupiter Observation
 		minVersion = 1.12.2
-		sortKey = 30
+		sortKey = 31
 		agent = Exploration
 	}
 	CONTRACT_GROUP
@@ -180,7 +188,7 @@ CONTRACT_GROUP
 		name = JupiterMoonLandings
 		displayName = Jovian Moon Landings
 		minVersion = 1.12.2
-		sortKey = 31
+		sortKey = 32
 		agent = Surveys
 	}
 	CONTRACT_GROUP
@@ -188,7 +196,7 @@ CONTRACT_GROUP
 		name = SaturnObservation
 		displayName = Saturn Observation
 		minVersion = 1.12.2
-		sortKey = 32
+		sortKey = 33
 		agent = Exploration
 	}
 	CONTRACT_GROUP
@@ -196,7 +204,7 @@ CONTRACT_GROUP
 		name = SaturnMoonLandings
 		displayName = Saturine Moon Landings
 		minVersion = 1.12.2
-		sortKey = 33
+		sortKey = 34
 		agent = Surveys
 	}
 	CONTRACT_GROUP
@@ -204,7 +212,7 @@ CONTRACT_GROUP
 		name = OuterPlanetFlyby
 		displayName = Outer Planet FLybys
 		minVersion = 1.12.2
-		sortKey = 34
+		sortKey = 35
 		agent = Exploration
 	}
 	CONTRACT_GROUP
@@ -212,7 +220,7 @@ CONTRACT_GROUP
 		name = OuterGasGiantSurvey
 		displayName = Outer Gas Giant Survey
 		minVersion = 1.12.2
-		sortKey = 35
+		sortKey = 36
 		agent = Surveys
 	}
 	CONTRACT_GROUP
@@ -220,7 +228,7 @@ CONTRACT_GROUP
 		name = PlutoLandings
 		displayName = Plutonian Landings
 		minVersion = 1.12.2
-		sortKey = 36
+		sortKey = 37
 		agent = Surveys
 	}
 	CONTRACT_GROUP
@@ -228,7 +236,7 @@ CONTRACT_GROUP
 		name = LunarHabitation
 		displayName = Lunar Habitation
 		minVersion = 1.12.2
-		sortKey = 37
+		sortKey = 38
 		agent = Base Construction
 	}
 	CONTRACT_GROUP
@@ -236,7 +244,7 @@ CONTRACT_GROUP
 		name = CrewedMarsExp
 		displayName = Crewed Mars Exploration
 		minVersion = 1.12.2
-		sortKey = 38
+		sortKey = 39
 		agent = Exploration
 	}
 	CONTRACT_GROUP
@@ -244,7 +252,7 @@ CONTRACT_GROUP
 		name = CrewedVenusExp
 		displayName = Crewed Venus Exploration
 		minVersion = 1.12.2
-		sortKey = 39
+		sortKey = 40
 		agent = Exploration
 	}
 	CONTRACT_GROUP
@@ -252,7 +260,7 @@ CONTRACT_GROUP
 		name = CrewedExploration
 		displayName = Crewed Solar System Exploration
 		minVersion = 1.12.2
-		sortKey = 40
+		sortKey = 41
 		agent = Exploration
 	}
 	CONTRACT_GROUP
@@ -260,7 +268,7 @@ CONTRACT_GROUP
 		name = Records
 		displayName = Records
 		minVersion = 1.12.2
-		sortKey = 41
+		sortKey = 42
 		agent = Federation Aeronautique Internationale
 	}
 	CONTRACT_GROUP
@@ -268,7 +276,7 @@ CONTRACT_GROUP
 		name = HumanRecords
 		displayName = Human Records
 		minVersion = 1.12.2
-		sortKey = 42
+		sortKey = 43
 		agent = Federation Aeronautique Internationale
 	}
 

--- a/GameData/RP-0/Contracts/Spaceplanes/DockingPlane.cfg
+++ b/GameData/RP-0/Contracts/Spaceplanes/DockingPlane.cfg
@@ -1,0 +1,117 @@
+CONTRACT_TYPE
+{
+	name = first_SpaceplaneDocking
+	title = First Docking by Spaceplane
+	group = EarlySpacePlanes
+	agent = Federation Aeronautique Internationale
+
+	description = A use for space shuttles is orbital servicing, docking to an existing satellite and performing repairs, like the Space Shuttle did to fix the Hubble Space Telescope. Also, docking is necessary to bring crew to space stations. Perform the first docking between a spaceplane and another spacecraft.&br;&br;<b><color=white>NOTE: You can not select this contract and 'First Docking' at the same time. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b><color=red>NOTE: This contract requires a horizontal landing on the space center runway.</color> If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.</b>
+
+	synopsis = Perform a Docking of two vessels in orbit of Earth, then bring one back to a runway landing
+
+	completedMessage = Nice Work! Docking capability will make our spaceplanes much more useful.
+
+	sortKey = 614
+
+	cancellable = false
+	declinable = false
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 0
+
+	targetBody = HomeWorld()
+
+
+	// ************ REWARDS ************
+	prestige = Trivial       // 1.0x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardFunds = 0
+	failureFunds = 0
+	rewardReputation = 180
+	failureReputation = @rewardReputation
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = CrewedSpaceplaneDev
+	}
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = SpaceplaneRendezvous
+	}
+	
+	REQUIREMENT
+	{
+		name = DockingResearched
+		type = TechResearched
+		tech = earlyDocking
+		title = Must have researched Early Docking Procedures
+	}
+	
+	REQUIREMENT
+	{
+		name = NotCapsule
+		type = AcceptContract
+		contractType = first_Docking
+		invertRequirement = True
+	}
+
+	PARAMETER
+	{
+		name = VesselGroup
+		type = VesselParameterGroup
+		title = Dock to another spacecraft while in orbit.
+		define = dockingSpacecraft
+
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = @targetBody.AtmosphereAltitude()
+			title = Orbit @targetBody
+			disableOnStateChange = true
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Docking
+			type = Docking
+			title = Dock two spacecraft in orbit
+			hideChildren = true
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = HorizontalLanding
+			type = HorizontalLanding
+			descentAngle = 10
+			hideChildren = true
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return Home Safely
+			hideChildren = true
+			completeInSequence = true
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Spaceplanes/FirstPlaneOrbit.cfg
+++ b/GameData/RP-0/Contracts/Spaceplanes/FirstPlaneOrbit.cfg
@@ -1,0 +1,120 @@
+CONTRACT_TYPE
+{
+	name = first_SpaceplaneOrbit
+	title = First Orbital Spaceplane Flight
+	group = EarlySpacePlanes
+	agent = Federation Aeronautique Internationale
+
+	description = Putting a human into orbit around the Earth is a major milestone in spaceplane development.  Such a spaceplane needs to be capable of both extended operation in space, like traditional spacecraft, but also atmospheric flight at speeds up to 7km/s. The task requires a reliable launch system and many hours of research and engineering to pull off. Before committing to the goal, ensure you have the time to research, design, and build a craft capable of putting a human into a 150 km orbit for at least one full orbit; there is a hard deadline and the penalties for failure are steep. Single-person orbital spaceplanes were not historically built, but a number of concepts were studied and X-20 Dyna-Soar (1966 planned, Titan III) even began construction, paving the way for later more capable vehicles.&br;&br;<b><color=red>NOTE: Unlike capsule missions, this contract requires a horizontal landing on the space center runway.</color> If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.</b>&br;&br;<b>HINT: Launching slightly northwards (if in the Northern Hemisphere) instead of due East will put the launch site back under your track after a small number of orbits, reducing crossrange requirements.</b>&br;&br;<b><color=red>NOTE: Completing this contract will cause the 'Suborbital Spaceplane (Crewed)' contracts to become unavailable. If it is accepted then it will automatically fail.</color></b>
+
+	synopsis = Send a person into orbit and return safely to a runway landing
+
+	completedMessage = Crew landed safely after the mission--congratulations!
+
+	sortKey = 609
+
+	cancellable = false
+	declinable = false
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 0
+
+	targetBody = HomeWorld()
+
+
+	// ************ REWARDS ************
+	prestige = Trivial       // 1.0x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardFunds = 0
+	failureFunds = 0
+	rewardReputation = 240 // 20% more than capsule, because landing is harder
+	failureReputation = @rewardReputation
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = CrewedSpaceplaneDev
+	}
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = first_OrbitRecover
+		title = Completed Reach Orbital Speed & Return Safely to Earth Contract
+	}
+	
+	REQUIREMENT
+	{
+		name = AcceptContract
+		type = AcceptContract
+		contractType = CrewedSpaceplaneSuborbital
+		invertRequirement = true
+	}
+
+	PARAMETER
+	{
+		name = CrewedSpaceplaneOrbit
+		type = VesselParameterGroup
+		title = Crewed Spaceplane in Orbit
+		define = CrewedSpaceplaneOrbit
+
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = OneCrew
+			type = HasCrew
+			minCrew = 1
+			maxCrew = 1
+			title = Have 1 crewmember on board
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = 150000
+			targetBody = HomeWorld()
+			disableOnStateChange = true
+
+			PARAMETER
+			{
+				name = Duration
+				type = Duration
+				duration = 1h
+				preWaitText = Reach specified orbit.
+				waitingText = Completing orbit...
+				completionText = Orbit completed, you may fire retros when ready.
+			}
+		}
+		PARAMETER
+		{
+			name = HorizontalLanding
+			type = HorizontalLanding
+			descentAngle = 10
+			hideChildren = true
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return Home Safely
+			hideChildren = true
+			completeInSequence = true
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Spaceplanes/OrbitalPlane1.cfg
+++ b/GameData/RP-0/Contracts/Spaceplanes/OrbitalPlane1.cfg
@@ -1,0 +1,175 @@
+CONTRACT_TYPE
+{
+	name = OrbitalSpaceplane1
+	title = Orbital Spaceplane (One Crew)
+	group = EarlySpacePlanes
+
+	description = Single-person orbital spaceplanes were not historically built, but a number of concepts were studied and X-20 Dyna-Soar (1966 planned, Titan III) even began construction, paving the way for later more capable vehicles. Design, build, and launch a spaceplane that remains for @/NoOfOrbits orbits and return the crew safely back to Earth.&br;&br;<b><color=white>NOTE: You can not select this contract and the Orbital Flight (One Crew) or Orbital Spaceplane with Maneuvers and 2+ Crew contract. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b><color=red>NOTE: This contract requires a horizontal landing on the space center runway.</color> If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target. <color=red>Make sure to plan your orbit to allow re-entry in the right place.</color></b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
+	
+	genericDescription = Launch a crewed spacecraft carrying one person into orbit for a routine mission for the specified duration and land safely on the runway.
+
+	synopsis = Fly a single-person LEO Orbital mission in a spaceplane.
+
+	completedMessage = Crew landed safely after the mission--congratulations!
+
+	sortKey = 610
+
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 0
+	maxSimultaneous = 1
+	deadline = 0
+
+	targetBody = HomeWorld()
+
+
+	// ************ REWARDS ************
+	prestige = Trivial       // 1.0x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardFunds = 0
+	failureFunds = 0
+	rewardReputation = 180 // 20% more than capsule, because landing is harder
+	failureReputation = @rewardReputation
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = CrewedSpaceplaneDev
+	}
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = first_SpaceplaneOrbit
+	}
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = OrbitalSpaceplane2
+		invertRequirement = true
+	}
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = OrbitalSpaceplane3
+		invertRequirement = true
+	}
+	
+	REQUIREMENT
+	{
+		name = NotCapsule
+		type = AcceptContract
+		contractType = OrbitalFlight1
+		invertRequirement = True
+	}
+	
+	DATA
+	{
+		type = int
+		NoOfOrbits = Random(1, 8) * 3
+		title = How many orbits?
+	}
+	DATA
+	{
+		type = Double
+		DurDouble = 5400 * @NoOfOrbits
+		title = How much time in orbit?
+	}
+	DATA
+	{
+		type = Duration
+		title = Duration
+		Duration = @DurDouble
+		title = Total Duration
+	}
+	
+	DATA
+	{
+		type = int
+		index = $OrbitalSpaceplane1_Count + 0
+	}
+
+	BEHAVIOUR
+	{
+		name = IncrementTheCount
+		type = Expression
+		
+		CONTRACT_COMPLETED_SUCCESS
+		{
+			OrbitalSpaceplane1_Count = $OrbitalSpaceplane1_Count + 1
+		}
+	}
+
+	// ************ PARAMETERS ************
+	
+	PARAMETER
+	{
+		name = VesselGroup
+		type = VesselParameterGroup
+		title = Crewed Orbital
+	
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = OneCrew
+			type = HasCrew
+			minCrew = 1
+			title = Have 1 crewmember on board
+			hideChildren = true
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = 150000 + Round(Random(0, 55000), 10000)
+			maxApA = 400000 + Round(Random(-100000, 200000), 1000)
+			targetBody = HomeWorld()
+			disableOnStateChange = true
+			
+			PARAMETER
+			{
+				name = Duration
+				type = Duration
+				duration = @/Duration
+				preWaitText = Reach specified orbit.
+				waitingText = Orbiting...
+				completionText = Orbits completed, you may fire retros when ready.
+			}
+		}
+		PARAMETER
+		{
+			name = HorizontalLanding
+			type = HorizontalLanding
+			descentAngle = 10
+			hideChildren = true
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return Home Safely
+			hideChildren = true
+			completeInSequence = true
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Spaceplanes/OrbitalPlane2.cfg
+++ b/GameData/RP-0/Contracts/Spaceplanes/OrbitalPlane2.cfg
@@ -1,0 +1,241 @@
+CONTRACT_TYPE
+{
+	name = OrbitalSpaceplane2
+	title = Orbital Spaceplane with Maneuvers and 2+ Crew
+	group = EarlySpacePlanes
+
+
+	description = Putting two people into space in the same spaceplane opens the door to a range of new activities and opportunities. Such a spacecraft must remain in orbit with its crew @/DurationText days and return them safely to Earth.&br;&br;<b><color=white>NOTE: You can not select this contract and 'Orbital Flight with Maneuvers and 2+ Crew' at the same time. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b><color=red>NOTE: This contract requires a horizontal landing on the space center runway.</color> If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.</b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
+
+	genericDescription = Launch a spaceplane with two people onboard into orbit for a routine mission for the specified number of days, perform the required orbit change, and then return safely home to a runway landing.
+
+	synopsis = Fly a two-plus-person LEO Orbital mission in a spaceplane.
+
+	completedMessage = Crew landed safely after the mission--congratulations!
+
+	sortKey = 611
+
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 0
+	maxSimultaneous = 1
+	deadline = 0
+
+	targetBody = HomeWorld()
+
+
+	// ************ REWARDS ************
+	prestige = Trivial       // 1.0x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardFunds = 0
+	failureFunds = 0
+	rewardReputation = 240 // 20% more than capsule, because landing is harder
+	failureReputation = @rewardReputation
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = CrewedSpaceplaneDev
+	}
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = OrbitalSpaceplane1
+	}
+	
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = OrbitalSpaceplane3
+		invertRequirement = true
+	}
+	
+	REQUIREMENT
+	{
+		name = NotCapsule
+		type = AcceptContract
+		contractType = OrbitalFlight2
+		invertRequirement = True
+	}
+
+	DATA
+	{
+		type = Duration
+		title = Duration
+		FirstDuration = Round(Random(1d, 4d), 1d)
+		title = How long in first orbit?
+	}
+	
+	DATA
+	{
+		type = int
+		startPeA = 150000 + Round(Random(0, 55000), 10000)
+		title = Starting PeA
+	}
+	
+	DATA
+	{
+		type = int
+		startApA = 225000 + Round(Random(0, 105000), 25000)
+		title = Starting ApA
+	}
+	
+	DATA
+	{
+		type = double
+		SecondDurationDouble = Round(Random(86400, 518400), 86400)
+		title = How long in 2nd orbit?
+	}
+	
+	DATA
+	{
+		type = Duration
+		title = Duration
+		SecondDuration = @SecondDurationDouble
+	}
+	
+	DATA
+	{
+		type = int
+		endApA = @startApA + Round(Random(150000, 800000), 25000)
+		title = 2nd Orbit ApA
+	}
+	
+	DATA
+	{
+		type = double
+		DurationText = (@FirstDuration + @SecondDuration) / 86400
+		title = Total Duration of Mission
+	}
+	
+	DATA
+	{
+		type = int
+		index = $OrbitalSpaceplane2_Count + 0
+	}
+
+	BEHAVIOUR
+	{
+		name = IncrementTheCount
+		type = Expression
+		
+		CONTRACT_COMPLETED_SUCCESS
+		{
+			OrbitalSpaceplane2_Count = $OrbitalSpaceplane2_Count + 1
+		}
+	}
+
+	// ************ PARAMETERS ************
+	
+	PARAMETER
+	{
+		name = VesselGroup
+		type = VesselParameterGroup
+		title = Crewed Orbital
+		completeInSequence = true
+	
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+
+		PARAMETER
+		{
+			name = TwoCrew
+			type = HasCrew
+			minCrew = 2
+			title = Have 2 crewmembers on board
+			hideChildren = true
+			disableOnStateChange = true    // Probably to prevent the timers from getting reset when EVAing a naut
+		}
+
+		PARAMETER
+		{
+			name = Orbit1Wrapper
+			title = Complete orbit 1
+			type = All
+			disableOnStateChange = true
+			completeInSequence = true
+
+			PARAMETER
+			{
+				name = Orbit
+				type = Orbit
+				minPeA = @/startPeA
+				minApA = @/startApA
+				maxApA = @minApA + 100000
+				targetBody = HomeWorld()
+			}
+
+			PARAMETER
+			{
+				name = Duration
+				type = Duration
+				duration =  @/FirstDuration
+				preWaitText = Stay in specified orbit for
+				waitingText = Orbiting...
+				completionText = Orbits completed, you may alter your orbit now.
+			}
+		}
+
+		PARAMETER
+		{
+			name = Orbit2Wrapper
+			title = Complete orbit 2
+			type = All
+			disableOnStateChange = true
+			completeInSequence = true
+		
+			PARAMETER
+			{
+				name = Orbit2
+				type = Orbit
+				minPeA = @/startPeA
+				minApA = @/endApA
+				maxApA = @minApA + 200000
+				targetBody = HomeWorld()
+			}
+			
+			PARAMETER
+			{
+				name = Duration2
+				type = Duration
+				duration =  @/SecondDuration
+				preWaitText = Stay in specified orbit for
+				waitingText = Orbiting...
+				completionText = Orbits completed, you may fire retros when ready.
+			}
+		}
+
+		PARAMETER
+		{
+			name = HorizontalLanding
+			type = HorizontalLanding
+			descentAngle = 10
+			hideChildren = true
+			completeInSequence = true
+		}
+
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return Home Safely
+			hideChildren = true
+			completeInSequence = true
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Spaceplanes/OrbitalPlane3.cfg
+++ b/GameData/RP-0/Contracts/Spaceplanes/OrbitalPlane3.cfg
@@ -1,0 +1,175 @@
+CONTRACT_TYPE
+{
+	name = OrbitalSpaceplane3
+	title = Orbital Spaceplane with at Least Three Crew
+	group = EarlySpacePlanes
+
+
+	description = The goal and realization of putting three (or more) crew on orbit at the same time begins the era of the space shuttle and ready access to LEO. These craft should be able to support at least three crew and prove that they can stay in orbit for @/DurationText days before returning to a runway landing. The U.S. Space Shuttle (1981, STS) performed this mission, while the Soviet Буран (1988, Energia) was designed to do the same but made only one, unmanned, orbital flight before cancellation.&br;&br;<b><color=white>NOTE: You can not select this contract and 'Orbital Flight with at Least Three Crew' at the same time. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b><color=red>NOTE: This contract requires a horizontal landing on the space center runway.</color> If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.</b>&br;&br;<b>Number of Contracts Completed: @index / unlimited</b>
+	
+	genericDescription = Launch a spacecraft with at least three people onboard into orbit for a routine mission for the required number of days and return safely home to a runway landing.
+
+	synopsis = Fly a three-person LEO Orbital mission in a spaceplane.
+
+	completedMessage = Crew landed safely after the mission--congratulations!
+
+	sortKey = 612
+
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 0
+	maxSimultaneous = 1
+	deadline = 0
+
+	targetBody = HomeWorld()
+
+
+	// ************ REWARDS ************
+	prestige = Trivial       // 1.0x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardFunds = 0
+	failureFunds = 0
+	rewardReputation = 300 // 20% more than capsule, because landing is harder
+	failureReputation = @rewardReputation
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = CrewedSpaceplaneDev
+	}
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = OrbitalSpaceplane2
+	}
+	
+	REQUIREMENT
+	{
+		name = NotCapsule
+		type = AcceptContract
+		contractType = OrbitalFlight3
+		invertRequirement = True
+	}
+	
+	DATA
+	{
+		type = Duration
+		title = Duration
+		Duration = Round(Random(7d, 14d), 1d)
+		title = Duration
+	}
+	DATA
+	{
+		type = int
+		DurationText = double(@Duration) / 86400
+		title = Duration
+	}
+	DATA
+	{
+		type = int
+		startPeA = 200000 + Round(Random(0, 100000), 25000)
+		title = Perigee
+	}
+	DATA
+	{
+		type = int
+		startApA = 300000 + Round(Random(0, 200000), 25000)
+		title = Apogee
+	}
+	DATA
+	{
+		type = double
+		Eccentricity = 0.002
+		title = Eccentricity
+	}
+	
+	DATA
+	{
+		type = int
+		index = $OrbitalSpaceplane3_Count + 0
+	}
+
+	BEHAVIOUR
+	{
+		name = IncrementTheCount
+		type = Expression
+		
+		CONTRACT_COMPLETED_SUCCESS
+		{
+			OrbitalSpaceplane3_Count = $OrbitalSpaceplane3_Count + 1
+		}
+	}
+
+	// ************ PARAMETERS ************
+	
+	PARAMETER
+	{
+		name = VesselGroup
+		type = VesselParameterGroup
+		title = Crewed Orbital
+	
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = TwoCrew
+			type = HasCrew
+			minCrew = 3
+			title = Have at least 3 crewmembers on board
+			hideChildren = true
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = @/startPeA
+			maxApA = @/startApA
+			maxEccentricity = @/Eccentricity
+			targetBody = HomeWorld()
+			disableOnStateChange = true
+			
+			PARAMETER
+			{
+				name = Duration
+				type = Duration
+				duration = @/Duration
+				preWaitText = Reach specified orbit.
+				waitingText = Orbiting...
+				completionText = Orbits completed, you may fire retros when ready.
+			}
+		}
+
+		PARAMETER
+		{
+			name = HorizontalLanding
+			type = HorizontalLanding
+			descentAngle = 10
+			hideChildren = true
+			completeInSequence = true
+		}
+		
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return Home Safely
+			hideChildren = true
+			completeInSequence = true
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Spaceplanes/RendezvousPlane.cfg
+++ b/GameData/RP-0/Contracts/Spaceplanes/RendezvousPlane.cfg
@@ -1,0 +1,120 @@
+CONTRACT_TYPE
+{
+	name = SpaceplaneRendezvous
+	title = First Rendezvous by Spaceplane
+	group = EarlySpacePlanes
+	agent = Federation Aeronautique Internationale
+
+	description = One mission planned for reconnaissance spaceplanes such as Dyna-Soar II was to rendezvous with and investigate satellites on orbit. Using your own knowledge of orbital mechanics, bring two craft to within 100 meters of each other while in orbit around Earth. At least one of the spacecraft must be a newly launched spaceplane which subsequently lands on the runway.&br;&br;<b><color=white>NOTE: You can not select this contract and 'First Rendezvous' at the same time. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b><color=red>NOTE: This contract requires a horizontal landing on the space center runway.</color> If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.</b>
+
+	synopsis = Perform the First Rendezvous of a spaceplane with another spacecraft
+
+	completedMessage = Congratulations! By accomplishing the first rendezvous, it opens up the possibilities of what our spaceplanes can do while in orbit.
+
+	sortKey = 613
+
+	cancellable = false
+	declinable = false
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 0
+
+	targetBody = HomeWorld()
+
+
+	// ************ REWARDS ************
+	prestige = Trivial       // 1.0x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardFunds = 0
+	failureFunds = 0
+	rewardReputation = 180
+	failureReputation = @rewardReputation
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = CrewedSpaceplaneDev
+	}
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = first_SpaceplaneOrbit
+	}
+	
+	REQUIREMENT
+	{
+		name = NotCapsule
+		type = AcceptContract
+		contractType = Rendezvous
+		invertRequirement = True
+	}
+
+	PARAMETER
+	{
+		name = Rendezvous
+		type = VesselParameterGroup
+		title = First Spaceplane Rendezvous
+		define = SpaceplaneRendezvous
+
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = HasCrew
+			type = HasCrew
+			minCrew = 1
+			maxCrew = 99
+			title = Have at least 1 crewmember on board
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Orbit
+			type = Orbit
+			minPeA = @targetBody.AtmosphereAltitude()
+			title = Orbit @targetBody
+			disableOnStateChange = true
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = Rendezvous
+			type = RP1Rendezvous
+			distance = 100
+			relativeSpeed = 0.5
+			title = Rendezvous two craft in Orbit (closer than 100m, relative speed less than 0.5m/s)
+			hideChildren = true
+			disableOnStateChange = true
+		}
+		PARAMETER
+		{
+			name = HorizontalLanding
+			type = HorizontalLanding
+			descentAngle = 10
+			hideChildren = true
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return Home Safely
+			hideChildren = true
+			completeInSequence = true
+		}
+	}
+}

--- a/GameData/RP-0/Contracts/Spaceplanes/SuborbitalPlaneCrewed.cfg
+++ b/GameData/RP-0/Contracts/Spaceplanes/SuborbitalPlaneCrewed.cfg
@@ -1,0 +1,138 @@
+CONTRACT_TYPE
+{
+	name = CrewedSpaceplaneSuborbital
+	title = Suborbital Spaceplane Flight (Crewed)
+	group = EarlySpacePlanes
+
+
+	description = Crewed suborbital flights are used as a safer prelude to an orbital mission, for research, or to set non-orbital altitude records. Send any number of crew above @VesselGroup/ReachAlt/minAltitude meters and land on the runway to satisfy the requirements of this mission. Historical missions used the X-15 (1963, B-52), and SpaceShipOne (2004, White Knight).<b><color=white>NOTE: You can not select this contract and 'First Orbital Spaceplane Flight', 'X-Planes (Suborbital)', or 'Suborbital Flight (Crewed)' at the same time. If you select the other contract while this is active, this will automatically fail.</color></b>&br;&br;<b><color=red>NOTE: This contract requires a horizontal landing on the space center runway.</color> If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.</b>&br;&br;<b>Number of Contracts Completed: @index / @maxCompletions</b>
+	
+	genericDescription = Launch a crewed spaceplane with at least one person aboard above the required height and return safely home to a runway landing.
+
+	synopsis = Send a crewed spaceplane on a suborbital flight
+
+	completedMessage = Congratulations! The crew has landed safely and we put another person in space.
+
+	sortKey = 602
+
+	cancellable = true
+	declinable = true
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 3
+	maxSimultaneous = 1
+	deadline = 0
+
+	targetBody = HomeWorld()
+
+
+	// ************ REWARDS ************
+	prestige = Trivial       // 1.0x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardFunds = 0
+	failureFunds = 0
+	rewardReputation = 72 // 20% more than capsule, because landing is harder
+	failureReputation = @rewardReputation
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = CrewedSpaceplaneDev
+	}
+
+	REQUIREMENT
+	{
+		name = CompleteContract
+		type = CompleteContract
+		contractType = first_SpaceplaneOrbit
+		invertRequirement = true
+	}
+	
+	REQUIREMENT
+	{
+		name = NotXPlanesSuborbital
+		type = AcceptContract
+		contractType = XPlanesSuborbital
+		invertRequirement = True
+	}
+	
+	REQUIREMENT
+	{
+		name = NotCapsuleSuborbital
+		type = AcceptContract
+		contractType = CrewedSuborbital
+		invertRequirement = True
+	}
+
+	DATA
+	{
+		type = int
+		index = $CrewedSpaceplaneSuborbital_Count + 0
+	}
+
+	BEHAVIOUR
+	{
+		name = IncrementTheCount
+		type = Expression
+		
+		CONTRACT_COMPLETED_SUCCESS
+		{
+			CrewedSpaceplaneSuborbital_Count = $CrewedSpaceplaneSuborbital_Count + 1
+		}
+	}
+
+	// ************ PARAMETERS ************
+	
+	PARAMETER
+	{
+		name = VesselGroup
+		type = VesselParameterGroup
+		title = Suborbital Flight
+
+		PARAMETER
+		{
+			name = NewVessel
+			type = NewVessel
+			title = Launch a New Vessel
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = OneCrew
+			type = HasCrew
+			minCrew = 1
+			title = Have at least 1 crewmember on board
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = ReachAlt
+			type = ReachState
+			minAltitude = Round(Random(140000, 200000), 10000)
+			disableOnStateChange = true
+			title = Reach @minAltitude meters
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = HorizontalLanding
+			type = HorizontalLanding
+			descentAngle = 10
+			hideChildren = true
+			completeInSequence = true
+		}
+		PARAMETER
+		{
+			name = ReturnHome
+			type = RP1ReturnHome
+			title = Return Home Safely
+			hideChildren = true
+			completeInSequence = true
+		}
+	}
+}

--- a/GameData/RP-0/Programs/Programs.cfg
+++ b/GameData/RP-0/Programs/Programs.cfg
@@ -469,6 +469,49 @@ RP0_PROGRAM
 
 RP0_PROGRAM
 {
+	name = CrewedSpaceplaneDev
+	title = Crewed Spaceplane Development
+	description = Spaceplanes potentially offer considerable advantages over capsules as a way to send people to orbit; in particular the controlled re-entry and runway landing makes recovery much simpler and cheaper. Proponents also cite the possibility of using aerodynamic lift to perform plane changes with less propellant. NOTE: This has contracts, but they have not been tested or balanced.
+	requirementsPrettyText = Complete 'X-Plane Research', and the contract 'Reach Orbital Speed & Return Safely to Earth' from the Crewed Orbit program.
+	objectivesPrettyText = Complete the program by successfully docking a spaceplane to another vessel in orbit.
+	nominalDurationYears = 10
+	baseFunding = 6000000
+	fundingCurve = BackloadedFundingCurve
+	repDeltaOnCompletePerYearEarly = 400
+	repPenaltyPerYearLate = 400
+
+	REQUIREMENTS
+	{
+		complete_program = EarlyXPlanes
+		// this will force you to have at least started the CrewedOrbit program
+		// we put it here because first_SpaceplaneOrbit requires it
+		complete_contract = first_OrbitRecover
+	}
+
+	OBJECTIVES
+	{
+		complete_contract = first_SpaceplaneOrbit
+		complete_contract = SpaceplaneRendezvous
+		complete_contract = first_SpaceplaneDocking
+	}
+
+	OPTIONALS
+	{
+		OrbitalPlane1 = true
+		OrbitalPlane2 = true
+		OrbitalPlane3 = true
+		CrewedSpaceplaneSuborbital = true
+	}
+	
+	CONFIDENCECOSTS
+	{
+		Normal = 2500
+		Fast = 7500
+	}
+}
+
+RP0_PROGRAM
+{
 	name = EarlyInnerPlanetProbes
 	title = Early Inner Planet Probes 
 	description = TODO: write up a program description. This program tasks you with exploring Venus and Mars. Though these may be Earth's closest neighbors, the distance between us and them still averages in the hundreds of millions of kilometers. Staying in contact with these probes will require advances in communication technology. Maintaining functionality and power over such great distances and long times will present new challenges in spacecraft design.


### PR DESCRIPTION
I've tested that the program and contracts are present in-game but that's about all.  And I have no idea how to balance things for NotBudgets so I just took the capsule equivalent contract rewards and added 20%.

Note that the way I've done this, the program isn't an alternative to `CrewedOrbit`, because it requires completing the orbital re-entry contract.  So instead it's either a follow-on or a parallel development.  And I've blocked taking both the capsule and spaceplane version of a given contract simultaneously, so you can't get paid twice for one mission, but there's no reason you can't use your spaceplane to complete `CrewedOrbit` contracts if it's ready in time.