### PR TITLE
Rework unlockable PartUpgrade tips

### DIFF
--- a/Source/RP0/Addons/GameplayTips.cs
+++ b/Source/RP0/Addons/GameplayTips.cs
@@ -12,10 +12,6 @@ namespace RP0
         private static bool _airlaunchTipShown;
         private static bool _isInterplanetaryWarningShown;
 
-        private bool _subcribedToPAWEvent;
-        private bool _hasNewPurchasableRATL;
-        private int _highestUnlockableRALvl;
-
         public static GameplayTips Instance { get; private set; }
 
         internal void Awake()
@@ -56,29 +52,6 @@ namespace RP0
                 }
 
                 StartCoroutine(CheckLandedWhileActuallyFlying());
-            }
-            else if (HighLogic.LoadedSceneIsEditor)
-            {
-                LoadRAUpgradeStatus(rp0Settings);
-
-                if (_hasNewPurchasableRATL)
-                {
-                    GameEvents.onPartActionUIShown.Add(OnPartActionUIShown);
-                    _subcribedToPAWEvent = true;
-                }
-            }
-        }
-
-        internal void OnDestroy()
-        {
-            if (_subcribedToPAWEvent) GameEvents.onPartActionUIShown.Remove(OnPartActionUIShown);
-        }
-
-        private void OnPartActionUIShown(UIPartActionWindow paw, Part part)
-        {
-            if (_hasNewPurchasableRATL && part.Modules.Contains("ModuleRealAntenna"))
-            {
-                ShowRATechAvailableTip();
             }
         }
 
@@ -147,23 +120,6 @@ namespace RP0
 
             double ecTotal = ship.Parts.Sum(p => p.Resources.Get("ElectricCharge")?.maxAmount ?? 0);
             return ecTotal > 10000;
-        }
-
-        private void ShowRATechAvailableTip()
-        {
-            var rp0Settings = HighLogic.CurrentGame.Parameters.CustomParams<RP0Settings>();
-            rp0Settings.RATLTipShown = _highestUnlockableRALvl;
-            _hasNewPurchasableRATL = false;
-
-            string msg = $"Communications Tech Level {_highestUnlockableRALvl} has been researched but not purchased. Purchase it in the R&D building to use higher-tech comms.";
-            PopupDialog.SpawnPopupDialog(new Vector2(0.5f, 0.5f),
-                                         new Vector2(0.5f, 0.5f),
-                                         "ShowRATLTip",
-                                         "New comms tech available",
-                                         msg,
-                                         KSP.Localization.Localizer.GetStringByTag("#autoLOC_190905"),
-                                         false,
-                                         HighLogic.UISkin).HideGUIsWhilePopup();
         }
 
         private IEnumerator CheckLandedWhileActuallyFlying()
@@ -284,29 +240,6 @@ namespace RP0
                 KSP.Localization.Localizer.Format("#rp0_GameplayTip_LaunchUntrainedPart_Text"),
                 KSP.Localization.Localizer.Format("#rp0_GameplayTip_LaunchUntrainedPart_Title"), null, 300, options);
             PopupDialog.SpawnPopupDialog(diag, false, HighLogic.UISkin).HideGUIsWhilePopup();
-        }
-
-        private void LoadRAUpgradeStatus(RP0Settings rp0Settings)
-        {
-            _highestUnlockableRALvl = rp0Settings.RATLTipShown;
-            const int tlUpgradeCount = 9;
-            for (int i = rp0Settings.RATLTipShown + 1; i <= tlUpgradeCount; i++)
-            {
-                string upgradeName = "commsTL" + i;
-                if (PartUpgradeManager.Handler.IsEnabled(upgradeName))
-                {
-                    rp0Settings.RATLTipShown = i;
-                    continue;
-                }
-        
-                if (PartUpgradeManager.Handler.IsAvailableToUnlock(upgradeName))
-                {
-                    _highestUnlockableRALvl = i;
-                    _hasNewPurchasableRATL = true;
-                    continue;
-                }
-                break;
-            }
         }
     }
 }

