### PR TITLE
Update Scientist Reputation Decay Descriptions

### DIFF
--- a/GameData/RP-1/Strategies/Leaders/LeadersScientists.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersScientists.cfg
@@ -598,7 +598,7 @@ STRATEGY
 		name = CurrencyModifier
 		effectTitle = Detained By Foreign Government
 		currency = Reputation
-		effectDescription = of reputation decay
+		effectDescription = loss from reputation decay
 		multiplier = 1.15
 		flipPositive = true
 		transactionReasons


### PR DESCRIPTION
Jack Parsons and Qian Xuesen both have their reputation decay effect read in game as "Reputation of reputation decay". Which doesn't quite parse correctly.

Propose to match existing DailyRepDecline effect language from Homer Hickam, Satish Dhawan, and Atomic Energy Commission,   "Reputation loss from reputation decay".

Readability and also consistency.