### PR TITLE
Reorganise the assigment of some crew experiments to better align with tech level and applications

### DIFF
--- a/GameData/RP-1/Science/Experiments/CrewScience/LunarOrbiterCapsulesExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/LunarOrbiterCapsulesExperiments.cfg
@@ -1,4 +1,4 @@
-@PART[D2_module1|ROC-GeminiLCMBDB|ROC-D2MissionModule1|ok_bo_male|ok_bo_fem]:BEFORE[RP-0-Kerbalism]
+@PART[D2_module1|ROC-GeminiLCMBDB|ROC-D2MissionModule1|ok_bo_male|ok_bo_fem|rn_zond_sa]:BEFORE[RP-0-Kerbalism]
 {
 	%capsuleTier = LunarOrbiter
 	%getsSecondGenExperiments = True

--- a/GameData/RP-1/Science/Experiments/CrewScience/MatureCapsuleExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/MatureCapsuleExperiments.cfg
@@ -1,7 +1,7 @@
 // ============================================================================
 // Add tag to parts
 // ============================================================================
-@PART[FASAGeminiBigG|FASAGeminiBigGWhite|SSTU-SC-A-OM|bluedog_Apollo_Block2_Capsule|FASAApollo_CM|SSTU-SC-B-CM|Mark1-2Pod|mk1-3pod|rn_lok_bo|t_bo|t_af_bo|SSTU-SC-B-CMX|rn_astp_bo|bluedog_Apollo_Block3_Capsule|MK2VApod|rn_va_capsule|SOYUZ_orbitalSegment|mk3-9pod|SSTU-SC-C-CM|SSTU-SC-C-CMX|XOrionPodXbb31|XOrionPodX|inlineCmdPod|CST-100?capsule|MK1CrewCabin|mk2Cockpit_Standard|mk2Cockpit_Inline|mk2CrewCabin|mk3Cockpit_Shuttle|benjee10_shuttle_forwardFuselage|D2_module2|ROC-ApolloCM|ROC-ApolloCMBDB|ROC-D2MissionModule2|ROC-ApolloCMBlockIII|ROC-ApolloCMBDBBlockIII|ROC-OrionCM]:BEFORE[RP-0-Kerbalism]
+@PART[FASAGeminiBigG|FASAGeminiBigGWhite|SSTU-SC-A-OM|bluedog_Apollo_Block2_Capsule|FASAApollo_CM|SSTU-SC-B-CM|Mark1-2Pod|mk1-3pod|rn_lok_bo|t_bo|t_af_bo|SSTU-SC-B-CMX|rn_astp_bo|bluedog_Apollo_Block3_Capsule|MK2VApod|rn_va_capsule|SOYUZ_orbitalSegment|mk3-9pod|SSTU-SC-C-CM|SSTU-SC-C-CMX|XOrionPodXbb31|XOrionPodX|inlineCmdPod|CST-100?capsule|mk2Cockpit_Standard|mk2Cockpit_Inline|mk2CrewCabin|mk3Cockpit_Shuttle|benjee10_shuttle_forwardFuselage|D2_module2|ROC-ApolloCM|ROC-ApolloCMBDB|ROC-D2MissionModule2|ROC-ApolloCMBlockIII|ROC-ApolloCMBDBBlockIII|ROC-OrionCM]:BEFORE[RP-0-Kerbalism]
 {
 	%capsuleTier = Mature
 	%getsSecondGenExperiments = True

--- a/GameData/RP-1/Science/Experiments/CrewScience/SecondGenExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/SecondGenExperiments.cfg
@@ -1,7 +1,7 @@
 // ============================================================================
 // Add tag to parts
 // ============================================================================
-@PART[Mk2Pod|kv3Pod|FASAGeminiPod2|FASAGeminiPod2White|K2Pod|ROAdvCapsule|Voskhod_Crew_A|RO-Mk1CrewModule|RO-Mk1CockpitInline|RO-Mk1Cockpit|ROC-GeminiCM|ROC-GeminiCMBDB|ROC-VoskhodCapsule|ROC-DynaBody|ROC-DynaCockpitMoroz]:BEFORE[RP-0-Kerbalism]
+@PART[Mk2Pod|kv3Pod|FASAGeminiPod2|FASAGeminiPod2White|K2Pod|ROAdvCapsule|Voskhod_Crew_A|RO-Mk1CrewModule|RO-Mk1CockpitInline|RO-Mk1Cockpit|MK1CrewCabin|ROC-GeminiCM|ROC-GeminiCMBDB|ROC-VoskhodCapsule|ROC-DynaBody|ROC-DynaCockpitMoroz]:BEFORE[RP-0-Kerbalism]
 {
 	%capsuleTier = SecondGen
 	%getsSecondGenExperiments = True


### PR DESCRIPTION
Zond was intended for crewed Soviet lunar flights, so it should get the lunar crew science too. Even though it was never intended for a lunar orbit, it had the capacity to operate in the cislunar environment.

Mk1 Crew Cabin for some reason was assigned to mature capsules. This PR moves it to 2nd gen crew science instead, where other Mk1 spaceplane parts are.