--- a/Source/RP0/Addons/RnDUpgradeTips.cs
+++ b/Source/RP0/Addons/RnDUpgradeTips.cs
@@ -1,0 +1,202 @@
+﻿using RealFuels;
+using RP0.UI;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace RP0.Addons
+{
+    [KSPAddon(KSPAddon.Startup.EditorAny, false)]
+    public class RnDUpgradeTips : MonoBehaviour
+    {
+        private class UpgradeLine
+        {
+            private readonly string[] _upgradeNames;
+            private readonly string _moduleName;
+            private readonly string _displayName;
+            private bool _subscribedToPAWEvent;
+
+            public int bestUpgrade { get; private set; } = -1;
+            public int bestUnpurchasedUpgrade { get; private set; } = -1;
+
+            public UpgradeLine(string moduleName, string displayName, string[] names)
+            {
+                _moduleName = moduleName;
+                _displayName = displayName;
+                _upgradeNames = names;
+            }
+
+            public void OnDestroy()
+            { 
+                if (_subscribedToPAWEvent) GameEvents.onPartActionUIShown.Remove(OnPartActionUIShown);
+            }
+
+            public PartUpgradeHandler.Upgrade GetUpgrade(int index)
+            {
+                return PartUpgradeManager.Handler.GetUpgrade(_upgradeNames[index]);
+            }
+
+            public int UpdateUpgradeInfo(int skipIndex)
+            {
+                bestUpgrade = skipIndex;
+                bestUnpurchasedUpgrade = -1;
+                for (int i = skipIndex + 1; i < _upgradeNames.Length; ++i)
+                {
+                    if (PartUpgradeManager.Handler.IsUnlocked(_upgradeNames[i]))
+                        bestUpgrade = i;
+                    else if (PartUpgradeManager.Handler.IsAvailableToUnlock(_upgradeNames[i]))
+                        bestUnpurchasedUpgrade = i;
+                }
+                if (bestUnpurchasedUpgrade > bestUpgrade && !_subscribedToPAWEvent)
+                {
+                    _subscribedToPAWEvent = true;
+                    GameEvents.onPartActionUIShown.Add(OnPartActionUIShown);
+                }
+                return bestUpgrade;
+            }
+
+            private void OnPartActionUIShown(UIPartActionWindow paw, Part part)
+            {
+                if (bestUnpurchasedUpgrade > bestUpgrade && part.Modules.Contains(_moduleName))
+                    ShowAvailableTechTip();
+            }
+
+            private void ShowAvailableTechTip()
+            {
+                List<DialogGUIBase> controls = new List<DialogGUIBase>();
+                string msg = $"A new <color=orange>{_displayName}</color> upgrade is available, and must be purchased here or in the R&D building before it can be used.\n" + 
+                             "<color=orange>NOTE: For upgrades to apply, either a scene change must occur, or affected parts must be deleted and replaced.</color>";
+                controls.Add(new DialogGUILabel(msg));
+
+                var upgrade = GetUpgrade(bestUnpurchasedUpgrade);
+
+                string txt = $"{upgrade.title}: {upgrade.description}\n";
+                var cmq = CurrencyModifierQueryRP0.RunQuery(TransactionReasonsRP0.PartOrUpgradeUnlock, -upgrade.entryCost, 0f, 0f);
+                string costStr = cmq.GetCostLineOverride(true, false, false, true);
+                double trueTotal = -cmq.GetTotal(CurrencyRP0.Funds, false);
+                double invertCMQOp = upgrade.entryCost / trueTotal;
+                double creditAmtToUse = Math.Min(trueTotal, UnlockCreditHandler.Instance.TotalCredit);
+                cmq.AddPostDelta(CurrencyRP0.Funds, creditAmtToUse, true);
+                string afterCreditLine = cmq.GetCostLineOverride(true, false, true, true, true);
+                if (string.IsNullOrEmpty(afterCreditLine))
+                    afterCreditLine = "free";
+                var button = new DialogGUIButtonWithTooltip($"Unlock ({afterCreditLine})",
+                    () =>
+                    {
+                        Harmony.RFECMPatcher.techNode = upgrade.techRequired;
+                        bool success = EntryCostManager.Instance.PurchaseConfig(upgrade.name);
+                        Harmony.RFECMPatcher.techNode = null;
+                        if (success)
+                        {
+                            PartUpgradeManager.Handler.SetUnlocked(upgrade.name, true);
+                            GameEvents.OnPartUpgradePurchased.Fire(upgrade);
+                            bestUpgrade = bestUnpurchasedUpgrade;
+                            UpdateShownUpgradeIndex(_displayName, bestUpgrade);
+                        }
+                    }, () => cmq.CanAfford(), 100, -1, true) 
+                    { tooltipText = $"Spending {creditAmtToUse:N0} unlock credit\n(Base cost {costStr})" };
+                controls.Add(new DialogGUIHorizontalLayout(TextAnchor.MiddleLeft,
+                                new DialogGUILabel(txt, expandW: true),
+                                button));
+                controls.Add(new DialogGUIFlexibleSpace());
+                controls.Add(new DialogGUIHorizontalLayout(sw: true, sh: false, 
+                    new DialogGUIButton(KSP.Localization.Localizer.GetStringByTag("#autoLOC_190905"), () => { }), 
+                    new DialogGUIButton(KSP.Localization.Localizer.GetStringByTag("#rp0_GameplayTip_DontShowAgain"), () => 
+                    { 
+                        bestUpgrade = bestUnpurchasedUpgrade;
+                        UpdateShownUpgradeIndex(_displayName, bestUpgrade);
+                    }
+                )));
+
+
+                var dlgRect = new Rect(0.5f, 0.5f, 400, 100);
+
+                PopupDialog.SpawnPopupDialog(new Vector2(0.5f, 0.5f), new Vector2(0.5f, 0.5f),
+                    new MultiOptionDialog("newAvailablePartUpgradePopup",
+                        null,
+                        $"New {_displayName} Upgrade",
+                        HighLogic.UISkin,
+                        dlgRect,
+                        controls.ToArray()),
+                    false,
+                    HighLogic.UISkin).HideGUIsWhilePopup();
+            }
+        }
+
+        public static RnDUpgradeTips Instance { get; private set; }
+
+        private UpgradeLine _fairings;
+        private UpgradeLine _hardDrives;
+        private UpgradeLine _mli;
+        private UpgradeLine _x2;
+
+        internal void Awake()
+        {
+            if (Instance != null)
+            {
+                Destroy(Instance);
+            }
+            Instance = this;
+        }
+
+        internal void Start()
+        {
+            string[] fairings = { "I", "II", "III", "IV", "V", "VI" };
+            for (int i = fairings.Length - 1; i >= 0; --i)
+            {
+                fairings[i] = "PFTech-Fairing-" + fairings[i];
+            }
+            _fairings = new UpgradeLine("ProceduralFairingSide", "Fairing Density", fairings);
+
+            string[] hardDrives = { "Early", "Basic", "1961", "1964", "1969", "1975", "1990", "1998", "2010", "2020" };
+            for (int i = hardDrives.Length - 1; i >= 0; --i)
+            {
+                hardDrives[i] = "HDD-Upgrade-" + hardDrives[i];
+            }
+            _hardDrives = new UpgradeLine("ModuleProceduralAvionics", "Data Storage", hardDrives);
+
+            string[] mli = new string[5];
+            for (int i = 0; i < 5; ++i)
+            {
+                mli[i] = $"MLI.Upgrade{i+1}";
+            }
+            _mli = new UpgradeLine("ModuleFuelTanks", "Multi-Layer Insulation", mli);
+
+            _x2 = new UpgradeLine("ModuleUnpressurizedCockpit", "X-1 Service Ceiling", ["X2CockpitUpgrade"]);
+            
+            var rp0Settings = HighLogic.CurrentGame.Parameters.CustomParams<RP0Settings>();
+            rp0Settings.FairingTLTipShown = _fairings.UpdateUpgradeInfo(rp0Settings.FairingTLTipShown);
+            rp0Settings.HardDriveTipShown = _hardDrives.UpdateUpgradeInfo(rp0Settings.HardDriveTipShown);
+            rp0Settings.MLITipShown = _mli.UpdateUpgradeInfo(rp0Settings.MLITipShown);
+            rp0Settings.X2TipShown = _x2.UpdateUpgradeInfo(rp0Settings.X2TipShown);
+        }
+
+        internal void OnDestroy()
+        {
+            _fairings.OnDestroy();
+            _hardDrives.OnDestroy();
+            _mli.OnDestroy();
+            _x2.OnDestroy();
+        }
+
+        private static void UpdateShownUpgradeIndex(string displayName, int index)
+        {
+            var rp0Settings = HighLogic.CurrentGame.Parameters.CustomParams<RP0Settings>();
+            switch (displayName)
+            {
+                case "Fairing Density":
+                    rp0Settings.FairingTLTipShown = index;
+                    break;
+                case "Data Storage":
+                    rp0Settings.HardDriveTipShown = index;
+                    break;
+                case "Multi-Layer Insulation":
+                    rp0Settings.MLITipShown = index;
+                    break;
+                case "X-1 Service Ceiling":
+                    rp0Settings.X2TipShown = index;
+                    break;
+            }
+        }
+    }
+}

