### PR TITLE
Remove the hacky cosmic ray sci experiment and make contracts use RP1CollectScience parameter instead

### DIFF
--- a/GameData/RP-0/Contracts/Early Satellites (Heavy)/FirstScienceSat-Heavy.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites (Heavy)/FirstScienceSat-Heavy.cfg
@@ -139,14 +139,13 @@ CONTRACT_TYPE
 			
 			PARAMETER
 			{
-				name = CollectScience
-				type = CollectScience
+				name = RP1CollectScience
+				type = RP1CollectScience
 				targetBody = HomeWorld()
 				situation = InSpaceLow
-				recoveryMethod = RecoverOrTransmit
-				title = Transmit Cosmic Ray Science from Low/Medium Earth Orbit
-				hideChildren = true
 				experiment = RP0cosmicRay1
+				fractionComplete = 0.01
+				title = Transmit 1 day's worth (1%) of Cosmic Ray Science from Low/Medium Earth Orbit
 			}
 		}
 	}

--- a/GameData/RP-0/Contracts/Early Satellites (Light)/FirstScienceSat.cfg
+++ b/GameData/RP-0/Contracts/Early Satellites (Light)/FirstScienceSat.cfg
@@ -131,14 +131,13 @@ CONTRACT_TYPE
 			
 			PARAMETER
 			{
-				name = CollectScience
-				type = CollectScience
+				name = RP1CollectScience
+				type = RP1CollectScience
 				targetBody = HomeWorld()
 				situation = InSpaceLow
-				recoveryMethod = RecoverOrTransmit
-				title = Transmit Cosmic Ray Science from Low/Medium Earth Orbit
-				hideChildren = true
 				experiment = RP0cosmicRay1
+				fractionComplete = 0.01
+				title = Transmit 1 day's worth (1%) of Cosmic Ray Science from Low/Medium Earth Orbit
 			}
 		}
 	}

--- a/GameData/RP-0/Parts/Science/US2.cfg
+++ b/GameData/RP-0/Parts/Science/US2.cfg
@@ -176,7 +176,7 @@
 	MODULE
 	{
 		name = Experiment
-		experiment_id = RP0cosmicRay1_5
+		experiment_id = RP0cosmicRay1
 		experiment_desc = A geiger-muller counter. Used to study the radiation environment; requires an eccentric orbit to study radiation belts and altitude-based variation.
 	}
 	MODULE
@@ -235,7 +235,7 @@
 			{
 			  type = Experiment
 			  id_field = experiment_id
-			  id_value = RP0cosmicRay1_5
+			  id_value = RP0cosmicRay1
 			}
 			MODULE
 			{

--- a/GameData/RP-0/Science/Configure.cfg
+++ b/GameData/RP-0/Science/Configure.cfg
@@ -28,7 +28,7 @@
 	MODULE
 	{
 		name = Experiment
-		experiment_id = RP0cosmicRay1_5
+		experiment_id = RP0cosmicRay1
 		experiment_desc = A geiger-muller counter. Used to study the radiation environment; requires an eccentric orbit to study radiation belts and altitude-based variation.
 	}
 	MODULE
@@ -211,7 +211,7 @@
 			{
 			  type = Experiment
 			  id_field = experiment_id
-			  id_value = RP0cosmicRay1_5
+			  id_value = RP0cosmicRay1
 			}
 			MODULE
 			{

--- a/GameData/RP-0/Science/Experiments/CosmicRay.cfg
+++ b/GameData/RP-0/Science/Experiments/CosmicRay.cfg
@@ -1,70 +1,41 @@
 //==================================================================================//
-//  DUMMY COSMIC RAY SCIENCE FOR FSO								//
+//  COSMIC RAY SCIENCE 1															//
 //==================================================================================//
 
 EXPERIMENT_DEFINITION
 {
-    id = RP0cosmicRay1
-    title = Cosmic Ray Science
-    baseValue = 0.1
-    scienceCap = 0.1
-    dataScale = 0.0018 //2 b/s
-    requireAtmosphere = False
-    situationMask = 48
-    biomeMask = 0
+	id = RP0cosmicRay1
+	title = Cosmic Ray Science
+	baseValue = 10
+	scienceCap = 10
+	dataScale = 1.9656 //2 b/s
+	requireAtmosphere = False
+	situationMask = 48
+	biomeMask = 0
 
-    RESULTS
-    {
-        default = The cosmic ray radiation data from the Geiger-Muller tube is recorded.
-    }
+	RESULTS
+	{
+		default = The cosmic ray radiation data from the Geiger-Muller tube is recorded.
+	}
 
-    KERBALISM_EXPERIMENT
-    {
+	KERBALISM_EXPERIMENT
+	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
-		IncludeExperiment = 
-    }
+	}
 }
 
-
-//==================================================================================//
-//  COSMIC RAY SCIENCE 1																//
-//==================================================================================//
-
-EXPERIMENT_DEFINITION
-{
-    id = RP0cosmicRay1_5
-    title = Cosmic Ray Science
-    baseValue = 10
-    scienceCap = 10
-    dataScale = 1.9656 //2 b/s
-    requireAtmosphere = False
-    situationMask = 48
-    biomeMask = 0
-
-    RESULTS
-    {
-        default = The cosmic ray radiation data from the Geiger-Muller tube is recorded.
-    }
-
-    KERBALISM_EXPERIMENT
-    {
-		// sample mass in tons. if undefined or 0, the experiment produce a file
-		SampleMass = 0
-		IncludeExperiment = RP0cosmicRay1
-    }
-}
 //ROK
 // ============================================================================
 // Replacing stock experiments
 // ============================================================================
-@PART[*]:HAS[@MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1_5]]]:FOR[RP-0-Kerbalism]
+@PART[*]:HAS[@MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1]]]:FOR[RP-0-Kerbalism]
 {
-	!MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1_5]]	{}
+	!MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1]] {}
 	MODULE
 	{
 		name = Experiment
-		experiment_id = RP0cosmicRay1_5
+		experiment_id = RP0cosmicRay1
 	}
 }
 
