### PR TITLE
Give starting parts 1 Byte of data, not zero

### DIFF
--- a/GameData/RP-1/Science/HardDriveConfigs.cfg
+++ b/GameData/RP-1/Science/HardDriveConfigs.cfg
@@ -717,7 +717,7 @@ KERBALISM_HDD_SIZES
 {
 	@MODULE[HardDrive]
 	{
-		%dataCapacity = 0				// will be upgraded with partupgrades later
+		%dataCapacity = 0.000001		// will be upgraded with partupgrades later. 1 byte (UI gets buggy with 0 data capacity)
 		%sampleCapacity = 1
 		%maxDataCapacityFactor = 10		// Sure, just add more tape
 		%dataCapacityCost = 50			// You can't un-upgrade, so this has to be universal. Be conservative and set it fairly low
@@ -756,7 +756,7 @@ KERBALISM_HDD_SIZES
 	//No hard drives for sputnik
 	@MODULE[HardDrive]
 	{
-		@dataCapacity = 0
+		@dataCapacity = 0.000001
 		@sampleCapacity = 0
 	}
 }


### PR DESCRIPTION
Apparently having 0 data storage capacity on a craft causes the Kerbalism data storage UI to get a bit buggy (displaying NaN for data capacity) so set everything to 1 Byte instead. Still too little to be useful, but makes the UI display data correctly.

resolves https://github.com/KSP-RO/RP-1/issues/2678 