--- a/Source/RP0/Properties/AssemblyInfo.cs
+++ b/Source/RP0/Properties/AssemblyInfo.cs
@@ -47,6 +47,7 @@ using System.Runtime.InteropServices;
 [assembly: KSPAssemblyDependency("RealFuels", 15, 7)]
 [assembly: KSPAssemblyDependency("RealAntennas", 2, 6)]
 [assembly: KSPAssemblyDependency("ROUtils", 1, 1, 0)]
+[assembly: KSPAssemblyDependency("ROLib", 2, 0, 0)]
 [assembly: KSPAssemblyDependency("ClickThroughBlocker", 1, 8)]
 [assembly: KSPAssemblyDependency("ContractConfigurator", 2, 6)]
 [assembly: KSPAssemblyDependency("ToolbarController", 1, 0)]

--- a/Source/RP0/RP0.csproj
+++ b/Source/RP0/RP0.csproj
@@ -40,6 +40,7 @@
       $(ReferencePath.TrimEnd([System.IO.Path]::DirectorySeparatorChar))</KSPRoot>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Addons\RnDUpgradeTips.cs" />
     <Compile Include="Avionics\ControlLockerUtils.cs" />
     <Compile Include="Avionics\EditorBinder.cs" />
     <Compile Include="ConfigurableStart\DateHandler.cs" />
@@ -338,6 +339,10 @@
       <HintPath>$(ReferencePath)/RealFuels.dll</HintPath>
       <Private>False</Private>
     </Reference>
+		<Reference Include="$(KSPRoot)/GameData/ROLib/Plugins/ROLib.dll">
+			<HintPath>$(ReferencePath)/ROLib.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
     <Reference Include="$(KSPRoot)/GameData/ROUtils/Plugins/ROUtils.dll">
       <HintPath>$(ReferencePath)/ROUtils.dll</HintPath>
       <Private>False</Private>

--- a/Source/RP0/RP0.csproj
+++ b/Source/RP0/RP0.csproj
@@ -40,7 +40,7 @@
       $(ReferencePath.TrimEnd([System.IO.Path]::DirectorySeparatorChar))</KSPRoot>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Addons\RnDUpgradeTips.cs" />
+    <Compile Include="ScenarioModules\RnDUpgradeTips.cs" />
     <Compile Include="Avionics\ControlLockerUtils.cs" />
     <Compile Include="Avionics\EditorBinder.cs" />
     <Compile Include="ConfigurableStart\DateHandler.cs" />
@@ -339,10 +339,10 @@
       <HintPath>$(ReferencePath)/RealFuels.dll</HintPath>
       <Private>False</Private>
     </Reference>
-		<Reference Include="$(KSPRoot)/GameData/ROLib/Plugins/ROLib.dll">
-			<HintPath>$(ReferencePath)/ROLib.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
+    <Reference Include="$(KSPRoot)/GameData/ROLib/Plugins/ROLib.dll">
+      <HintPath>$(ReferencePath)/ROLib.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="$(KSPRoot)/GameData/ROUtils/Plugins/ROUtils.dll">
       <HintPath>$(ReferencePath)/ROUtils.dll</HintPath>
       <Private>False</Private>

