### PR TITLE
Fix inaccurate auto alarms not being deleted

### DIFF
--- a/Source/RP0/UI/KCT/GUI_BuildList.cs
+++ b/Source/RP0/UI/KCT/GUI_BuildList.cs
@@ -218,7 +218,7 @@ namespace RP0
                 if (KCTSettings.Instance.AutoAlarms && buildItem.GetTimeLeft() > 30)    //don't check if less than 30 seconds to completion. Might fix errors people are seeing
                 {
                     double UT = Planetarium.GetUniversalTime();
-                    if (!KCTUtilities.IsApproximatelyEqual(SpaceCenterManagement.Instance.AlarmUT - UT, buildItem.GetTimeLeft(), 1))
+                    if (!KCTUtilities.IsApproximatelyEqual(SpaceCenterManagement.Instance.AlarmUT - UT, buildItem.GetTimeLeft()))
                     {
                         // old alarm, need to delete to get the new alarm for the new buildItem
                         SpaceCenterManagement.Instance.AlarmUT = buildItem.GetTimeLeft() + UT;

--- a/Source/RP0/Utilities/KCTUtilities.cs
+++ b/Source/RP0/Utilities/KCTUtilities.cs
@@ -721,8 +721,12 @@ namespace RP0
             return intact;
         }
 
+        /// <remarks>
+        /// Do not pass in an error value greater than or equal to 1. (100%)
+        /// </remarks>
         public static bool IsApproximatelyEqual(double d1, double d2, double error = 0.01)
         {
+            if (error >= 1) error = 0.01;
             return (1 - error) <= (d1 / d2) && (d1 / d2) <= (1 + error);
         }
 


### PR DESCRIPTION
Reported by [Sinalene](https://discord.com/channels/319857228905447436/512556137380315139/1462251399189627099)

In https://github.com/KSP-RO/RP-1/pull/2618 I somehow assumed that the error parameter `IsApproximatelyEqual` was an absolute difference, and not a relative one. (did I not check the original method?) This made it so alarms had to have at least a 100% error from the next item for it to make a new one, instead of the previous 1%.
I've also updated `IsApproximatelyEqual` to hopefully remove the possibility of this mistake coming up again.