### PR TITLE
Explicitly distinguish HP and SM tank on oxygen gas unlock tech

### DIFF
--- a/GameData/RP-0/Tree/ResourceTechs.cfg
+++ b/GameData/RP-0/Tree/ResourceTechs.cfg
@@ -1,9 +1,5 @@
 @TANK_DEFINITION[*]:FOR[RP-0]
 {
-	@TANK[Oxygen]
-	{
-		%techRequired = standardDockingPorts  // For late RCS configs
-	}
 	@TANK[Food]
 	{
 		%techRequired = crewSurvivability
@@ -13,22 +9,25 @@
 		%techRequired = materialsScienceSatellite  // 1956 Blue Sky Node (for SUNTAN)
 	}
 }
-@TANK_DEFINITION:HAS[#addResourcesSM[true]]:FOR[RP-0]
+@TANK_DEFINITION:HAS[#addResourcesSM[true]]:FOR[RP-0]  // Explcitly distinguish between HP and SM tanks
 {
 	@TANK[Oxygen]
 	{
 		%techRequired = crewSurvivability
 	}
 }
-@TANK_DEFINITION[*]:AFTER[TacLifeSupport]
+@TANK_DEFINITION:HAS[#addResourcesHP[true],~addResourcesSM[true]]:FOR[RP-0]
 {
 	@TANK[Oxygen]
 	{
 		%techRequired = standardDockingPorts  // For late RCS configs
 	}
+}
+@TANK_DEFINITION[*]:AFTER[TacLifeSupport]
+{
 	@TANK[Water]
 	{
-		%techRequired = crewSurvivability
+		-techRequired = DEL  // Water is used by some engines
 	}
 	@TANK[Food]
 	{
@@ -40,6 +39,13 @@
 	@TANK[Oxygen]
 	{
 		%techRequired = crewSurvivability
+	}
+}
+@TANK_DEFINITION:HAS[#addResourcesHP[true],~addResourcesSM[true]]:AFTER[TacLifeSupport]
+{
+	@TANK[Oxygen]
+	{
+		%techRequired = standardDockingPorts  // For late RCS configs
 	}
 }
 


### PR DESCRIPTION
So that patching order is not an issue. Uses the tags from Realism Overhaul, before they are removed by zzzTagCleanup.
Requires https://github.com/KSP-RO/RealismOverhaul/pull/2857 and should solve #1964. 
Thank @Capkirk123 and @arrowmaster for the idea. 