### PR TITLE
Add effective cost breakdown tab in editor

### DIFF
--- a/Source/RP0/RP0.csproj
+++ b/Source/RP0/RP0.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Singletons\LeaderNotifications.cs" />
     <Compile Include="SpaceCenter\Projects\HireStaffProject.cs" />
     <Compile Include="SpaceCenter\Projects\VesselRepairProject.cs" />
+    <Compile Include="UI\CostBreakdownGUI.cs" />
     <Compile Include="UI\ProceduralAvionicsWindow.cs" />
     <Compile Include="CareerLog\CareerEvent.cs" />
     <Compile Include="CareerLog\CareerEventScope.cs" />

--- a/Source/RP0/SpaceCenter/Projects/VesselProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/VesselProject.cs
@@ -116,6 +116,15 @@ namespace RP0
         private double _buildRate = -1d;
         private double _leaderEffect = -1d;
         public double LeaderEffect => _leaderEffect < 0 ? UpdateLeaderEffect() : _leaderEffect;
+        private double _modifiedEC = -1d;
+        public double ModifiedEC 
+        { 
+            get
+            {
+                if (_modifiedEC < 0) UpdateLeaderEffect();
+                return _modifiedEC;
+            } 
+        }
 
         internal ShipConstruct _ship;
 