--- a/Source/RP0/ScenarioModules/RnDUpgradeTips.cs
+++ b/Source/RP0/ScenarioModules/RnDUpgradeTips.cs
@@ -27,7 +27,7 @@ namespace RP0.Addons
                 _moduleName = moduleName;
                 _displayName = displayName;
                 _upgradeNames = names;
-                bestUpgrade = Instance.GetOrCreateUpgradeIndex(id);
+                bestUpgrade = _upgradeNames.IndexOf(Instance.GetBestShownUpgradeName(id));
                 UpdateUpgradeInfo();
             }
 
@@ -56,7 +56,8 @@ namespace RP0.Addons
                     _subscribedToPAWEvent = true;
                     GameEvents.onPartActionUIShown.Add(OnPartActionUIShown);
                 }
-                Instance.UpdateUpgradeIndex(_id, bestUpgrade);
+                if (bestUpgrade != -1)
+                    Instance.UpdateBestShownUpgradeName(_id, _upgradeNames[bestUpgrade]);
             }
 
             private void OnPartActionUIShown(UIPartActionWindow paw, Part part)
@@ -95,7 +96,7 @@ namespace RP0.Addons
                             PartUpgradeManager.Handler.SetUnlocked(upgrade.name, true);
                             GameEvents.OnPartUpgradePurchased.Fire(upgrade);
                             bestUpgrade = bestUnpurchasedUpgrade;
-                            Instance.UpdateUpgradeIndex(_id, bestUpgrade);
+                            Instance.UpdateBestShownUpgradeName(_id, upgrade.name);
                         }
                     }, () => cmq.CanAfford(), 100, -1, true) 
                     { tooltipText = $"Spending {creditAmtToUse:N0} unlock credit\n(Base cost {costStr})" };
@@ -108,7 +109,7 @@ namespace RP0.Addons
                     new DialogGUIButton(KSP.Localization.Localizer.GetStringByTag("#rp0_GameplayTip_DontShowAgain"), () => 
                     { 
                         bestUpgrade = bestUnpurchasedUpgrade;
-                        Instance.UpdateUpgradeIndex(_id, bestUpgrade);
+                        Instance.UpdateBestShownUpgradeName(_id, upgrade.name);
                     }
                 )));
 
@@ -135,7 +136,7 @@ namespace RP0.Addons
         private UpgradeLine _x2;
 
         [KSPField(isPersistant = true)]
-        private PersistentDictionaryValueTypes<string, int> _bestUpgrades = new PersistentDictionaryValueTypes<string, int>();
+        private PersistentDictionaryValueTypes<string, string> _bestUpgrades = new PersistentDictionaryValueTypes<string, string>();
 
         public override void OnAwake()
         {
@@ -180,17 +181,17 @@ namespace RP0.Addons
             _x2.OnDestroy();
         }
 
-        public int GetOrCreateUpgradeIndex(string id)
+        public string GetBestShownUpgradeName(string id)
         {
-            if (_bestUpgrades.TryGetValue(id, out int index))
-                return index;
-            return _bestUpgrades[id] = -1;
+            if (_bestUpgrades.TryGetValue(id, out string name))
+                return name;
+            return null;
         }
 
-        public void UpdateUpgradeIndex(string id, int index)
+        public void UpdateBestShownUpgradeName(string id, string name)
         {
-            RP0Debug.Log($"Upgrade {id} set to {index}");
-            _bestUpgrades[id] = index;
+            RP0Debug.Log($"[RnDUpgradeTips] Upgrade {id} set to {name}");
+            _bestUpgrades[id] = name;
         }
     }
 }

--- a/Source/RP0/ScenarioModules/RnDUpgradeTips.cs
+++ b/Source/RP0/ScenarioModules/RnDUpgradeTips.cs
@@ -1,4 +1,5 @@
 ﻿using RealFuels;
+using ROUtils.DataTypes;
 using RP0.UI;
 using System;
 using System.Collections.Generic;