@@ -75,7 +46,7 @@ EXPERIMENT_DEFINITION
 // ============================================================================
 @PART[*]:HAS[@MODULE[Experiment]]:AFTER[RP-0-Kerbalism]
 {
-	@MODULE[Experiment]:HAS[#experiment_id[RP0cosmicRay1_5]]
+	@MODULE[Experiment]:HAS[#experiment_id[RP0cosmicRay1]]
 	{
 		%ec_rate = 0.0001
 		%data_rate = 1.9656 //2 b/s
@@ -92,31 +63,30 @@ EXPERIMENT_DEFINITION
 //Cosmic Ray tier 2: Scintillation Counter Cosmic Ray Telescopes used on many spacecraft
 EXPERIMENT_DEFINITION
 {
-    id = RP0cosmicRay2
-    title = Cosmic Ray Science 2
-    baseValue = 30
-    scienceCap = 30
-    dataScale = 39
-    requireAtmosphere = False
-    situationMask = 48
-    biomeMask = 0
+	id = RP0cosmicRay2
+	title = Cosmic Ray Science 2
+	baseValue = 30
+	scienceCap = 30
+	dataScale = 39
+	requireAtmosphere = False
+	situationMask = 48
+	biomeMask = 0
 
-    RESULTS
-    {
-        default = The cosmic ray radiation data from the Scintillation Counter Cosmic Ray Telescope has been collected.
-    }
-    
-    KERBALISM_EXPERIMENT
-    {
+	RESULTS
+	{
+		default = The cosmic ray radiation data from the Scintillation Counter Cosmic Ray Telescope has been collected.
+	}
+	
+	KERBALISM_EXPERIMENT
+	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
-		IncludeExperiment = RP0cosmicRay1_5
-    }
+	}
 }
 //ROK
 @PART[*]:HAS[@MODULE[ModuleScienceExperiment]:HAS[#experimentID[RP0cosmicRay2]]]:FOR[RP-0-Kerbalism]
 {
-	!MODULE[ModuleScienceExperiment]:HAS[#experimentID[RP0cosmicRay2]]	{}
+	!MODULE[ModuleScienceExperiment]:HAS[#experimentID[RP0cosmicRay2]] {}
 	MODULE
 	{
 		name = Experiment
@@ -146,7 +116,7 @@ EXPERIMENT_DEFINITION
 	MODULE
 	{
 		name = DMModuleScienceAnimateGeneric
-		experimentID = RP0cosmicRay1_5
+		experimentID = RP0cosmicRay1
 		
 		animationName = needle
 		experimentAnimation = true
@@ -237,21 +207,21 @@ EXPERIMENT_DEFINITION
 // ============================================================================
 @PART[RO-ScintillationCounter]:BEFORE[RP-0-Kerbalism]
 {
-	!MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1_5]]	{}
+	!MODULE[DMModuleScienceAnimateGeneric]:HAS[#experimentID[RP0cosmicRay1]] {}
 	MODULE
-    {
-        name = ModuleScienceExperiment
-        experimentID = RP0cosmicRay2
-        experimentActionName = Log Radiation
-        resetActionName = Discard Data
-        reviewActionName = Review Stored Data
-        useStaging = False
-        useActionGroups = True
-        hideUIwhenUnavailable = True
-        rerunnable = True
-        xmitDataScalar = 1
-        usageReqMaskInternal = 1
-        usageReqMaskExternal = 4
+	{
+		name = ModuleScienceExperiment
+		experimentID = RP0cosmicRay2
+		experimentActionName = Log Radiation
+		resetActionName = Discard Data
+		reviewActionName = Review Stored Data
+		useStaging = False
+		useActionGroups = True
+		hideUIwhenUnavailable = True
+		rerunnable = True
+		xmitDataScalar = 1
+		usageReqMaskInternal = 1
+		usageReqMaskExternal = 4
 		dataIsCollectable = true
-    }
+	}
 }


### PR DESCRIPTION
This requires 1% of the experiment to be transmitted to RnD and doesn't actually care what vessel (or vessels) did it.