### PR TITLE
Remove landing training from Apollo capsule and split Gemini Lunar training

### DIFF
--- a/GameData/RP-1/CrewTrainingTimes.cfg
+++ b/GameData/RP-1/CrewTrainingTimes.cfg
@@ -134,7 +134,7 @@ TRAININGTIMES
 		Mk2Pod = Gemini
 	Gemini-Mission = 120
 
-	// Advanced Gemini (Lunar), also include Big Gemini as potential lunar ferry
+	// Advanced Gemini (Lunar)
 	GeminiLunar = 50, Gemini									// 700
 		ROC-GeminiLCMBDB = GeminiLunar		
 	GeminiLunar-Mission = 150
@@ -147,7 +147,7 @@ TRAININGTIMES
 	ApolloD2-Mission = 135
 		
 	// Apollo
-	Apollo = 110, MatureCapsules									// 700
+	Apollo = 110, MatureCapsules								// 700
 		bluedog-Apollo-Block2-Capsule = Apollo
 		FASAApollo-CM = Apollo
 		SSTU-SC-B-CM = Apollo


### PR DESCRIPTION
Removed landing from the Apollo capsule training requirement (unlocking training at AC4 instead of AC5) while keeping the LEM as AC5. Since you still need LEM training if included in the LV, no training time is lost.

This would allow early Apollo 8 missions with Apollo or even use Apollo for Adv Crew if you are coming late to the Crew Program and skip Gemini altogether, without needing AC5 yet, which is focused on landing operations.

Also split off Gemini Lunar into extra lunar operation's training in line with the proposed changes to crew lunar experiment being a requirement in lunar explo, allowing Gemini Lunar to be usable at the cost of extra training. Also lumped in Big Gemini as potential lunar ferry as it is a later variant.

There is weird training progression where Gemini Lunar is more training than D2 and more training than Apollo, but that can account for more advanced tech making it easier to train.