### PR TITLE
Remove apoapsis check for 3 crewed orbital

### DIFF
--- a/GameData/RP-1/Contracts/Earth Crewed Adv/OrbitalFlight3.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed Adv/OrbitalFlight3.cfg
@@ -112,12 +112,6 @@ CONTRACT_TYPE
 	}
 	DATA
 	{
-		type = int
-		startApA = 300000 + Round(Random(0, 200000), 25000)
-		title = Apogee
-	}
-	DATA
-	{
 		type = double
 		Eccentricity = 0.0034
 		title = Eccentricity

--- a/GameData/RP-1/Contracts/Earth Crewed Adv/OrbitalFlight3.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed Adv/OrbitalFlight3.cfg
@@ -167,7 +167,6 @@ CONTRACT_TYPE
 			title = Stay in specified orbit for the duration
 			type = Orbit
 			minPeA = @/startPeA
-			maxApA = @/startApA
 			maxEccentricity = @/Eccentricity
 			targetBody = HomeWorld()
 			disableOnStateChange = true


### PR DESCRIPTION
It doesn't make sense to have a constraint for periapsis, apoapsis, AND eccentricity. Additionally, the way that the periapsis and apoapsis are set up means that they can rarely intersect with each other, as seen [here](https://discord.com/channels/319857228905447436/512556137380315139/1494155775126405273) (periapsis above 300km and apoapsis below 300km)