### PR TITLE
Make LC min mass fraction MM-patchable

### DIFF
--- a/GameData/RP-1/SpaceCenterSettings.cfg
+++ b/GameData/RP-1/SpaceCenterSettings.cfg
@@ -272,6 +272,3 @@ SPACECENTERSETTINGS
 		XenonGas = 1.0
 	}
 }
-
-// Min vessel mass an LC accepts, as a fraction of its max tonnage. Override example:
-//@SPACECENTERSETTINGS:FINAL { @lcMassMinFraction = 0.5 }

--- a/GameData/RP-1/SpaceCenterSettings.cfg
+++ b/GameData/RP-1/SpaceCenterSettings.cfg
@@ -6,6 +6,7 @@ SPACECENTERSETTINGS
 	hangarCostForMaintenanceOffset = 240000 // these are wrt its cost
 	hangarCostForMaintenanceMin = 20000
 	lcCostMultiplier = 2
+	lcMassMinFraction = 0.75
 	salaryEngineers = 500
 	salaryResearchers = 750
 	researchersToUnlockCreditSalaryMultipliers
@@ -271,3 +272,6 @@ SPACECENTERSETTINGS
 		XenonGas = 1.0
 	}
 }
+
+// Min vessel mass an LC accepts, as a fraction of its max tonnage. Override example:
+//@SPACECENTERSETTINGS:FINAL { @lcMassMinFraction = 0.5 }

--- a/Source/RP0/Settings/GameParameters.cs
+++ b/Source/RP0/Settings/GameParameters.cs
@@ -134,7 +134,6 @@ namespace RP0
                     UnlockCredRate = 1f;
                     ProfTrainRate = 1f;
                     MissionTrainRate = 1f;
-                    LCMassMinFraction = 0f;
                     break;
                 case GameParameters.Preset.Normal:
                     IncludeCraftFiles = true;
@@ -147,7 +146,6 @@ namespace RP0
                     UnlockCredRate = 1f;
                     ProfTrainRate = 1f;
                     MissionTrainRate = 1f;
-                    LCMassMinFraction = 0.5f;
                     break;
                 case GameParameters.Preset.Moderate:
                     IncludeCraftFiles = false;
@@ -160,7 +158,6 @@ namespace RP0
                     UnlockCredRate = 1f;
                     ProfTrainRate = 1f;
                     MissionTrainRate = 1f;
-                    LCMassMinFraction = 0.75f;
                     break;
                 case GameParameters.Preset.Hard:
                     IncludeCraftFiles = false;
@@ -173,7 +170,6 @@ namespace RP0
                     UnlockCredRate = 1f;
                     ProfTrainRate = 1f;
                     MissionTrainRate = 1f;
-                    LCMassMinFraction = 0.85f;
                     break;
             }
         }

--- a/Source/RP0/Settings/GameParameters.cs
+++ b/Source/RP0/Settings/GameParameters.cs
@@ -68,6 +68,9 @@ namespace RP0
         [GameParameters.CustomFloatParameterUI("Kerbal Death Percent Rep Loss", minValue = 0.05f, maxValue = 0.5f, stepCount = 46, displayFormat = "P0", gameMode = GameParameters.GameMode.CAREER)]
         public float RepLossNautDeathPercent = 0.1f;
 
+        [GameParameters.CustomFloatParameterUI("Launch Complex min tonnage", minValue = 0f, maxValue = 1f, stepCount = 21, displayFormat = "P0", gameMode = GameParameters.GameMode.CAREER, toolTip = "Minimum vessel mass an LC accepts, as a fraction of its max tonnage. Lower values let one LC launch a wider range of vehicles. Stock is 75%.")]
+        public float LCMassMinFraction = 0.75f;
+
         [GameParameters.CustomParameterUI("Enable career progress logging", gameMode = GameParameters.GameMode.CAREER)]
         public bool CareerLogEnabled = true;
 
@@ -131,6 +134,7 @@ namespace RP0
                     UnlockCredRate = 1f;
                     ProfTrainRate = 1f;
                     MissionTrainRate = 1f;
+                    LCMassMinFraction = 0f;
                     break;
                 case GameParameters.Preset.Normal:
                     IncludeCraftFiles = true;
@@ -143,6 +147,7 @@ namespace RP0
                     UnlockCredRate = 1f;
                     ProfTrainRate = 1f;
                     MissionTrainRate = 1f;
+                    LCMassMinFraction = 0.5f;
                     break;
                 case GameParameters.Preset.Moderate:
                     IncludeCraftFiles = false;
@@ -155,6 +160,7 @@ namespace RP0
                     UnlockCredRate = 1f;
                     ProfTrainRate = 1f;
                     MissionTrainRate = 1f;
+                    LCMassMinFraction = 0.75f;
                     break;
                 case GameParameters.Preset.Hard:
                     IncludeCraftFiles = false;
