### PR TITLE
Default oxygen gas tanks to unlock in tech crewsurvivability

### DIFF
--- a/GameData/RP-0/Tree/ResourceTechs.cfg
+++ b/GameData/RP-0/Tree/ResourceTechs.cfg
@@ -2,7 +2,7 @@
 {
 	@TANK[Oxygen]
 	{
-		%techRequired = standardDockingPorts  // For late RCS configs
+		%techRequired = crewSurvivability
 	}
 	@TANK[Food]
 	{
@@ -13,18 +13,18 @@
 		%techRequired = materialsScienceSatellite  // 1956 Blue Sky Node (for SUNTAN)
 	}
 }
-@TANK_DEFINITION:HAS[#addResourcesSM[true]]:FOR[RP-0]
+@TANK_DEFINITION:HAS[#addResourcesHP[true],~addResourcesSM[true]]:FOR[RP-0]
 {
 	@TANK[Oxygen]
 	{
-		%techRequired = crewSurvivability
+		%techRequired = standardDockingPorts  // For late RCS configs
 	}
 }
 @TANK_DEFINITION[*]:AFTER[TacLifeSupport]
 {
 	@TANK[Oxygen]
 	{
-		%techRequired = standardDockingPorts  // For late RCS configs
+		%techRequired = crewSurvivability
 	}
 	@TANK[Water]
 	{
@@ -35,11 +35,11 @@
 		%techRequired = crewSurvivability
 	}
 }
-@TANK_DEFINITION:HAS[#addResourcesSM[true]]:AFTER[TacLifeSupport]
+@TANK_DEFINITION:HAS[#addResourcesHP[true],~addResourcesSM[true]]:AFTER[TacLifeSupport]
 {
 	@TANK[Oxygen]
 	{
-		%techRequired = crewSurvivability
+		%techRequired = standardDockingPorts  // For late RCS configs
 	}
 }
 


### PR DESCRIPTION
By changing the order in which the patches are applied. This change means oxygen gas in legacy RF `ServiceModule` tanks are unlocked in the new default `crewSurvivability` tech, instead of `standardDockingPorts`.
Thank @NathanKell for the idea. 
Should finally solve #1964. 