@@ -6,11 +7,12 @@ using UnityEngine;
 
 namespace RP0.Addons
 {
-    [KSPAddon(KSPAddon.Startup.EditorAny, false)]
-    public class RnDUpgradeTips : MonoBehaviour
+    [KSPScenario((ScenarioCreationOptions)480, [GameScenes.EDITOR])]
+    public class RnDUpgradeTips : ScenarioModule
     {
         private class UpgradeLine
         {
+            private readonly string _id;
             private readonly string[] _upgradeNames;
             private readonly string _moduleName;
             private readonly string _displayName;
@@ -19,15 +21,18 @@ namespace RP0.Addons
             public int bestUpgrade { get; private set; } = -1;
             public int bestUnpurchasedUpgrade { get; private set; } = -1;
 
-            public UpgradeLine(string moduleName, string displayName, string[] names)
+            public UpgradeLine(string id, string moduleName, string displayName, string[] names)
             {
+                _id = id;
                 _moduleName = moduleName;
                 _displayName = displayName;
                 _upgradeNames = names;
+                bestUpgrade = Instance.GetOrCreateUpgradeIndex(id);
+                UpdateUpgradeInfo();
             }
 
             public void OnDestroy()
-            { 
+            {
                 if (_subscribedToPAWEvent) GameEvents.onPartActionUIShown.Remove(OnPartActionUIShown);
             }
 
@@ -36,11 +41,10 @@ namespace RP0.Addons
                 return PartUpgradeManager.Handler.GetUpgrade(_upgradeNames[index]);
             }
 
-            public int UpdateUpgradeInfo(int skipIndex)
+            public void UpdateUpgradeInfo()
             {
-                bestUpgrade = skipIndex;
                 bestUnpurchasedUpgrade = -1;
-                for (int i = skipIndex + 1; i < _upgradeNames.Length; ++i)
+                for (int i = bestUpgrade + 1; i < _upgradeNames.Length; ++i)
                 {
                     if (PartUpgradeManager.Handler.IsUnlocked(_upgradeNames[i]))
                         bestUpgrade = i;
@@ -52,7 +56,7 @@ namespace RP0.Addons
                     _subscribedToPAWEvent = true;
                     GameEvents.onPartActionUIShown.Add(OnPartActionUIShown);
                 }
-                return bestUpgrade;
+                Instance.UpdateUpgradeIndex(_id, bestUpgrade);
             }
 
             private void OnPartActionUIShown(UIPartActionWindow paw, Part part)
@@ -91,7 +95,7 @@ namespace RP0.Addons
                             PartUpgradeManager.Handler.SetUnlocked(upgrade.name, true);
                             GameEvents.OnPartUpgradePurchased.Fire(upgrade);
                             bestUpgrade = bestUnpurchasedUpgrade;
-                            UpdateShownUpgradeIndex(_displayName, bestUpgrade);
+                            Instance.UpdateUpgradeIndex(_id, bestUpgrade);
                         }
                     }, () => cmq.CanAfford(), 100, -1, true) 
                     { tooltipText = $"Spending {creditAmtToUse:N0} unlock credit\n(Base cost {costStr})" };
@@ -104,7 +108,7 @@ namespace RP0.Addons
                     new DialogGUIButton(KSP.Localization.Localizer.GetStringByTag("#rp0_GameplayTip_DontShowAgain"), () => 
                     { 
                         bestUpgrade = bestUnpurchasedUpgrade;
-                        UpdateShownUpgradeIndex(_displayName, bestUpgrade);
+                        Instance.UpdateUpgradeIndex(_id, bestUpgrade);
                     }
                 )));
 
@@ -130,12 +134,13 @@ namespace RP0.Addons
         private UpgradeLine _mli;
         private UpgradeLine _x2;
 
-        internal void Awake()
+        [KSPField(isPersistant = true)]
+        private PersistentDictionaryValueTypes<string, int> _bestUpgrades = new PersistentDictionaryValueTypes<string, int>();
+
+        public override void OnAwake()
         {
             if (Instance != null)
-            {
                 Destroy(Instance);
-            }
             Instance = this;
         }
 
@@ -146,57 +151,46 @@ namespace RP0.Addons
             {
                 fairings[i] = "PFTech-Fairing-" + fairings[i];
             }
-            _fairings = new UpgradeLine("ProceduralFairingSide", "Fairing Density", fairings);
+            _fairings = new UpgradeLine("fairings", "ProceduralFairingSide", "Fairing Density", fairings);
 
             string[] hardDrives = { "Early", "Basic", "1961", "1964", "1969", "1975", "1990", "1998", "2010", "2020" };
             for (int i = hardDrives.Length - 1; i >= 0; --i)
             {
                 hardDrives[i] = "HDD-Upgrade-" + hardDrives[i];
             }
-            _hardDrives = new UpgradeLine("ModuleProceduralAvionics", "Data Storage", hardDrives);
+            _hardDrives = new UpgradeLine("storage", "ModuleProceduralAvionics", "Data Storage", hardDrives);
 
             string[] mli = new string[5];
             for (int i = 0; i < 5; ++i)
             {
                 mli[i] = $"MLI.Upgrade{i+1}";
             }
-            _mli = new UpgradeLine("ModuleFuelTanks", "Multi-Layer Insulation", mli);
+            _mli = new UpgradeLine("mli", "ModuleFuelTanks", "Multi-Layer Insulation", mli);
 
-            _x2 = new UpgradeLine("ModuleUnpressurizedCockpit", "X-1 Service Ceiling", ["X2CockpitUpgrade"]);
-            
-            var rp0Settings = HighLogic.CurrentGame.Parameters.CustomParams<RP0Settings>();
-            rp0Settings.FairingTLTipShown = _fairings.UpdateUpgradeInfo(rp0Settings.FairingTLTipShown);
-            rp0Settings.HardDriveTipShown = _hardDrives.UpdateUpgradeInfo(rp0Settings.HardDriveTipShown);
-            rp0Settings.MLITipShown = _mli.UpdateUpgradeInfo(rp0Settings.MLITipShown);
-            rp0Settings.X2TipShown = _x2.UpdateUpgradeInfo(rp0Settings.X2TipShown);
+            _x2 = new UpgradeLine("x2", "ModuleUnpressurizedCockpit", "X-1 Service Ceiling", ["X2CockpitUpgrade"]);
         }
 
-        internal void OnDestroy()
+        public void OnDestroy()
         {
+            if (Instance == this)
+                Instance = null;
             _fairings.OnDestroy();
             _hardDrives.OnDestroy();
             _mli.OnDestroy();
             _x2.OnDestroy();
         }
 