@@ -167,6 +173,7 @@ namespace RP0
                     UnlockCredRate = 1f;
                     ProfTrainRate = 1f;
                     MissionTrainRate = 1f;
+                    LCMassMinFraction = 0.85f;
                     break;
             }
         }

--- a/Source/RP0/Settings/GameParameters.cs
+++ b/Source/RP0/Settings/GameParameters.cs
@@ -68,9 +68,6 @@ namespace RP0
         [GameParameters.CustomFloatParameterUI("Kerbal Death Percent Rep Loss", minValue = 0.05f, maxValue = 0.5f, stepCount = 46, displayFormat = "P0", gameMode = GameParameters.GameMode.CAREER)]
         public float RepLossNautDeathPercent = 0.1f;
 
-        [GameParameters.CustomFloatParameterUI("Launch Complex min tonnage", minValue = 0f, maxValue = 1f, stepCount = 21, displayFormat = "P0", gameMode = GameParameters.GameMode.CAREER, toolTip = "Minimum vessel mass an LC accepts, as a fraction of its max tonnage. Lower values let one LC launch a wider range of vehicles. Stock is 75%.")]
-        public float LCMassMinFraction = 0.75f;
-
         [GameParameters.CustomParameterUI("Enable career progress logging", gameMode = GameParameters.GameMode.CAREER)]
         public bool CareerLogEnabled = true;
 

--- a/Source/RP0/Settings/SpaceCenterSettings.cs
+++ b/Source/RP0/Settings/SpaceCenterSettings.cs
@@ -31,6 +31,9 @@ namespace RP0
         public double lcCostMultiplier = 2d;
 
         [Persistent]
+        public double lcMassMinFraction = 0.75d;
+
+        [Persistent]
         public PersistentListValueType<double> nautYearlyUpkeepPerFacLevel = new PersistentListValueType<double>();
 
         [Persistent]

