### PR TITLE
Provide confidence for optional contract parameters

### DIFF
--- a/GameData/RP-1/Contracts/Commercial Applications 2/FirstTargetedGeo.cfg
+++ b/GameData/RP-1/Contracts/Commercial Applications 2/FirstTargetedGeo.cfg
@@ -127,7 +127,7 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = OptVesselGroup
+			name = FirstTargetedGeoOptVG
 			type = VesselParameterGroup
 			title = Obtain a more precise orbit
 			rewardReputation = 20

--- a/GameData/RP-1/Contracts/Commercial Applications 2/GEORepeatComSats.cfg
+++ b/GameData/RP-1/Contracts/Commercial Applications 2/GEORepeatComSats.cfg
@@ -191,7 +191,7 @@ CONTRACT_TYPE
 		}
 		PARAMETER
 		{
-			name = OptVesselGroup
+			name = GEORepeatComSatsOptVG
 			type = VesselParameterGroup
 			title = Obtain a more precise orbit
 			rewardReputation = 20

--- a/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
+++ b/GameData/RP-1/Contracts/Earth Crewed Adv/Docking.cfg
@@ -114,7 +114,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = VesselGroup
+		name = FirstDockingOptRendevous
 		type = VesselParameterGroup
 		title = Dock to another spacecraft while in orbit. // does not require crew because of Kosmos 186 and 188 docking autonomously in 1967
 		define = dockingSpacecraft

--- a/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
+++ b/GameData/RP-1/Contracts/Lunar Crewed/CrewedMoonLandingTargeted.cfg
@@ -332,7 +332,7 @@ CONTRACT_TYPE
 	
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = RepeatMoonLandingCrewOptVG
 		type = VesselParameterGroup
 		title = Demonstrate precision landing
 		rewardReputation = 50

--- a/GameData/RP-1/Contracts/X-Plane Research/RocketPlaneDevelopmentOptional.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/RocketPlaneDevelopmentOptional.cfg
@@ -214,7 +214,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitude.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitude.cfg
@@ -137,7 +137,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitudeOptional.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHighAltitudeOptional.cfg
@@ -202,7 +202,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonic.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonic.cfg
@@ -152,7 +152,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonicOptional.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesHypersonicOptional.cfg
@@ -180,7 +180,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesKarman.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesKarman.cfg
@@ -140,7 +140,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesStratosphericResearch.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesStratosphericResearch.cfg
@@ -139,7 +139,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesStratosphericResearchOptional.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesStratosphericResearchOptional.cfg
@@ -164,7 +164,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesSuborbital.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesSuborbital.cfg
@@ -170,7 +170,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicMach2.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicMach2.cfg
@@ -149,7 +149,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalHigh.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalHigh.cfg
@@ -206,7 +206,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalLow.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesSupersonicOptionalLow.cfg
@@ -184,7 +184,7 @@ CONTRACT_TYPE
 
 	PARAMETER
 	{
-		name = OptVesselGroup
+		name = LandOnRunwayOptVG
 		type = VesselParameterGroup
 		title = OPTIONAL: Land on the runway with a descent angle lower than 10 degrees
 		rewardReputation = Round(@/rewardReputation * 0.3 + 0.4999, 1)

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -37,6 +37,11 @@ RP0_PROGRAM
 		XPlanesSuborbital = true
 		XPlanesHypersonicOptional = true
 	}
+
+	OPTIONAL_PARAMS
+	{
+		LandOnRunwayOptVG = true
+	}
 	
 	CONFIDENCECOSTS
 	{
@@ -687,6 +692,11 @@ RP0_PROGRAM
 		first_EVA = true // optional here, required in next
 		OrbitalFlight3 = true // we're skipping orb2
 	}
+
+	OPTIONAL_PARAMS
+	{
+		FirstDockingOptRendevous = true
+	}
 }
 
 RP0_PROGRAM
@@ -732,6 +742,11 @@ RP0_PROGRAM
 	{
 		OrbitalFlight2 = true
 		OrbitalFlight3 = true
+	}
+
+	OPTIONAL_PARAMS
+	{
+		FirstDockingOptRendevous = true
 	}
 }
 