-        private static void UpdateShownUpgradeIndex(string displayName, int index)
+        public int GetOrCreateUpgradeIndex(string id)
         {
-            var rp0Settings = HighLogic.CurrentGame.Parameters.CustomParams<RP0Settings>();
-            switch (displayName)
-            {
-                case "Fairing Density":
-                    rp0Settings.FairingTLTipShown = index;
-                    break;
-                case "Data Storage":
-                    rp0Settings.HardDriveTipShown = index;
-                    break;
-                case "Multi-Layer Insulation":
-                    rp0Settings.MLITipShown = index;
-                    break;
-                case "X-1 Service Ceiling":
-                    rp0Settings.X2TipShown = index;
-                    break;
-            }
+            if (_bestUpgrades.TryGetValue(id, out int index))
+                return index;
+            return _bestUpgrades[id] = -1;
+        }
+
+        public void UpdateUpgradeIndex(string id, int index)
+        {
+            RP0Debug.Log($"Upgrade {id} set to {index}");
+            _bestUpgrades[id] = index;
         }
     }
 }

--- a/Source/RP0/ScenarioModules/RnDUpgradeTips.cs
+++ b/Source/RP0/ScenarioModules/RnDUpgradeTips.cs
@@ -1,8 +1,10 @@
 ﻿using RealFuels;
+using RealFuels.Tanks;
 using ROUtils.DataTypes;
 using RP0.UI;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace RP0.Addons
