### PR TITLE
Improve Cherenkov detector configs

### DIFF
--- a/GameData/RP-1/Parts/Science/CD01-CherenkovCounter.cfg
+++ b/GameData/RP-1/Parts/Science/CD01-CherenkovCounter.cfg
@@ -3,11 +3,15 @@
 //
 //	Based on the Cherenkov Counter Cosmic Ray Telescopes used on many spacecraft
 //  for more detailed study of the Cosmic Energy particles.
+//	Based on the IMP/OGO-1 cosmic ray telescope????
 //
 //	Part originally created by CobaltWolf as the Pioneer 10 Cosmic Ray Telescope
 //
 //**********************************************************************************
 
+//I have no idea what this was originally based on, the only instrument of roughly appropriate size, era and type in SP-3028 is the IMP/OGO-1
+//scintillation counter cosmic ray telescope.
+//This is not quite right, but close enough???
 PART
 {
 	name = RP0Cherenkov
@@ -32,7 +36,7 @@ PART
 	manufacturer = Realism Overhaul
 	description = The Cherenkov detector is another type of high energy particle detector, using a Cherenkov detector in combination with a scintillation detector to further observe and characterize high-energy gamma rays.  It measures the arrival directions and energies of gamma rays and highly-energetic charged particles from cosmic radiation. This detailed measurement can allow for more detailed analysis of the radiation environments in interplanetary space.
 	attachRules = 0,1,0,0,1
-	mass = 0.0065 // Source from NASA SP-3028 Space Measurements Survey Instruments and Spacecraft
+	mass = 0.0068 // Source from NASA SP-3028 Space Measurements Survey Instruments and Spacecraft p.737
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2

--- a/GameData/RP-1/Science/Configure.cfg
+++ b/GameData/RP-1/Science/Configure.cfg
@@ -249,7 +249,7 @@
 		SETUP
 		{
 			name = Cherenkov Detector 1
-			mass = 0.00055
+			mass = 0.00068
 			cost = 58
 			tech = scienceHuman
 			

--- a/GameData/RP-1/Science/Experiments/Cherenkov.cfg
+++ b/GameData/RP-1/Science/Experiments/Cherenkov.cfg
@@ -37,7 +37,7 @@ EXPERIMENT_DEFINITION
 {
 	@MODULE[Experiment]:HAS[#experiment_id[RP0Cherenkov]]
 	{
-		%ec_rate = 0.0005
+		%ec_rate = 0.0016 //1.6 W
 		%data_rate = 5 //2 b/s
 		@data_rate /= 7862400 //3 months
 		%requires = OrbitMinEccentricity:0.04


### PR DESCRIPTION
While attempting to resolve https://github.com/KSP-RO/RP-1/issues/2681 and find the "correct" mass of the Cherenkov detector, I discovered that the config is pretty much completely unsourced.
Therefore, I selected the IMP/OGO cosmic ray telescope as a reference (it's roughly the correct size and era) and adjusted the Cherenkov detector configs to match.
resolves https://github.com/KSP-RO/RP-1/issues/2681