### PR TITLE
Fill in _serverUrl with the RP1 career log one by default

### DIFF
--- a/Source/RP0/UI/CareerLogGUI.cs
+++ b/Source/RP0/UI/CareerLogGUI.cs
@@ -23,6 +23,7 @@ namespace RP0
                 _serverUrl = Encoding.UTF8.GetString(bytes);
             }
             _token = settings?.CareerLog_Token;
+            _serverUrl = "https://rp1careerlog.azurewebsites.net/api/CareerLogs/";
         }
 
         public void RenderTab()


### PR DESCRIPTION
This should save a copy and paste step for anyone using the career log, while still leaving the option open for other APIs (are there any?)

<img width="472" height="335" alt="image" src="https://github.com/user-attachments/assets/18f9e018-2ee4-44f1-9ce4-7df594d119c0" />