@@ -12,21 +14,25 @@ namespace RP0.Addons
     {
         private class UpgradeLine
         {
+            public delegate bool ValidPartModuleFilter(PartModule pm);
+
             private readonly string _id;
             private readonly string[] _upgradeNames;
             private readonly string _moduleName;
             private readonly string _displayName;
             private bool _subscribedToPAWEvent;
+            private readonly ValidPartModuleFilter _filter;
 
             public int bestUpgrade { get; private set; } = -1;
             public int bestUnpurchasedUpgrade { get; private set; } = -1;
 
-            public UpgradeLine(string id, string moduleName, string displayName, string[] names)
+            public UpgradeLine(string id, string moduleName, string displayName, string[] names, ValidPartModuleFilter filter = null)
             {
                 _id = id;
                 _moduleName = moduleName;
                 _displayName = displayName;
                 _upgradeNames = names;
+                _filter = filter;
                 bestUpgrade = _upgradeNames.IndexOf(Instance.GetBestShownUpgradeName(id));
                 UpdateUpgradeInfo();
             }
@@ -62,7 +68,8 @@ namespace RP0.Addons
 
             private void OnPartActionUIShown(UIPartActionWindow paw, Part part)
             {
-                if (bestUnpurchasedUpgrade > bestUpgrade && part.Modules.Contains(_moduleName))
+                // If there is any module that matches the given name AND meets the filter requirement, show the tip.
+                if (bestUnpurchasedUpgrade > bestUpgrade && part.Modules.modules.Any(pm => pm.ClassName == _moduleName && (_filter == null || _filter(pm))))
                     ShowAvailableTechTip();
             }
 
@@ -75,7 +82,7 @@ namespace RP0.Addons
 
                 var upgrade = GetUpgrade(bestUnpurchasedUpgrade);
 
-                string txt = $"{upgrade.title}: {upgrade.description}\n";
+                string txt = $"<b>{upgrade.title}</b>\n{upgrade.description}";
                 var cmq = CurrencyModifierQueryRP0.RunQuery(TransactionReasonsRP0.PartOrUpgradeUnlock, -upgrade.entryCost, 0f, 0f);
                 string costStr = cmq.GetCostLineOverride(true, false, false, true);
                 double trueTotal = -cmq.GetTotal(CurrencyRP0.Funds, false);
@@ -130,10 +137,7 @@ namespace RP0.Addons
 
         public static RnDUpgradeTips Instance { get; private set; }
 
-        private UpgradeLine _fairings;
-        private UpgradeLine _hardDrives;
-        private UpgradeLine _mli;
-        private UpgradeLine _x2;
+        private readonly List<UpgradeLine> _upgradeLines = new List<UpgradeLine>();
 
         [KSPField(isPersistant = true)]
         private PersistentDictionaryValueTypes<string, string> _bestUpgrades = new PersistentDictionaryValueTypes<string, string>();
@@ -152,33 +156,39 @@ namespace RP0.Addons
             {
                 fairings[i] = "PFTech-Fairing-" + fairings[i];
             }
-            _fairings = new UpgradeLine("fairings", "ProceduralFairingSide", "Fairing Density", fairings);
+            _upgradeLines.Add(new UpgradeLine("fairings", "ProceduralFairingSide", "Fairing Density", fairings));
 
             string[] hardDrives = { "Early", "Basic", "1961", "1964", "1969", "1975", "1990", "1998", "2010", "2020" };
             for (int i = hardDrives.Length - 1; i >= 0; --i)
             {
                 hardDrives[i] = "HDD-Upgrade-" + hardDrives[i];
             }
-            _hardDrives = new UpgradeLine("storage", "ModuleProceduralAvionics", "Data Storage", hardDrives);
+            _upgradeLines.Add(new UpgradeLine("storage", "ModuleProceduralAvionics", "Data Storage", hardDrives));
 
             string[] mli = new string[5];
             for (int i = 0; i < 5; ++i)
             {
                 mli[i] = $"MLI.Upgrade{i+1}";
             }
-            _mli = new UpgradeLine("mli", "ModuleFuelTanks", "Multi-Layer Insulation", mli);
+            _upgradeLines.Add(new UpgradeLine("mli", "ModuleFuelTanks", "Multi-Layer Insulation", mli, pm => {
+                // Only fire for conventional or isogrid tanks.
+                return pm is ModuleFuelTanks tank && (tank.type.StartsWith("Tank-Sep") || tank.type.StartsWith("Tank-Iso"));
+            }));
 
-            _x2 = new UpgradeLine("x2", "ModuleUnpressurizedCockpit", "X-1 Service Ceiling", ["X2CockpitUpgrade"]);
+            _upgradeLines.Add(new UpgradeLine("mliBalloon", "ModuleFuelTanks", "Multi-Layer Insulation (Balloon)", ["RFTech-MLI-UpgradeBalloon"], pm => {
+                // Only fire for balloon
+                return pm is ModuleFuelTanks tank && tank.type.StartsWith("Tank-Balloon");
+            }));
+
+            _upgradeLines.Add(new UpgradeLine("x2", "ModuleUnpressurizedCockpit", "X-1 Service Ceiling", ["X2CockpitUpgrade"]));
         }
 
         public void OnDestroy()
         {
             if (Instance == this)
                 Instance = null;
-            _fairings.OnDestroy();
-            _hardDrives.OnDestroy();
-            _mli.OnDestroy();
-            _x2.OnDestroy();
+            foreach (UpgradeLine line in _upgradeLines)
+                line.OnDestroy();
         }
 
         public string GetBestShownUpgradeName(string id)

--- a/Source/RP0/ScenarioModules/RnDUpgradeTips.cs
+++ b/Source/RP0/ScenarioModules/RnDUpgradeTips.cs
@@ -4,10 +4,10 @@ using ROUtils.DataTypes;
 using RP0.UI;
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using UniLinq;
 using UnityEngine;
 
-namespace RP0.Addons
+namespace RP0
 {
     [KSPScenario((ScenarioCreationOptions)480, [GameScenes.EDITOR])]
     public class RnDUpgradeTips : ScenarioModule
@@ -21,6 +21,7 @@ namespace RP0.Addons
             private readonly string _moduleName;
             private readonly string _displayName;
             private bool _subscribedToPAWEvent;
+            private bool _firedAlready = false;
             private readonly ValidPartModuleFilter _filter;
 
             public int bestUpgrade { get; private set; } = -1;
@@ -69,8 +70,10 @@ namespace RP0.Addons
             private void OnPartActionUIShown(UIPartActionWindow paw, Part part)
             {
                 // If there is any module that matches the given name AND meets the filter requirement, show the tip.
-                if (bestUnpurchasedUpgrade > bestUpgrade && part.Modules.modules.Any(pm => pm.ClassName == _moduleName && (_filter == null || _filter(pm))))
+                if (!_firedAlready && bestUnpurchasedUpgrade > bestUpgrade && part.Modules.modules.Any(pm => pm.ClassName == _moduleName && (_filter == null || _filter(pm)))) {
+                    _firedAlready = true;
                     ShowAvailableTechTip();
+                }
             }
 
             private void ShowAvailableTechTip()
@@ -86,7 +89,6 @@ namespace RP0.Addons
                 var cmq = CurrencyModifierQueryRP0.RunQuery(TransactionReasonsRP0.PartOrUpgradeUnlock, -upgrade.entryCost, 0f, 0f);
                 string costStr = cmq.GetCostLineOverride(true, false, false, true);
                 double trueTotal = -cmq.GetTotal(CurrencyRP0.Funds, false);
-                double invertCMQOp = upgrade.entryCost / trueTotal;
                 double creditAmtToUse = Math.Min(trueTotal, UnlockCreditHandler.Instance.TotalCredit);
                 cmq.AddPostDelta(CurrencyRP0.Funds, creditAmtToUse, true);
                 string afterCreditLine = cmq.GetCostLineOverride(true, false, true, true, true);
@@ -103,7 +105,7 @@ namespace RP0.Addons
                             PartUpgradeManager.Handler.SetUnlocked(upgrade.name, true);
                             GameEvents.OnPartUpgradePurchased.Fire(upgrade);
                             bestUpgrade = bestUnpurchasedUpgrade;
-                            Instance.UpdateBestShownUpgradeName(_id, upgrade.name);
+                            UpdateUpgradeInfo();
                         }
                     }, () => cmq.CanAfford(), 100, -1, true) 
                     { tooltipText = $"Spending {creditAmtToUse:N0} unlock credit\n(Base cost {costStr})" };
@@ -116,7 +118,7 @@ namespace RP0.Addons
                     new DialogGUIButton(KSP.Localization.Localizer.GetStringByTag("#rp0_GameplayTip_DontShowAgain"), () => 
                     { 
                         bestUpgrade = bestUnpurchasedUpgrade;
-                        Instance.UpdateBestShownUpgradeName(_id, upgrade.name);
+                        UpdateUpgradeInfo();
                     }
                 )));
 

--- a/Source/RP0/ScenarioModules/RnDUpgradeTips.cs
+++ b/Source/RP0/ScenarioModules/RnDUpgradeTips.cs
@@ -84,8 +84,9 @@ namespace RP0
                 controls.Add(new DialogGUILabel(msg));
 
                 var upgrade = GetUpgrade(bestUnpurchasedUpgrade);
