### PR TITLE
Fix typo in magnetometry contract

### DIFF
--- a/GameData/RP-1/Contracts/Earth Observation 1/EOSMagScan1.cfg
+++ b/GameData/RP-1/Contracts/Earth Observation 1/EOSMagScan1.cfg
@@ -53,7 +53,7 @@ CONTRACT_TYPE
 	{
 		name = ScienceSatMagScan1
 		type = VesselParameterGroup
-		title = First magnetrometry satellite
+		title = First magnetometry satellite
 		define = ScienceSatMagScan1
 
 		PARAMETER
@@ -132,3 +132,4 @@ CONTRACT_TYPE
 		title = Transmit 75% of Magnetic Scan science from High Earth Orbit
 	}
 }
+


### PR DESCRIPTION
magnetometry instead of magnetrometry in the title parameter for the contract when it shows up in the sidebar