--- a/Source/RP0/Settings/SpaceCenterSettings.cs
+++ b/Source/RP0/Settings/SpaceCenterSettings.cs
@@ -1,6 +1,7 @@
 ﻿using ROUtils;
 using ROUtils.DataTypes;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace RP0
 {
@@ -31,7 +32,7 @@ namespace RP0
         public double lcCostMultiplier = 2d;
 
         [Persistent]
-        public double lcMassMinFraction = 0.75d;
+        public float lcMassMinFraction = 0.75f;
 
         [Persistent]
         public PersistentListValueType<double> nautYearlyUpkeepPerFacLevel = new PersistentListValueType<double>();
@@ -110,6 +111,7 @@ namespace RP0
         public override void Load(ConfigNode node)
         {
             base.Load(node);
+            lcMassMinFraction = Mathf.Clamp01(lcMassMinFraction);
             foreach (var k in nautYearlyUpkeepPerTraining.Keys)
             {
                 nautUpkeepTrainings.Add(k);

--- a/Source/RP0/SpaceCenter/LaunchComplex/LCData.cs
+++ b/Source/RP0/SpaceCenter/LaunchComplex/LCData.cs
@@ -39,7 +39,13 @@ namespace RP0
         public bool IsMassWithinUpgradeMargin => massMax <= MaxPossibleMass;
         public bool IsMassWithinDowngradeMargin => massMax >= MinPossibleMass;
         public bool IsMassWithinUpAndDowngradeMargins => IsMassWithinUpgradeMargin && IsMassWithinDowngradeMargin;
-        public static float CalcMassMin(float massMax) => massMax == float.MaxValue ? 0f : Mathf.Floor(massMax * 0.75f);
+        public static float CalcMassMin(float massMax)
+        {
+            float frac = 0.75f;
+            if (HighLogic.CurrentGame != null)
+                frac = HighLogic.CurrentGame.Parameters.CustomParams<RP0Settings>().LCMassMinFraction;
+            return Mathf.Floor(massMax * frac);
+        }
         public float MassMin => CalcMassMin(massMax);
         public static float CalcMassMaxFromMin(float massMin) => Mathf.Ceil(massMin / 0.75f);
 

--- a/Source/RP0/SpaceCenter/LaunchComplex/LCData.cs
+++ b/Source/RP0/SpaceCenter/LaunchComplex/LCData.cs
@@ -41,8 +41,9 @@ namespace RP0
         public bool IsMassWithinUpAndDowngradeMargins => IsMassWithinUpgradeMargin && IsMassWithinDowngradeMargin;
         public static float CalcMassMin(float massMax)
         {
-            if (massMax == float.MaxValue) return 0f;
-            return Mathf.Floor(massMax * GetMassMinFraction());
+            if (massMax < float.MaxValue)
+                return Mathf.Floor(massMax * GetMassMinFraction());
+            return 0f;
         }
         public float MassMin => CalcMassMin(massMax);
         public static float CalcMassMaxFromMin(float massMin)

--- a/Source/RP0/SpaceCenter/LaunchComplex/LCData.cs
+++ b/Source/RP0/SpaceCenter/LaunchComplex/LCData.cs
@@ -41,13 +41,21 @@ namespace RP0
         public bool IsMassWithinUpAndDowngradeMargins => IsMassWithinUpgradeMargin && IsMassWithinDowngradeMargin;
         public static float CalcMassMin(float massMax)
         {
-            float frac = 0.75f;
-            if (HighLogic.CurrentGame != null)
-                frac = HighLogic.CurrentGame.Parameters.CustomParams<RP0Settings>().LCMassMinFraction;
-            return Mathf.Floor(massMax * frac);
+            if (massMax == float.MaxValue) return 0f;
+            return Mathf.Floor(massMax * GetMassMinFraction());
         }
         public float MassMin => CalcMassMin(massMax);
-        public static float CalcMassMaxFromMin(float massMin) => Mathf.Ceil(massMin / 0.75f);
+        public static float CalcMassMaxFromMin(float massMin)
+        {
+            float frac = GetMassMinFraction();
+            return frac > 0f ? Mathf.Ceil(massMin / frac) : massMin;
+        }
+
+        private static float GetMassMinFraction()
+        {
+            if (HighLogic.CurrentGame == null) return 0.75f;
+            return HighLogic.CurrentGame.Parameters.CustomParams<RP0Settings>().LCMassMinFraction;
+        }
 
         public static readonly LCData StartingHangar = new LCData("Hangar", float.MaxValue, float.MaxValue, new Vector3(40f, 10f, 40f), LaunchComplexType.Hangar, true, new PersistentDictionaryValueTypes<string, double>());
 

--- a/Source/RP0/SpaceCenter/LaunchComplex/LCData.cs
+++ b/Source/RP0/SpaceCenter/LaunchComplex/LCData.cs
@@ -39,24 +39,11 @@ namespace RP0
         public bool IsMassWithinUpgradeMargin => massMax <= MaxPossibleMass;
         public bool IsMassWithinDowngradeMargin => massMax >= MinPossibleMass;
         public bool IsMassWithinUpAndDowngradeMargins => IsMassWithinUpgradeMargin && IsMassWithinDowngradeMargin;
-        public static float CalcMassMin(float massMax)
-        {
-            if (massMax < float.MaxValue)
-                return Mathf.Floor(massMax * GetMassMinFraction());
-            return 0f;
-        }
+        public static float CalcMassMin(float massMax) => massMax < float.MaxValue ? Mathf.Floor(massMax * MassMinFraction) : 0f;
         public float MassMin => CalcMassMin(massMax);
-        public static float CalcMassMaxFromMin(float massMin)
-        {
-            float frac = GetMassMinFraction();
-            return frac > 0f ? Mathf.Ceil(massMin / frac) : massMin;
-        }
+        public static float CalcMassMaxFromMin(float massMin) => MassMinFraction > 0f ? Mathf.Ceil(massMin / MassMinFraction) : massMin;
 
-        private static float GetMassMinFraction()
-        {
-            if (HighLogic.CurrentGame == null) return 0.75f;
-            return HighLogic.CurrentGame.Parameters.CustomParams<RP0Settings>().LCMassMinFraction;
-        }
+        private static float MassMinFraction => (float)Database.SettingsSC.lcMassMinFraction;
 
         public static readonly LCData StartingHangar = new LCData("Hangar", float.MaxValue, float.MaxValue, new Vector3(40f, 10f, 40f), LaunchComplexType.Hangar, true, new PersistentDictionaryValueTypes<string, double>());
 

--- a/Source/RP0/SpaceCenter/LaunchComplex/LCData.cs
+++ b/Source/RP0/SpaceCenter/LaunchComplex/LCData.cs
@@ -43,7 +43,7 @@ namespace RP0
         public float MassMin => CalcMassMin(massMax);
         public static float CalcMassMaxFromMin(float massMin) => MassMinFraction > 0f ? Mathf.Ceil(massMin / MassMinFraction) : massMin;
 
-        private static float MassMinFraction => (float)Database.SettingsSC.lcMassMinFraction;
+        private static float MassMinFraction => Database.SettingsSC.lcMassMinFraction;
 
         public static readonly LCData StartingHangar = new LCData("Hangar", float.MaxValue, float.MaxValue, new Vector3(40f, 10f, 40f), LaunchComplexType.Hangar, true, new PersistentDictionaryValueTypes<string, double>());
 


### PR DESCRIPTION
## Summary

- Move the LC min mass fraction from hardcoded `0.75f` in `LCData.CalcMassMin` to a new `lcMassMinFraction` field on `SpaceCenterSettings`, default 0.75 (no behavior change).
- MM patches can now override it, e.g. `@SPACECENTERSETTINGS:FINAL { @lcMassMinFraction = 0.5 }`, for players who want a wider LC mass range without a recompile.