@@ -843,6 +858,11 @@ RP0_PROGRAM
 	{
 		CrewedLunarOrbitRepeat = true
 		MoonExtendedStayCrew = true
+	}
+
+	OPTIONAL_PARAMS
+	{
+		RepeatMoonLandingCrewOptVG = true
 	}
 }
 
@@ -1977,6 +1997,12 @@ RP0_PROGRAM
 		GEORepeatComSats = true
 		MolniyaRepeatComSats = true
 		TundraRepeatComSats = true
+	}
+
+	OPTIONAL_PARAMS
+	{
+		FirstTargetedGeoOptVG = true
+		GEORepeatComSatsOptVG = true
 	}
 
 	CONFIDENCECOSTS

--- a/Source/RP0/Harmony/ContractParameter.cs
+++ b/Source/RP0/Harmony/ContractParameter.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using KSP.UI.Screens;
 using Contracts;
 
@@ -13,13 +13,15 @@ namespace RP0.Harmony
         [HarmonyPatch("SendStateMessage")]
         internal static void Prefix_SendStateMessage(ContractParameter __instance, ref string message, MessageSystemButton.ButtonIcons icon)
         {
-            if (icon != MessageSystemButton.ButtonIcons.COMPLETE || !__instance.Optional)
-                return;
-
-            if (__instance.Root is ContractConfigurator.ConfiguredContract cc && Programs.ProgramHandler.Instance != null && Programs.ProgramHandler.Instance.RepToConfidenceForContract(cc, true) is float repToConf && repToConf > 0f)
+            if (_storedRep != 0f && icon == MessageSystemButton.ButtonIcons.COMPLETE &&
+                __instance.Optional && Programs.ProgramHandler.Instance != null)
             {
-                var cmq = CurrencyModifierQueryRP0.RunQuery(TransactionReasonsRP0.ContractReward, 0d, 0d, 0d, _storedRep * repToConf, 0d);
-                message += $"<color={CurrencyModifierQueryRP0.CurrencyColor(CurrencyRP0.Confidence)}>{CurrencyModifierQueryRP0.SpriteString(CurrencyRP0.Confidence)} {cmq.GetTotal(CurrencyRP0.Confidence):N0} {cmq.GetEffectDeltaText(CurrencyRP0.Confidence, "N0", CurrencyModifierQuery.TextStyling.OnGUI)}  </color>";
+                float repToConf = Programs.ProgramHandler.Instance.RepToConfidenceForParam(__instance, true);
+                if (repToConf > 0f)
+                {
+                    var cmq = CurrencyModifierQueryRP0.RunQuery(TransactionReasonsRP0.ContractReward, 0d, 0d, 0d, _storedRep * repToConf, 0d);
+                    message += $"<color={CurrencyModifierQueryRP0.CurrencyColor(CurrencyRP0.Confidence)}>{CurrencyModifierQueryRP0.SpriteString(CurrencyRP0.Confidence)} {cmq.GetTotal(CurrencyRP0.Confidence):N0} {cmq.GetEffectDeltaText(CurrencyRP0.Confidence, "N0", CurrencyModifierQuery.TextStyling.OnGUI)}  </color>";
+                }
             }
         }
 
@@ -29,10 +31,25 @@ namespace RP0.Harmony
         {
             //KSP sets the rewards to 0 as part of this!
             //So we have to intercept and store the value.
-            if (__instance.Root is ContractConfigurator.ConfiguredContract cc && Programs.ProgramHandler.Instance != null && Programs.ProgramHandler.Instance.RepToConfidenceForContract(cc, true) is float repToConf && repToConf > 0f)
+            _storedRep = 0f;
+            if (Programs.ProgramHandler.Instance != null)
             {
-                _storedRep = __instance.ReputationCompletion / (float)CurrencyUtils.Rep(TransactionReasonsRP0.ContractReward, 1d);
+                float repToConf = Programs.ProgramHandler.Instance.RepToConfidenceForParam(__instance, true);
+                if (repToConf > 0f)
+                    _storedRep = __instance.ReputationCompletion / (float)CurrencyUtils.Rep(TransactionReasonsRP0.ContractReward, 1d);
             }
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch("AwardCompletion")]
+        internal static void Postfix_AwardCompletion(ContractParameter __instance)
+        {
+            if (_storedRep == 0f || Programs.ProgramHandler.Instance == null)
+                return;
+
+            float repToConf = Programs.ProgramHandler.Instance.RepToConfidenceForParam(__instance, true);
+            if (repToConf > 0f)
+                Confidence.Instance.AddConfidence(repToConf * _storedRep, TransactionReasons.ContractReward);
         }
     }
 }

