### PR TITLE
Add hard drives to stuff I forgot (mostly planes)

### DIFF
--- a/GameData/RP-1/Science/HardDriveConfigs.cfg
+++ b/GameData/RP-1/Science/HardDriveConfigs.cfg
@@ -590,6 +590,11 @@ KERBALISM_HDD_SIZES
 	}
 
 	//Manned Spacecrafts
+	generalAviation
+	{
+		data = 1							//Magnetic wire technology was mature by the 1940s, and magnetic tape was entering the market. Even early recorders were "desktop" sized, it would be fairly trivial to install one in all but the smallest manned aircraft.
+		samples = 5						//Whatever, you can shove a lot of film behind the seat
+	}
 	mercury
 	{
 		data = 0.150							//Mercury could afford do carry a good-sized tape recorder
@@ -746,6 +751,14 @@ KERBALISM_HDD_SIZES
 // Stop scrolling, there's not much you can fiddle with further.
 // Do Not Touch! (please?)
 // ============================================================================
+@PART[probeCoreSphere_v2|SXTSputnik|sputnik1]:FOR[RO-KerbalismHardDrives]
+{
+	//No hard drives for sputnik
+	!MODULE[HardDrive]
+	{
+	}
+}
+
 @PART[tiros-1]:FOR[RO-KerbalismHardDrives]
 {
 	@MODULE[HardDrive]
@@ -845,6 +858,18 @@ KERBALISM_HDD_SIZES
 	}
 }
 
+@PART[625mBonny|SXTke111|SXTBuzzard|RO-OldFighterCockpit|RO-X1Cockpit|RO-FighterInlineCockpit|SXTClyde|SXTmk3Cockpit52|Mark1Cockpit|Mark2Cockpit|25mKossak]:FOR[RO-KerbalismHardDrives]
+{
+	!MODULE[HardDrive] {}
+	MODULE
+	{
+		name = HardDrive
+		title = Data Storage
+		dataCapacity = #$@KERBALISM_HDD_SIZES/generalAviation/data$
+		sampleCapacity = #$@KERBALISM_HDD_SIZES/generalAviation/samples$
+	}
+}
+
 @PART[FASAMercuryPod|mk1pod|mk1pod_v2|rn_vostok_sc|rn_voskhod_sc|landerCabinSmall|FASA_Gemini_Lander_Pod|rn_vostok_sc|rn_voskhod_sc|ok_sa|ROC-MercuryCM|ROC-MercuryCMBDB|ROC-VostokCapsule|ROC-VoskhodCapsule]:FOR[RO-KerbalismHardDrives]
 {
 	!MODULE[HardDrive] {}
@@ -857,7 +882,7 @@ KERBALISM_HDD_SIZES
 	}
 }
 
-@PART[FASAGeminiPod2|FASAGeminiPod2White|ROAdvCapsule|RO-Mk1Cockpit|RO-Mk1CockpitInline|MK1CrewCabin|ok_bo_fem|ok_bo_male|rn_zond_sa|rn_lok_sa|rn_lok_bo|D2_pod|ROC-GeminiCM|ROC-GeminiCMBDB|ROC-GeminiLCMBDB|ROC-DynaBody|ROC-DynaCockpitMoroz|ROC-D2CM|ROC-D2MissionModule1]:FOR[RO-KerbalismHardDrives]
+@PART[FASAGeminiPod2|FASAGeminiPod2White|ROAdvCapsule|RO-Mk1Cockpit|RO-Mk1CockpitInline|MK1CrewCabin|ok_bo_fem|ok_bo_male|rn_zond_sa|rn_lok_sa|rn_lok_bo|D2_pod|ROC-GeminiCM|ROC-GeminiCMBDB|ROC-GeminiLCMBDB|ROC-DynaBody|ROC-DynaCockpitMoroz|ROC-DynaCockpitAltMoroz|ROC-D2CM|ROC-D2MissionModule1]:FOR[RO-KerbalismHardDrives]
 {
 	!MODULE[HardDrive] {}
 	MODULE


### PR DESCRIPTION
Give aircraft cockpits a 1 MB hard drive by default (desktop tape recorders were entering the market by the late 1940s, and you could easily pack a lot of tape into even a small plane). Also remove hard drives from sputnik and add hard drives to some miscellaneous spaceplane parts that got missed before.