### PR TITLE
Add case for program capacity text when only 1 slot is available

### DIFF
--- a/Source/RP0/Programs/ProgramStrategy.cs
+++ b/Source/RP0/Programs/ProgramStrategy.cs
@@ -118,8 +118,16 @@ namespace RP0.Programs
             int freeSlots = ProgramHandler.Instance.MaxProgramSlots - ProgramHandler.Instance.ActiveProgramSlots;
             if (_program.slots > freeSlots)
             {
-                reason = $"This program requires {_program.slots} free slots but only {freeSlots} slots are available.";
-                return false;
+                if (freeSlots > 1)
+                {
+                    reason = $"This program requires {_program.slots} free slots but only {freeSlots} slots are available.";
+                    return false;
+                }
+                else
+                {
+                    reason = $"This program requires {_program.slots} free slots but only 1 slot is available.";
+                    return false;
+                }
             }
 
             return true;


### PR DESCRIPTION
"1 slots are available" obviously isn't right :D