### PR TITLE
ECM discount from 5D60 (DF-2) to YF-1 (DF-3)

### DIFF
--- a/GameData/RP-1/Tree/ECM-Engines.cfg
+++ b/GameData/RP-1/Tree/ECM-Engines.cfg
@@ -28,7 +28,7 @@
     4x-NK-21 = NK-21
     4x-NK-39 = NK-39
     5D22 = 1,11D423
-    5D60 = 17000, YF-Family-Early
+    5D60 = 12000, YF-Family-Early
     8x-NK-15V = NK-15V
     8x-NK-43 = NK-43
     A-136 = 20000,J93-GE-3,SpaceReactors

--- a/GameData/RP-1/Tree/EntryCostModifiers.cfg
+++ b/GameData/RP-1/Tree/EntryCostModifiers.cfg
@@ -163,7 +163,7 @@ ENTRYCOSTMODS
 	Proton-Family = 80000, Early-Soviet-Staged
 
 	//Chinese
-    YF-Family-Early = 5000, RD101-TP
+    YF-Family-Early = 10000, RD101-TP
 	YF-Family = 5000, HypergolicPumps, YF-Family-Early   //similar to R-12/R-14, but smaller. Some claim these were directly derived from R-12, but I find it dubious. Sino-Soviet split occured before first R-12 flight, and YF-1 includes developments (bipropellant gas generator) that R-12/RD-214 never had. There are also claims that it was derived from Isayev booster engines (S2.1100/S2.1150) which seems dubious for the same reasons. I believe these were a mostly independent development, with minor influence from preliminary R-12/R-14 design documents. Tie to RD-100 engines, they're the last common ancestor of most of these engines and early enough engineering information was shared before Sino-Soviet split.
 	YF-Upper = 5000, YF-Family		//air-start capability and nozzle extension
 	YF-Family-1971 = 125000, YF-Family		//YF-20. These are much more RD-215-like, very nice performance for hypergolic boosters and still in service to this day. Similar costs to R-36/RD-250.


### PR DESCRIPTION
With this change, going 5D60 -> YF-1 now saves you 10,000 fund than without 5D60, to reflect chinese rocket development from DF-2 to DF-3, and also make 5D60 less of a dead-end.