### PR TITLE
Specify where the live crewed lunar orbit TV experiment can be found

### DIFF
--- a/GameData/RP-1/Contracts/Lunar Crewed/FirstCrewedLunarOrbit.cfg
+++ b/GameData/RP-1/Contracts/Lunar Crewed/FirstCrewedLunarOrbit.cfg
@@ -6,7 +6,7 @@ CONTRACT_TYPE
 
 	tag = CrewedLunarOrbitRequired
 
-	description = <b>Program: Crewed Lunar Exploration<br>Type: <color=green>Required</color></b><br><br>Design and launch a spacecraft with at least two crew members to orbit close to the Moon for at least 20 hours and return safely to Earth. Historically, Apollo 8 was the first to do this, flying to the Moon over Christmas, 1968.
+	description = <b>Program: Crewed Lunar Exploration<br>Type: <color=green>Required</color></b><br><br>Design and launch a spacecraft with at least two crew members to orbit close to the Moon for at least 20 hours and return safely to Earth. You must also broadcast live TV during the mission, the experiment for which is unlocked in the Improved Communications technology node. Historically, Apollo 8 was the first to do this, flying to the Moon over Christmas, 1968.
 
 	synopsis = Fly the first Crewed Lunar Orbit mission
 


### PR DESCRIPTION
On the RP-1 discord some confusion about where the live TV experiment for the crewed lunar orbit contract was expressed.
I've added a short explanation to the contract description to help clarify.