-
-                string txt = $"<b>{upgrade.title}</b>\n{upgrade.description}";
+                int noteLoc = upgrade.description.IndexOf("NOTE:");
+                if (noteLoc == -1) noteLoc = upgrade.description.Length;
+                string txt = $"<b>{upgrade.title}</b>\n{upgrade.description.Substring(0, noteLoc)}";
                 var cmq = CurrencyModifierQueryRP0.RunQuery(TransactionReasonsRP0.PartOrUpgradeUnlock, -upgrade.entryCost, 0f, 0f);
                 string costStr = cmq.GetCostLineOverride(true, false, false, true);
                 double trueTotal = -cmq.GetTotal(CurrencyRP0.Funds, false);

--- a/Source/RP0/Settings/GameParameters.cs
+++ b/Source/RP0/Settings/GameParameters.cs
@@ -106,7 +106,11 @@ namespace RP0
         public bool AvionicsWindow_ShowInfo3 = true;
         public bool NeverShowUntrainedReminders = false;
         public bool NeverShowHSFProgramReminders = false;
-        public int RATLTipShown = 0;
+
+        public int FairingTLTipShown = 0;
+        public int HardDriveTipShown = 0;
+        public int MLITipShown = 0;
+        public int X2TipShown = 0;
 
         public string CareerLog_URL;
         public string CareerLog_Token;

--- a/Source/RP0/Settings/GameParameters.cs
+++ b/Source/RP0/Settings/GameParameters.cs
@@ -107,11 +107,6 @@ namespace RP0
         public bool NeverShowUntrainedReminders = false;
         public bool NeverShowHSFProgramReminders = false;
 
-        public int FairingTLTipShown = 0;
-        public int HardDriveTipShown = 0;
-        public int MLITipShown = 0;
-        public int X2TipShown = 0;
-
         public string CareerLog_URL;
         public string CareerLog_Token;
 

--- a/Source/RP0/Utilities/ECMHelper.cs
+++ b/Source/RP0/Utilities/ECMHelper.cs
@@ -19,6 +19,12 @@ namespace RP0
 
             if (pm is RealFuels.Tanks.ModuleFuelTanks)
                 return GetEcmNameFromModuleFuelTanks(pm);
+            
+            if (pm is RealAntennas.ModuleRealAntenna ra)
+                return GetEcmNameFromModuleRealAntenna(ra);
+
+            if (pm is ROLib.ModuleROSolar solar)
+                return GetEcmNameFromModuleROSolar(solar);
 
             return null;
         }
@@ -37,6 +43,16 @@ namespace RP0
         {
             PartUpgradeHandler.Upgrade upgrade = RealFuels.Tanks.ModuleFuelTanks.GetUpgradeForType((RealFuels.Tanks.ModuleFuelTanks)pm);
             return upgrade?.name;
+        }
+
+        internal static string GetEcmNameFromModuleRealAntenna(RealAntennas.ModuleRealAntenna pm)
+        {
+            return pm.RAAntenna.TechLevelInfo.name;
+        }
+
+        internal static string GetEcmNameFromModuleROSolar(ROLib.ModuleROSolar solar)
+        {
+            return $"solarTL{solar.TechLevel}";
         }
     }
 }


### PR DESCRIPTION
Currently there are 6 PartUpgrade lines that can only be purchased in R&D, and are therefore frequently missed by new players. Even experienced players can forget to purchase a corresponding upgrade when it is unlocked.
These are:
- Communications tech
- Solar panel tech
- Minimum structure density upgrades (referred to as Fairing upgrades)
- Data storage
- MLI layers
- The X-2 cockpit upgrade

We currently only warn about communications tech, and in order to purchase it players must leave the VAB and enter R&D.

For antennas and solar panels, the following behaviour now applies:
- We do not warn about unpurchased tech levels.
- When a part is placed, the new default TL is now the best researched TL (that is not necessarily purchased).
- Unpurchased TL issues can be fixed during vessel integration.

For the other 4 cases, the following behaviour now applies:
- When a PAW is opened containing the relevant module AND there is an upgrade in the order that has not been purchased AND the user has not chosen to fully ignore the alert for this upgrade:
  - A popup will appear, notifying the user that a new upgrade is available. They will be prompted to either purchase it immediately, acknowledge the notification (which can show again), or disable the notification (which will disable it forever for that upgrade and all before it, but not any future ones).

The "relevant modules" for the 4 tech lines described above are as follows:
- Fairing upgrades: `ProceduralFairingSide`
- Data storage: `ModuleProceduralAvionics`
- MLI layers: `ModuleFuelTanks`
- X-2: `ModuleUnpressurizedCockpit`

Implementation notes:
- ~~The Balloon tank MLI upgrade is not in the MLI tech order. I do not know of a clean way to distinguish Balloon tanks from non-Balloon tanks.~~ [Edit: The Balloon tank MLI upgrade is now included.]
- It may still be worthwhile to notify the user when a new comms tech is available, for the sole purpose of reminding the user that the Tracking Station needs to be upgraded to support it. 
- ~~If a part would cause multiple alerts to be set off at the same time, only one shows. As far as I can tell this occurs in one of two situations:~~ [Edit: There should no longer be any simultaneous alerts.]
  - ~~A procedural avionics core is opened when there is an MLI upgrade and data storage upgrade available. This could probably be fixed by the same fix that distinguishes Balloon tanks.~~
  - ~~A X-1 cockpit is opened when there is an MLI upgrade and X-2 cockpit upgrade available.~~
- The solar panel PartUpgrade names are currently hardcoded in a bunch of places. I don't like this.

This pull request requires https://github.com/KSP-RO/ROLibrary/pull/30 and https://github.com/KSP-RO/RealAntennas/pull/74 to handle the comms and solar panel cases, but theoretically works standalone without them.