### PR TITLE
Give Sputnik an empty hard drive so it actually works

### DIFF
--- a/GameData/RP-1/Science/HardDriveConfigs.cfg
+++ b/GameData/RP-1/Science/HardDriveConfigs.cfg
@@ -754,8 +754,10 @@ KERBALISM_HDD_SIZES
 @PART[probeCoreSphere_v2|SXTSputnik|sputnik1]:FOR[RO-KerbalismHardDrives]
 {
 	//No hard drives for sputnik
-	!MODULE[HardDrive]
+	@MODULE[HardDrive]
 	{
+		@dataCapacity = 0
+		@sampleCapacity = 0
 	}
 }
 


### PR DESCRIPTION
resolves https://github.com/KSP-RO/RP-1/issues/2675

Apparently if you delete a hard drive from a part completely it bugs out and can't transmit science. Give Sputnik an empty hard drive instead so it works properly-ish.