### PR TITLE
Add sun angle requirements to photography experiments

### DIFF
--- a/GameData/RP-1/Science/Experiments/Photography.cfg
+++ b/GameData/RP-1/Science/Experiments/Photography.cfg
@@ -58,9 +58,9 @@ EXPERIMENT_DEFINITION
 		%ec_rate = 0.005
 		%data_rate = 20
 		@data_rate /=  600 //10 minutes
-		%requires = 
+		%requires = SunAngleMax:85 // Can capture with almost any amount of sunlight, like RP0visibleImaging1
 		%resources = 
-		%experiment_desc = Early film flown on V2 rockets, taking the first photos from space. Can also be used as a reconnaissance camera. Requires physical recovery.
+		%experiment_desc = Early film flown on V2 rockets, taking the first photos from space. Can also be used as a reconnaissance camera. Requires daylight on the planet below the camera while running the experiment, and physical recovery to collect the science.
 		allow_shrouded = false
 	}
 }
@@ -120,7 +120,7 @@ EXPERIMENT_DEFINITION
 		%ec_rate = 0.15
 		%data_rate = 20
 		@data_rate /=  7200 //10 minutes
-		%requires = 
+		%requires = SunAngleMax:85
 		%resources = 
 		%experiment_desc = Earth photography satellite experiment based on the early KH-1 system from the Corona/Discoverer program. Requires multiple launches for film storage and recovery limitations.
 		allow_shrouded = false
@@ -174,7 +174,7 @@ EXPERIMENT_DEFINITION
 		%ec_rate = 0.125
 		%data_rate = 50
 		@data_rate /= 172800 //2 days per biome means 40 days of continous on orbit lifetime, so 8 kh-4s, or 4 zenit
-		%requires = OrbitMaxInclination:100,OrbitMaxEccentricity:0.035,AltitudeMax:445000
+		%requires = OrbitMaxInclination:100,OrbitMaxEccentricity:0.035,AltitudeMax:445000,SunAngleMax:85
 		%resources = 
 		%experiment_desc = Long term Earth imaging satellite experiment based on the Corona program. Requires multiple launches for film storage and recovery limitations.
 		allow_shrouded = false
@@ -238,7 +238,7 @@ EXPERIMENT_DEFINITION
 		%ec_rate = 0.5
 		%data_rate = 300
 		@data_rate /= 315360000 //10 years, program lasted from 1971 to 1986
-		%requires = OrbitMinInclination:94.5,OrbitMaxInclination:97,OrbitMaxEccentricity:0.01
+		%requires = OrbitMinInclination:94.5,OrbitMaxInclination:97,OrbitMaxEccentricity:0.01,SunAngleMax:85
 		%resources = 
 		%experiment_desc = Very long duration Earth imaging experiment, based on the KH-9 series of satellites. Requires multiple launches for film storage and recovery limitations.
 		allow_shrouded = false
@@ -293,9 +293,9 @@ EXPERIMENT_DEFINITION
 		%ec_rate = 2.1  //Hubble uses 2.1 kW on average
 		%data_rate = 18720000 //Hubble sends an average of 18 GB of data per week
 		@data_rate /= 630720000 //20 years, HST has been operating for almost 30 years
-		%requires = OrbitMaxEccentricity:0.005,AltitudeMin:350000,RadiationMax:0.005 //changing eccentricity to the Principia values by default.
+		%requires = OrbitMaxEccentricity:0.005,AltitudeMin:350000,RadiationMax:0.005,SunAngleMin:25,SunAngleMax:85
 		%resources = 
-		%experiment_desc = Extremely long duration Earth imaging experiment, based on the KH-11 series of satellites and the Hubble Space Telescope. Transmitted digitally back to Earth.
+		%experiment_desc = Extremely long duration Earth imaging experiment, based on the KH-11 series of satellites and the Hubble Space Telescope. Transmitted digitally back to Earth. Requires sunlight for exposure, but at an angle and not directly overhead so that shadows will enhance depth features.
 		allow_shrouded = false
 	}
 }


### PR DESCRIPTION
Fixes #2669 which points out that most film/still camera satellites required sunlight to work up until there were infrared and radar satellites that came later than our last current experiments (e.g. late KH-11) . Up to KH-9 / Photography 4 I have added the same 85 degree max sun angle as the early video experiment, since they used relatively arbitrary orbits and took occasional photos throughout the local day. For early KH-11 / Photography 5 I added a min sun angle similar to the later video experiments which mirrors early KH-11's real use of sun-synchronous orbits to always take photos at local not-noon to get consistent useful shadows.