--- a/Source/RP0/Programs/Program.cs
+++ b/Source/RP0/Programs/Program.cs
@@ -152,6 +152,8 @@ namespace RP0.Programs
 
         public List<string> optionalContracts = new List<string>();
 
+        public List<string> optionalParams = new List<string>();
+
         public RequirementBlock RequirementsBlock;
         public RequirementBlock ObjectivesBlock;
 
@@ -205,6 +207,7 @@ namespace RP0.Programs
             _objectivesPredicate = toCopy._objectivesPredicate;
             programsToDisableOnAccept = toCopy.programsToDisableOnAccept;
             optionalContracts = toCopy.optionalContracts;
+            optionalParams = toCopy.optionalParams;
             speed = toCopy.speed;
             confidenceCosts = new Dictionary<Speed, float>(toCopy.confidenceCosts);
             repToConfidence = toCopy.repToConfidence;
@@ -260,6 +263,13 @@ namespace RP0.Programs
             {
                 foreach (Value v in cn.values)
                     optionalContracts.Add(v.name);
+            }
+
+            cn = node.GetNode("OPTIONAL_PARAMS");
+            if (cn != null)
+            {
+                foreach (Value v in cn.values)
+                    optionalParams.Add(v.name);
             }
 
             LoadConfidenceCosts(node, confidenceCosts);

--- a/Source/RP0/Programs/ProgramHandler.cs
+++ b/Source/RP0/Programs/ProgramHandler.cs
@@ -336,6 +336,22 @@ namespace RP0.Programs
             return 0f;
         }
 
+        public float RepToConfidenceForParam(ContractParameter param, bool isAwarding)
+        {
+            foreach (Program p in ActivePrograms)
+                if (p.optionalParams.Contains(param.ID))
+                    return p.RepToConfidence;
+
+            if (isAwarding)
+                return 0f;
+
+            foreach (Program p in CompletedPrograms)
+                if (p.optionalParams.Contains(param.ID))
+                    return p.RepToConfidence;
+
+            return 0f;
+        }
+
         private void OnContractAccept(Contract data)
         {
             if (SpaceCenterManagement.Instance.StartedProgram)
@@ -371,15 +387,10 @@ namespace RP0.Programs
                     SpaceCenterManagement.Instance.Applicants += applicants;
 
                 // Handle Confidence
+                // Note: optional parameter confidence is awarded at parameter completion time (see PatchContractParameter.Postfix_AwardCompletion).
                 float repToConf = RepToConfidenceForContract(cc, true);
                 if (repToConf > 0f)
-                {
-                    float rep = 0;
-                    foreach (var param in cc.AllParameters)
-                        if (param.Optional && param.ReputationCompletion > 0 && param.State == ParameterState.Complete)
-                            rep += param.ReputationCompletion;
-                    Confidence.Instance.AddConfidence(repToConf * (rep + data.ReputationCompletion), TransactionReasons.ContractReward);
-                }
+                    Confidence.Instance.AddConfidence(repToConf * data.ReputationCompletion, TransactionReasons.ContractReward);
             }
         }
 


### PR DESCRIPTION
All contract parameters that provide confidence now need to be configured at the program level in `OPTIONAL_PARAMS` node.
It's entirely possible that the optional runway landings will now provide way too much confidence. At least I didn't make the experiments in Stations program provide any extra as the collected science itself will convert to confidence.

Closes #2401 