### PR TITLE
Reduce TL0 FlyingLow and FlyingHigh Science

### DIFF
--- a/GameData/RP-1/Science/BodyScienceParams.cfg
+++ b/GameData/RP-1/Science/BodyScienceParams.cfg
@@ -13,7 +13,7 @@
 				%landedDataValue = 1
 				%splashedDataValue = 1
 				%flyingLowDataValue = 1
-				%flyingHighDataValue = 0.6
+				%flyingHighDataValue = 1
 				%inSpaceLowDataValue = 1
 				%inSpaceHighDataValue = 1.25
 				%recoveryValue = 1.0

--- a/GameData/RP-1/Science/Experiments/PressureScan.cfg
+++ b/GameData/RP-1/Science/Experiments/PressureScan.cfg
@@ -11,7 +11,7 @@
 	@dataScale /= #$baseValue$
 	@requireAtmosphere = False
 	@situationMask = 61
-	@biomeMask = 5
+	@biomeMask = 1
 	
 	%RESULTS
 	{

--- a/GameData/RP-1/Science/Experiments/TelemetryAnalysis.cfg
+++ b/GameData/RP-1/Science/Experiments/TelemetryAnalysis.cfg
@@ -12,7 +12,7 @@ EXPERIMENT_DEFINITION
 	dataScale = 0.00005625
 	requireAtmosphere = False
 	situationMask = 63
-	biomeMask = 7	
+	biomeMask = 3	
 	
 	RESULTS
 	{

--- a/GameData/RP-1/Science/Experiments/Temperature.cfg
+++ b/GameData/RP-1/Science/Experiments/Temperature.cfg
@@ -10,7 +10,7 @@
 	@scienceCap = 4
 	@requireAtmosphere = False
 	%situationMask = 63 // ALL
-	%biomeMask = 15 // Surface Landed/Splashed, Flying Low/High
+	%biomeMask = 3 // Surface Landed/Splashed
 	KERBALISM_EXPERIMENT
 	{
 		// sample mass in tons. if undefined or 0, the experiment produce a file


### PR DESCRIPTION
Temperature, Telemetry, and Pressure Scan are a bit powerful, and may discourage using later tech experiments for gathering science. Given that these only require 5-10 minutes of operation, it doesn't seem appropriate for having these provide science for biome-specific areas under FlyingLow and FlyingHigh conditions. This PR is to change these to only provide science for the situation rather than each biome.

To provide some data, the below is what can be gathered with Telemetry, Temp, and Pressure if you look at Venus and Mars. This excludes space high and low.

Venus (8 biomes): 2,033 Science
Landed science: 704
FlyingLow/High: 1,329

Mars (19 Biomes): 3,406 Science
Landed science: 1,463
FlyingLow/High: 1,943

Total for Venus and Mars: 5,439

This alone could get you to 1972 (6,069 total science points), accounting for all the tech already researched to take on Early Inner Planet Probes. With the proposed change, the above scenario would be reduced to 2,519.

From a gameplay perspective, this will not impact the science gathered with the first probe sent to the bodies, but subsequent missions would have diminished returns. This change will also impact the sounding rocket era by removing FlyingHigh temperature-farming from biomes adjacent to the LC. To compensate, the multiplier was increased.


<img width="1817" height="930" alt="RP-1 Tech Tree - Total Science" src="https://github.com/user-attachments/assets/05301bb2-bab4-42dc-8607-0c38dee4a03e" />
