### PR TITLE
Fix GEM-60/TVC ECM error

### DIFF
--- a/GameData/RP-1/Tree/ECM-Engines.cfg
+++ b/GameData/RP-1/Tree/ECM-Engines.cfg
@@ -197,7 +197,7 @@
     GEM-46/Fixed-Ground = 24000,GEM
     GEM-46/TVC-Ground = 0,GEM-46/Fixed-Ground,SolidsTVC
     GEM-60/Fixed = 36000,GEM
-    GEM-60/TVC = 0,GEM-60/TVC,SolidsTVC
+    GEM-60/TVC = 0,GEM-60/Fixed,SolidsTVC
     GEM-63 = 48000,GEM
     GEM-63XL = 0,GEM
     GEnx-2B67B = 25000,CF6-50E2

--- a/Source/Tech Tree/Parts Browser/data/Engine_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Engine_Config.json
@@ -4130,7 +4130,7 @@
         "spacecraft": "Delta IV",
         "engine_config": "GEM-60",
         "upgrade": false,
-        "entry_cost_mods": "0,GEM-60/TVC,SolidsTVC",
+        "entry_cost_mods": "0,GEM-60/Fixed,SolidsTVC",
         "identical_part_name": "",
         "module_tags": []
     },


### PR DESCRIPTION
Correct the GEM-60/TVC config entry cost modifier to reference the base GEM-60/Fixed instead of itself.