### PR TITLE
Change Venus Probe science collection parameters

### DIFF
--- a/GameData/RP-1/Contracts/Venus/Venus Probe.cfg
+++ b/GameData/RP-1/Contracts/Venus/Venus Probe.cfg
@@ -74,12 +74,28 @@ CONTRACT_TYPE
 		PARAMETER
 		{
 			name = AtmoScience
-			type = CollectScience
-			situation = FlyingHigh
-			recoveryMethod = Transmit
-			title = Transmit science data from Venus's atmosphere, AFTER going below 110 km
-			hideChildren = true
+			type = Any
+			title = Transmit at least one full experiment flying high, flying low, or landed, AFTER going below 110 km
 			completeInSequence = true
+			hideChildren = true
+			PARAMETER
+			{
+				type = CollectScience
+				situation = FlyingHigh
+				recoveryMethod = Transmit
+			}
+			PARAMETER
+			{
+				type = CollectScience
+				situation = FlyingLow
+				recoveryMethod = Transmit
+			}
+			PARAMETER
+			{
+				type = CollectScience
+				situation = SrfLanded
+				recoveryMethod = Transmit
+			}	
 		}
 	}
 }


### PR DESCRIPTION
It is apparently possible to build a probe that is aerodynamic enough to fall through flying high so fast you never fully complete an experiment. 
This PR modifies the contract such that any experiment fully completed after going below 110km counts by adding FlyingLow and SrfLanded to the valid situations.