### PR TITLE
Add toggles for KAC alarms related to leaders

### DIFF
--- a/Source/RP0/Leaders/StrategyRP0.cs
+++ b/Source/RP0/Leaders/StrategyRP0.cs
@@ -161,15 +161,15 @@ namespace RP0
                 {
                     AlarmHelper.DeleteAllAlarmsWithTitle(ConfigRP0.Title);
 
-                    if (LeastDuration > 0)
+                    if (LeastDuration > 0 && _settings._MakeAlarmCooldownOver)
                     {
                         AlarmHelper.CreateAlarm($"Firing Cooldown Over: {ConfigRP0.Title}", $"{ConfigRP0.Title} can be removed with a fee at this time.", DateActivated + LeastDuration, alarmType);
                     }
-                    if (RemovePenaltyDuration > 0)
+                    if (RemovePenaltyDuration > 0 && _settings._MakeAlarmFreeRemove)
                     {
                         AlarmHelper.CreateAlarm($"Free to Remove: {ConfigRP0.Title}", $"{ConfigRP0.Title} can be removed without paying a penalty fee at this time.", DateActivated + RemovePenaltyDuration, alarmType);
                     }
-                    if (LongestDuration > 0)
+                    if (LongestDuration > 0 && _settings._MakeAlarmRetirement)
                     {
                         AlarmHelper.CreateAlarm($"Retirement: {ConfigRP0.Title}", $"{ConfigRP0.Title} will be removed at this time.", DateActivated + LongestDuration, alarmType);
                     }

--- a/Source/RP0/UI/ContractGUI.cs
+++ b/Source/RP0/UI/ContractGUI.cs
@@ -18,6 +18,9 @@ namespace RP0
 
         private static string _newspaperTitle = "Space Gazette";
         private static bool _useLastScreenshot = false;
+        private static bool _MakeAlarmCooldownOver = false;
+        private static bool _MakeAlarmFreeRemove = false;
+        private static bool _MakeAlarmRetirement = false;
 
         private RP0Settings _settings;
 
@@ -96,6 +99,25 @@ namespace RP0
                 GUILayout.Space(10f);
                 _useLastScreenshot = GUILayout.Toggle(_useLastScreenshot, "Use last screenshot instead of auto screenshot for Newspaper");
                 _settings.UseLastScreenshot = _useLastScreenshot;
+            }
+            finally
+            {
+                GUILayout.EndVertical();
+            }
+            try
+            {
+                GUILayout.Space(10f);
+                GUILayout.Space(10f);
+                GUILayout.Label($"Use this area to toggle the creation of automatic KAC alarms for events related to leaders.", BoldLabel);
+                GUILayout.Space(10f);
+                _MakeAlarmCooldownOver = GUILayout.Toggle(_MakeAlarmCooldownOver, "Firing cooldown over");
+                GUILayout.Space(5f);
+                _MakeAlarmFreeRemove = GUILayout.Toggle(_MakeAlarmFreeRemove, "Free to remove with no penalty");
+                GUILayout.Space(5f);
+                _MakeAlarmRetirement = GUILayout.Toggle(_MakeAlarmRetirement, "Retirement");
+                _settings._MakeAlarmCooldownOver = _MakeAlarmCooldownOver;
+                _settings._MakeAlarmFreeRemove= _MakeAlarmFreeRemove;
+                _settings._MakeAlarmRetirement = _MakeAlarmRetirement;
             }
             finally
             {


### PR DESCRIPTION
This PR adds some toggle buttons in the Settings screen of the RP-1 window to disable the alarms for end of firing cooldown, free to fire with no penalty and retirement. All of them are off by default, not sure if that should be the case but I personally find them to be more annoying than useful.

Admittedly, I have not actually tested it because I haven't figured out how to compile RP-1 yet, but I basically copied all the code from other parts of RP-1 and just changed some parameters, so I think it should work. If someone wants to test it that would be great. I will mark this as draft until I or someone else can verify that it works.