### PR TITLE
Tweak "Repeat Prototype Space Station" Fraction Completions

### DIFF
--- a/GameData/RP-1/Contracts/Early Space Stations/Repeat Prototype Space Station.cfg
+++ b/GameData/RP-1/Contracts/Early Space Stations/Repeat Prototype Space Station.cfg
@@ -77,7 +77,7 @@ CONTRACT_TYPE
 	{
 		type = List<float>
 		durationMultiplier = [1,1,1,2]
-		experimentList = [0.3332,0.4998,0.6664,0.9]
+		experimentList = [0.2498,0.4164,0.5831,0.8164]
 	}
 	DATA
 	{


### PR DESCRIPTION
This contract states to "accumulate the next month worth of Long Term Habitation experimentation", and specifies either 30 or 60 days for the duration. Given that the "First Space Station Contract" only requires a 14 day duration, the first time you would perform this optional contract you would need to collect 45 days of the science rather than 30 days.

The parameters currently looks for completion of the Multi-Week Habitation Analysis, with values of 60 days, 90 days, 120 days, and 162 days. This PR tweaks those fraction completions to 45 days, 75 days, 105 days and 147 days.