### PR TITLE
Improve Parts Browser docs and files for Linux and Mac

### DIFF
--- a/Source/Tech Tree/Parts Browser/README.md
+++ b/Source/Tech Tree/Parts Browser/README.md
@@ -3,7 +3,12 @@ This is a browser/editor application for the RP-1 parts list (converted to json 
 
 To get it working:
    1. Download and unzip the ZIP file of the source code
-   2. Open RP-1/Source/Tech Tree/Parts Browser/app.exe
+   2. Run the application
+      1. Windows: Run `RP-1/Source/Tech Tree/Parts Browser/app.exe`
+      2. Linux/Mac:
+         1. Open `RP-1/Source/Tech Tree/Parts Browser/`
+         2. Run `pip install -r requirements.txt` (only the first time)
+         3. Run `./app.py`
    3. Ignore any errors and wait a minute for the web server to start
    4. Open http://localhost:5000/dashboard
 

--- a/Source/Tech Tree/Parts Browser/app.py
+++ b/Source/Tech Tree/Parts Browser/app.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import json
 

--- a/Source/Tech Tree/Parts Browser/requirements.txt
+++ b/Source/Tech Tree/Parts Browser/requirements.txt
@@ -1,0 +1,2 @@
+flask
+slugify


### PR DESCRIPTION
It is currently non-obvious how to run the Parts Browser in environments other than Windows for which there is a pre-compiled exe. This PR updates `app.py` to be executable, adds a `requirements.txt` for installing the python dependencies, and updates `README.md` with relevant instructions.

Ideally the `requirements.txt` would be replaced by a `pyproject.toml` that fully describes the build process used to produce `app.exe`.