### PR TITLE
Fix direct crewed lunar landing contract

### DIFF
--- a/GameData/RP-1/Contracts/Lunar Crewed/FirstMoonLandingCrewedDirect.cfg
+++ b/GameData/RP-1/Contracts/Lunar Crewed/FirstMoonLandingCrewedDirect.cfg
@@ -89,8 +89,8 @@ CONTRACT_TYPE
 		{
 			name = ReachMoonWithTwoCrew
 			type = All
-			title = Launch a new vessel with two crew and bring them to and back from the Moon
-			disableOnStateChange = false
+			title = Launch a new vessel with two crew and bring them to the Moon
+			disableOnStateChange = true
 		
 			PARAMETER
 			{
@@ -102,7 +102,7 @@ CONTRACT_TYPE
 			
 			PARAMETER
 			{
-				name = TwoCrew
+				name = TwoCrewToMoon
 				type = HasCrew
 				minCrew = 2
 				crewOnly = true
@@ -117,7 +117,6 @@ CONTRACT_TYPE
 				type = ReachState
 				targetBody = Moon
 				hideChildren = true
-				disableOnStateChange = true
 			}
 		}
 
@@ -161,14 +160,32 @@ CONTRACT_TYPE
 			experiment = RP0LunarLandingTelevisionBroadcast
 			fractionComplete = 1
 		}
-
+		
 		PARAMETER
 		{
-			name = ReturnHome
-			type = RP1ReturnHome
-			title = Return home safely
-			hideChildren = true
+			name = ReturnWithTwoCrew
+			type = All
+			title = Safely return the two crew to Earth
+			disableOnStateChange = false
 			completeInSequence = true
+			
+			PARAMETER
+			{
+				name = ReturnHome
+				type = RP1ReturnHome
+				title = Return home safely
+				hideChildren = true
+			}
+			
+			PARAMETER
+			{
+				name = TwoCrewToEarth
+				type = HasCrew
+				minCrew = 2
+				crewOnly = true
+				title = Have at least 2 crew on board
+				hideChildren = true
+			}
 		}
 	}
 }


### PR DESCRIPTION
Flag planting was previously impossible to check off due to the two-crew parameter and completeInSequence on the flag, rendering the contract impossible. This is now fixed by splitting the two-crew check up into a to the Moon and return to Earth component.