@@ -1287,15 +1296,15 @@ namespace RP0
 
         public double UpdateLeaderEffect()
         {
-            double modifiedEC = effectiveCost;
+            _modifiedEC = effectiveCost;
             double globalMult = ApplyGlobalCostModifiers();
             foreach (var t in tagEffectiveCosts)
             {
                 double ec = t.ec * Leaders.LeaderUtils.GetPartEffectiveCostEffect(t.tags);
-                modifiedEC += (ec - t.ec) * globalMult;
+                _modifiedEC += (ec - t.ec) * globalMult;
             }
-            modifiedEC *= Leaders.LeaderUtils.GetGlobalEffectiveCostEffect(globalTags, resourceAmounts);
-            double modifiedBP = Formula.GetVesselBuildPoints(modifiedEC);
+            _modifiedEC *= Leaders.LeaderUtils.GetGlobalEffectiveCostEffect(globalTags, resourceAmounts);
+            double modifiedBP = Formula.GetVesselBuildPoints(_modifiedEC);
             if (modifiedBP < 1d)
                 modifiedBP = 1d;
 

--- a/Source/RP0/UI/CostBreakdownGUI.cs
+++ b/Source/RP0/UI/CostBreakdownGUI.cs
@@ -17,9 +17,9 @@ namespace RP0.UI
             public double effectiveCost;
             public double effectiveCostModifier;
 
-            public override bool Equals(object o)
+            public override bool Equals(object obj)
             {
-                if (o is CostEntry other)
+                if (obj is CostEntry other)
                     return Equals(other);
                 else
                     return false;

--- a/Source/RP0/UI/CostBreakdownGUI.cs
+++ b/Source/RP0/UI/CostBreakdownGUI.cs
@@ -11,11 +11,29 @@ namespace RP0.UI
 {
     public class CostBreakdownGUI : UIBase
     {
-        private record struct CostEntry
+        private struct CostEntry
         {
             public string name;
             public double effectiveCost;
             public double effectiveCostModifier;
+
+            public override bool Equals(object o)
+            {
+                if (o is CostEntry other)
+                    return Equals(other);
+                else
+                    return false;
+            }
+
+            private bool Equals(CostEntry other)
+            {
+                return effectiveCost == other.effectiveCost && effectiveCostModifier == other.effectiveCostModifier && name == other.name;
+            }
+
+            public override int GetHashCode()
+            {
+                return (name, effectiveCost, effectiveCostModifier).GetHashCode();
+            }
         }
         
         private float _lastUpdateTrigger = 0f;

--- a/Source/RP0/UI/CostBreakdownGUI.cs
+++ b/Source/RP0/UI/CostBreakdownGUI.cs
@@ -1,0 +1,186 @@
+﻿using KSPCommunityFixes;
+using RealFuels;
+using Smooth.Slinq;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace RP0.UI
+{
+    public class CostBreakdownGUI : UIBase
+    {
+        private record struct CostEntry
+        {
+            public string name;
+            public double effectiveCost;
+            public double effectiveCostModifier;
+        }
+        
+        private float _lastUpdateTrigger = 0f;
+        private readonly Dictionary<CostEntry, int> _partCosts = new Dictionary<CostEntry, int>();
+        private readonly List<Part> _singlePart = new List<Part>(); // dummy list for calling GetEffectiveCost, to avoid extra allocations
+        private Vector2 _partCostsScroll = new Vector2();
+        private bool _isToolingTempDisabled = false;
+        private IEnumerator _activeUpdate = null; 
+
+        protected override void OnStart()
+        {
+            GameEvents.onEditorShipModified.Add(ShipModifiedEvent);
+        }
+
+        protected override void OnDestroy()
+        {
+            GameEvents.onEditorShipModified.Remove(ShipModifiedEvent);
+        }
+
+        public UITab RenderCostBreakdownTab()
+        {
+            VesselProject vessel = SpaceCenterManagement.Instance?.EditorVessel;
+            if (vessel == null)
+            {
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("No vessel currently detected.", HighLogic.Skin.label, GUILayout.Width(500));
+                GUILayout.EndHorizontal();
+                return UITab.CostBreakdown;
+            }
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label(new GUIContent("Total Effective Cost", "Effective cost is a metric that includes the various cost multiplier tags attached to each part and resource.\n" +
+                "This is usually the preferred metric for cost comparison between different rockets."), HighLogic.Skin.label, GUILayout.Width(312));
+            GUILayout.Label($"{vessel.effectiveCost:N2}", RightLabel, GUILayout.Width(144));
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label(new GUIContent("Effective Cost after Leader effects (conditional only)", "Unconditional integration speed buffs/debuffs are ignored."), HighLogic.Skin.label, GUILayout.Width(312));
+            GUILayout.Label($"{vessel.ModifiedEC:N2}", RightLabel, GUILayout.Width(144));
+            GUILayout.EndHorizontal();
+
+            DrawHorizontalSeparator();
+
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Part Name", BoldLabel, GUILayout.Width(312));
+            GUILayout.Label(new GUIContent("Ind. Effective Cost", "Global effective-cost modifiers are not included unless they originate from the part."), BoldRightLabel, GUILayout.Width(144));
+            GUILayout.EndHorizontal();
+
+            _partCostsScroll = GUILayout.BeginScrollView(_partCostsScroll, GUILayout.Height(300), GUILayout.Width(500));
+            foreach (var kvp in _partCosts.OrderByDescending(kvp => kvp.Key.effectiveCost * kvp.Key.effectiveCostModifier * kvp.Value))
+            {
+                CostEntry entry = kvp.Key;
+                int multiplicity = kvp.Value;
+                GUILayout.BeginHorizontal();
+                string name = entry.name;
+                if (multiplicity > 1)
+                    name = $"{multiplicity} x " + name;
+                GUILayout.Label(name, BoldLabel, GUILayout.Width(312));
+                GUIContent costAndTooltip = new GUIContent(FormatCostAndMultiplier(entry.effectiveCost * multiplicity, entry.effectiveCostModifier), 
+                                               FormatCostAndMultiplier(entry.effectiveCost, entry.effectiveCostModifier) + " per part");
+                GUILayout.Label(costAndTooltip, RightLabel, GUILayout.Width(144));
+                GUILayout.EndHorizontal();
+            }
+            GUILayout.EndScrollView();
+            GUILayout.BeginVertical();
+            try
+            {
+                RenderToolingPreviewButton();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+            }
+            GUILayout.EndVertical();
+            return UITab.CostBreakdown;
+        }
+
+        private void ShipModifiedEvent(ShipConstruct ship)
+        {
+            float now = Time.time;
+            if (_lastUpdateTrigger < now)
+            {
+                if (_activeUpdate != null)
+                    UIHolder.Instance?.StopCoroutine(_activeUpdate);
+                _lastUpdateTrigger = now;
+                _activeUpdate = Update(ship);
+                UIHolder.Instance?.StartCoroutine(_activeUpdate);
+            }
+        }
+
+        private IEnumerator Update(ShipConstruct ship) 
+        {
+            yield return null;
+            // Stall a frame.
+
+            var parts = ship?.Parts; 
+            if (parts?.Count > 0)
+            {
+                _partCosts.Clear();
+
+                for (int i = parts.Count - 1; i >= 0; --i)
+                {
+                    Part p = parts[i];
+                    CostEntry entry = new CostEntry();
+                    entry.name = GetPartDisplayName(p);
+                    _singlePart.Clear();
+                    _singlePart.Add(p);
+                    entry.effectiveCost = VesselProject.GetEffectiveCost(_singlePart);
+                    List<string> tags = ModuleTagList.GetTags(p);
+                    if (tags?.Count > 0)
+                        entry.effectiveCostModifier = Leaders.LeaderUtils.GetPartEffectiveCostEffect(tags);
+                    else
+                        entry.effectiveCostModifier = 1;
+                    if (_partCosts.TryGetValue(entry, out int value))
+                        _partCosts[entry] = value + 1;
+                    else
+                        _partCosts.Add(entry, 1);
+                }
+            }
+        }
+
+        private void RenderToolingPreviewButton()
+        {
+            var c = new GUIContent("Press to preview fully tooled integration time & cost", "Hold the button pressed and watch the cost & time values change in the Integration Info window");
+            if (GUILayout.RepeatButton(c, HighLogic.Skin.button, GUILayout.Width(500)))
+            {
+                if (!_isToolingTempDisabled)
+                {
+                    _isToolingTempDisabled = true;
+                    ToolingManager.Instance.toolingEnabled = false;
+                    GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
+                }
+            }
+            else if (_isToolingTempDisabled && Event.current.type == EventType.Repaint)   // button events are handled on the Repaint pass
+            {
+                ToolingManager.Instance.toolingEnabled = HighLogic.CurrentGame.Mode == Game.Modes.CAREER;
+                _isToolingTempDisabled = false;
+                GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
+            }
+        }
+
+        private static string FormatCostAndMultiplier(double cost, double multiplier)
+        { 
+            string ret = $"{cost * multiplier:N2}";
+            const double eps = 0.001;
+            if (Math.Abs(multiplier - 1) > eps)
+            {
+                ret = $"<color={CurrencyModifierQueryRP0.TextStylingColor(multiplier < 1, true)}>({LocalizationHandler.FormatRatioAsPercent(multiplier)})</color> " + ret;
+            }
+            return ret;
+        }
+
+        private static string GetPartDisplayName(Part p)
+        {
+            var toolingModule = p.FindModuleImplementingFast<ModuleTooling>();
+            if (toolingModule != null) 
+                // for single-tooling module parts we can insert this info to help disambiguate
+                return $"{p.partInfo?.title} ({toolingModule.ToolingTypeTitle}) {toolingModule.GetToolingParameterInfo()}";
+            
+            var engineModule = p.FindModuleImplementingFast<ModuleEngineConfigsBase>();
+            if (engineModule != null)
+                return $"{p.partInfo?.title} ({engineModule.configurationDisplay})";
+
+            return (p.partInfo?.title == null) ? "(unknown)" : p.partInfo.title;
+        }
+    }
+
+}

--- a/Source/RP0/UI/CostBreakdownGUI.cs
+++ b/Source/RP0/UI/CostBreakdownGUI.cs
@@ -16,28 +16,11 @@ namespace RP0.UI
             public string name;
             public double effectiveCost;
             public double effectiveCostModifier;
-
-            public override bool Equals(object obj)
-            {
-                if (obj is CostEntry other)
-                    return Equals(other);
-                else
-                    return false;
-            }
-
-            private bool Equals(CostEntry other)
-            {
-                return effectiveCost == other.effectiveCost && effectiveCostModifier == other.effectiveCostModifier && name == other.name;
-            }
-
-            public override int GetHashCode()
-            {
-                return (name, effectiveCost, effectiveCostModifier).GetHashCode();
-            }
         }
         
         private float _lastUpdateTrigger = 0f;
         private readonly Dictionary<CostEntry, int> _partCosts = new Dictionary<CostEntry, int>();
+        private readonly List<KeyValuePair<CostEntry, int>> _cachedSortedPartCosts = new List<KeyValuePair<CostEntry, int>>();
         private readonly List<Part> _singlePart = new List<Part>(); // dummy list for calling GetEffectiveCost, to avoid extra allocations
         private Vector2 _partCostsScroll = new Vector2();
         private bool _isToolingTempDisabled = false;
@@ -83,7 +66,7 @@ namespace RP0.UI
             GUILayout.EndHorizontal();
 
             _partCostsScroll = GUILayout.BeginScrollView(_partCostsScroll, GUILayout.Height(300), GUILayout.Width(500));
-            foreach (var kvp in _partCosts.OrderByDescending(kvp => kvp.Key.effectiveCost * kvp.Key.effectiveCostModifier * kvp.Value))
+            foreach (var kvp in _cachedSortedPartCosts)
             {
                 CostEntry entry = kvp.Key;
                 int multiplicity = kvp.Value;
@@ -130,10 +113,10 @@ namespace RP0.UI
             // Stall a frame.
 
             var parts = ship?.Parts; 
+            _partCosts.Clear();
+            _cachedSortedPartCosts.Clear();
             if (parts?.Count > 0)
             {
-                _partCosts.Clear();
-
                 for (int i = parts.Count - 1; i >= 0; --i)
                 {
                     Part p = parts[i];
@@ -152,6 +135,7 @@ namespace RP0.UI
                     else
                         _partCosts.Add(entry, 1);
                 }
+                _cachedSortedPartCosts.AddRange(_partCosts.OrderByDescending(kvp => kvp.Key.effectiveCost * kvp.Key.effectiveCostModifier * kvp.Value));
             }
         }
 

--- a/Source/RP0/UI/TopWindow.cs
+++ b/Source/RP0/UI/TopWindow.cs
@@ -1,4 +1,5 @@
 ﻿using ClickThroughFix;
+using RP0.UI;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace RP0
 
         private readonly MaintenanceGUI _maintUI = new MaintenanceGUI();
         private readonly ToolingGUI _toolUI = new ToolingGUI();
+        private readonly CostBreakdownGUI _costUI = new CostBreakdownGUI();
         private readonly Crew.TrainingGUI _fsUI = new Crew.TrainingGUI();
         private readonly AvionicsGUI _avUI = new AvionicsGUI();
         private readonly ContractGUI _contractUI = new ContractGUI();
@@ -41,6 +43,7 @@ namespace RP0
         {
             _maintUI.Start();
             _toolUI.Start();
+            _costUI.Start();
             _fsUI.Start();
             _avUI.Start();
             _contractUI.Start();
@@ -51,6 +54,7 @@ namespace RP0
         {
             _maintUI.Destroy();
             _toolUI.Destroy();
+            _costUI.Destroy();
             _fsUI.Destroy();
             _avUI.Destroy();
             _contractUI.Destroy();
@@ -67,13 +71,19 @@ namespace RP0
 
         private void UpdateSelectedTab()
         {
+            GUILayout.BeginVertical();
             GUILayout.BeginHorizontal();
             if (ShouldShowTab(UITab.Budget) && RenderToggleButton("Budget", _currentTab == UITab.Budget))
                 SwitchTabTo(UITab.Budget);
             if (ShouldShowTab(UITab.Tooling) && RenderToggleButton("Tooling", _currentTab == UITab.Tooling))
                 SwitchTabTo(UITab.Tooling);
+            if (ShouldShowTab(UITab.CostBreakdown) && RenderToggleButton("Cost Breakdown", _currentTab == UITab.CostBreakdown))
+                SwitchTabTo(UITab.CostBreakdown);
             if (ShouldShowTab(UITab.Astronauts) && RenderToggleButton("Astronauts", _currentTab == UITab.Astronauts))
                 SwitchTabTo(UITab.Astronauts);
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
             if (ShouldShowTab(UITab.Training) && RenderToggleButton("Training", _currentTab == UITab.Training))
                 SwitchTabTo(UITab.Training);
             if (ShouldShowTab(UITab.Avionics) && RenderToggleButton("Avionics", _currentTab == UITab.Avionics))
@@ -83,6 +93,7 @@ namespace RP0
             if (ShouldShowTab(UITab.CareerLog) && RenderToggleButton("Career Log", _currentTab == UITab.CareerLog))
                 SwitchTabTo(UITab.CareerLog);
             GUILayout.EndHorizontal();
+            GUILayout.EndVertical();
         }
 
         public void DrawWindow(int windowID)
@@ -139,6 +150,9 @@ namespace RP0
                             break;
                         case UITab.CareerLog:
                             _logUI.RenderTab();
+                            break;
+                        case UITab.CostBreakdown:
+                            _costUI.RenderCostBreakdownTab();
                             break;
                         default:    // can't happen
                             break;

--- a/Source/RP0/UI/UIBase.cs
+++ b/Source/RP0/UI/UIBase.cs
@@ -7,10 +7,11 @@ namespace RP0
         public enum UITab
         {
             Budget, Facilities, Integration, Construction, AstronautCosts, Tooling, ToolingType,
-            Astronauts, Training, NewCourse, Naut, Avionics, Contracts, CareerLog, Programs
+            Astronauts, Training, NewCourse, Naut, Avionics, Contracts, CareerLog, Programs,
+            CostBreakdown
         };
 
-        protected GUIStyle RightLabel, BoldLabel, BoldRightLabel, PressedButton, InfoButton;
+        protected GUIStyle RightLabel, BoldLabel, BoldRightLabel, PressedButton, InfoButton, HorizontalLineStyle;
 
         public UIBase()
         {
@@ -37,6 +38,12 @@ namespace RP0
                 fixedWidth = 19f,
                 contentOffset = new Vector2(1, -1),
                 margin = new RectOffset(4, 4, 6, 4)
+            };
+            HorizontalLineStyle = new GUIStyle()
+            {
+                normal = new GUIStyleState() { background = Texture2D.whiteTexture },
+                margin = new RectOffset(0, 0, 4, 4),
+                fixedHeight = 1
             };
         }
 
@@ -71,6 +78,8 @@ namespace RP0
                     return HighLogic.CurrentGame.Mode == Game.Modes.CAREER;
                 case UITab.Avionics:
                     return HighLogic.LoadedSceneIsEditor;
+                case UITab.CostBreakdown:
+                    return HighLogic.CurrentGame.Mode == Game.Modes.CAREER && HighLogic.LoadedSceneIsEditor;
                 case UITab.Astronauts:
                 case UITab.Training:
                 case UITab.NewCourse:
@@ -88,6 +97,14 @@ namespace RP0
         public bool RenderToggleButton(GUIContent c, bool selected, params GUILayoutOption[] options)
         {
             return GUILayout.Button(c, selected ? PressedButton : HighLogic.Skin.button, options);
+        }
+
+        protected void DrawHorizontalSeparator()
+        {
+            var c = GUI.color;
+            GUI.color = Color.white;
+            GUILayout.Box(GUIContent.none, HorizontalLineStyle);
+            GUI.color = c;
         }
     }
 }


### PR DESCRIPTION
<img width="524" height="514" alt="image" src="https://github.com/user-attachments/assets/c03c36d1-1470-4989-b91e-42680ebae6d5" />

[An untooled version of a Moonboots vehicle, because I needed something realistic with a 6-digit cost.]

The current implementation works, but it feels a little hacky and there's more logic duplication than I'm happy with. It also removes the debug log line in `GetEffectiveCostInternal` because otherwise we would start spamming the log.

This does also mean we recompute the cost of the vessel every 0.5s while the vessel is open, which could be computationally nasty for large vessels on weak computers.

Leaving as a draft for now to gather feedback on UI/UX and implementation details. It is fully functional, though.