### PR TITLE
Sort skopos maintenance contracts last

### DIFF
--- a/Source/RP0/Harmony/ContractsApp.cs
+++ b/Source/RP0/Harmony/ContractsApp.cs
@@ -13,64 +13,43 @@ namespace RP0.Harmony
         [HarmonyPatch("CreateItem")]
         internal static bool Prefix_CreateItem(ContractsApp __instance, Contract contract, ref UICascadingList.CascadingListItem __result)
         {
-            if (contract is ContractConfigurator.ConfiguredContract configuredContract)
+            if (!(contract is ContractConfigurator.ConfiguredContract configuredContract))
             {
-                // Skopos goes at the end
-                if (ContractUtils.ContractIsSkoposMaintenance(configuredContract))
-                    return true;
-
-                UnityEngine.UI.Button button;
-                int index = -1;
-
-                if (ContractUtils.ContractIsRecord(configuredContract))
-                {
-                    // Find the index of the first Skopos maintenance contract.
-                    foreach (var kvp in __instance.contractList)
-                    {
-                        if (ContractSystem.Instance.GetContractByGuid(kvp.Key) is ContractConfigurator.ConfiguredContract cc)
-                        {
-                            if (ContractUtils.ContractIsSkoposMaintenance(cc))
-                            {
-                                int idx = __instance.cascadingList.ruiList.cascadingList.GetIndex(kvp.Value.header);
-                                if (idx < 0)
-                                {
-                                    RP0Debug.LogError($"ContractsApp patcher: {cc.contractType.name} can't be found in UI list despite its guid existing in dictionary!");
-                                    continue;
-                                }
-                                if (index < 0 || idx < index)
-                                    index = idx;
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    // Find the index of the first record.
-                    foreach (var kvp in __instance.contractList)
-                    {
-                        if (ContractSystem.Instance.GetContractByGuid(kvp.Key) is ContractConfigurator.ConfiguredContract cc)
-                        {
-                            if (ContractUtils.ContractIsRecord(cc))
-                            {
-                                int idx = __instance.cascadingList.ruiList.cascadingList.GetIndex(kvp.Value.header);
-                                if (idx < 0)
-                                {
-                                    RP0Debug.LogError($"ContractsApp patcher: {cc.contractType.name} can't be found in UI list despite its guid existing in dictionary!");
-                                    continue;
-                                }
-                                if (index < 0 || idx < index)
-                                    index = idx;
-                            }
-                        }
-                    }
-                }
-                
-                UIListItem header = __instance.cascadingList.CreateHeader("<color=#e6752a>" + contract.Title + "</color>", out button, scaleBg: true);
-                __result = __instance.cascadingList.ruiList.AddCascadingItem(header, __instance.cascadingList.CreateFooter(), __instance.CreateParameterList(contract), button, index);
-                return false;
+                return true;
             }
 
-            return true;
+            // Skopos goes at the end
+            if (ContractUtils.ContractIsSkoposMaintenance(configuredContract))
+                return true;
+
+            int index = -1;
+
+            // search for the contract we need to go before:
+            // if record, find Skopos
+            // otherwise, find record
+            bool isRecord = ContractUtils.ContractIsRecord(configuredContract);
+            foreach (var kvp in __instance.contractList)
+            {
+                if (ContractSystem.Instance.GetContractByGuid(kvp.Key) is ContractConfigurator.ConfiguredContract cc)
+                {
+                    if ((isRecord && ContractUtils.ContractIsSkoposMaintenance(cc)) || (!isRecord && ContractUtils.ContractIsRecord(cc)))
+                    {
+                        int idx = __instance.cascadingList.ruiList.cascadingList.GetIndex(kvp.Value.header);
+                        if (idx < 0)
+                        {
+                            RP0Debug.LogError($"ContractsApp patcher: {cc.contractType.name} can't be found in UI list despite its guid existing in dictionary!");
+                            continue;
+                        }
+                        if (index < 0 || idx < index)
+                            index = idx;
+                    }
+                }
+            }
+            UnityEngine.UI.Button button;
+
+            UIListItem header = __instance.cascadingList.CreateHeader("<color=#e6752a>" + contract.Title + "</color>", out button, scaleBg: true);
+            __result = __instance.cascadingList.ruiList.AddCascadingItem(header, __instance.cascadingList.CreateFooter(), __instance.CreateParameterList(contract), button, index);
+            return false;
         }
     }
 }

--- a/Source/RP0/Harmony/ContractsApp.cs
+++ b/Source/RP0/Harmony/ContractsApp.cs
@@ -15,32 +15,56 @@ namespace RP0.Harmony
         {
             if (contract is ContractConfigurator.ConfiguredContract configuredContract)
             {
-                // Records go at the end
-                if (ContractUtils.ContractIsRecord(configuredContract))
+                // Skopos goes at the end
+                if (ContractUtils.ContractIsSkoposMaintenance(configuredContract))
                     return true;
 
                 UnityEngine.UI.Button button;
                 int index = -1;
 
-                // Find the index of the first record.
-                foreach (var kvp in __instance.contractList)
+                if (ContractUtils.ContractIsRecord(configuredContract))
                 {
-                    if (ContractSystem.Instance.GetContractByGuid(kvp.Key) is ContractConfigurator.ConfiguredContract cc)
+                    // Find the index of the first Skopos maintenance contract.
+                    foreach (var kvp in __instance.contractList)
                     {
-                        if (ContractUtils.ContractIsRecord(cc))
+                        if (ContractSystem.Instance.GetContractByGuid(kvp.Key) is ContractConfigurator.ConfiguredContract cc)
                         {
-                            int idx = __instance.cascadingList.ruiList.cascadingList.GetIndex(kvp.Value.header);
-                            if (idx < 0)
+                            if (ContractUtils.ContractIsSkoposMaintenance(cc))
                             {
-                                RP0Debug.LogError($"ContractsApp patcher: {cc.contractType.name} can't be found in UI list despite its guid existing in dictionary!");
-                                continue;
+                                int idx = __instance.cascadingList.ruiList.cascadingList.GetIndex(kvp.Value.header);
+                                if (idx < 0)
+                                {
+                                    RP0Debug.LogError($"ContractsApp patcher: {cc.contractType.name} can't be found in UI list despite its guid existing in dictionary!");
+                                    continue;
+                                }
+                                if (index < 0 || idx < index)
+                                    index = idx;
                             }
-                            if (index < 0 || idx < index)
-                                index = idx;
                         }
                     }
                 }
-
+                else
+                {
+                    // Find the index of the first record.
+                    foreach (var kvp in __instance.contractList)
+                    {
+                        if (ContractSystem.Instance.GetContractByGuid(kvp.Key) is ContractConfigurator.ConfiguredContract cc)
+                        {
+                            if (ContractUtils.ContractIsRecord(cc))
+                            {
+                                int idx = __instance.cascadingList.ruiList.cascadingList.GetIndex(kvp.Value.header);
+                                if (idx < 0)
+                                {
+                                    RP0Debug.LogError($"ContractsApp patcher: {cc.contractType.name} can't be found in UI list despite its guid existing in dictionary!");
+                                    continue;
+                                }
+                                if (index < 0 || idx < index)
+                                    index = idx;
+                            }
+                        }
+                    }
+                }
+                
                 UIListItem header = __instance.cascadingList.CreateHeader("<color=#e6752a>" + contract.Title + "</color>", out button, scaleBg: true);
                 __result = __instance.cascadingList.ruiList.AddCascadingItem(header, __instance.cascadingList.CreateFooter(), __instance.CreateParameterList(contract), button, index);
                 return false;

--- a/Source/RP0/Harmony/ContractsApp.cs
+++ b/Source/RP0/Harmony/ContractsApp.cs
@@ -30,19 +30,17 @@ namespace RP0.Harmony
             bool isRecord = ContractUtils.ContractIsRecord(configuredContract);
             foreach (var kvp in __instance.contractList)
             {
-                if (ContractSystem.Instance.GetContractByGuid(kvp.Key) is ContractConfigurator.ConfiguredContract cc)
+                if (ContractSystem.Instance.GetContractByGuid(kvp.Key) is ContractConfigurator.ConfiguredContract cc &&
+                    ((isRecord && ContractUtils.ContractIsSkoposMaintenance(cc)) || (!isRecord && ContractUtils.ContractIsRecord(cc))))
                 {
-                    if ((isRecord && ContractUtils.ContractIsSkoposMaintenance(cc)) || (!isRecord && ContractUtils.ContractIsRecord(cc)))
+                    int idx = __instance.cascadingList.ruiList.cascadingList.GetIndex(kvp.Value.header);
+                    if (idx < 0)
                     {
-                        int idx = __instance.cascadingList.ruiList.cascadingList.GetIndex(kvp.Value.header);
-                        if (idx < 0)
-                        {
-                            RP0Debug.LogError($"ContractsApp patcher: {cc.contractType.name} can't be found in UI list despite its guid existing in dictionary!");
-                            continue;
-                        }
-                        if (index < 0 || idx < index)
-                            index = idx;
+                        RP0Debug.LogError($"ContractsApp patcher: {cc.contractType.name} can't be found in UI list despite its guid existing in dictionary!");
+                        continue;
                     }
+                    if (index < 0 || idx < index)
+                        index = idx;
                 }
             }
             UnityEngine.UI.Button button;

--- a/Source/RP0/Harmony/MissionControl.cs
+++ b/Source/RP0/Harmony/MissionControl.cs
@@ -19,6 +19,13 @@ namespace RP0.Harmony
         {
             if (a is ConfiguredContract ccA && b is ConfiguredContract ccB)
             {
+                // Normal contracts, then Records, then Skopos maintenance
+                bool aSkopos = ContractUtils.ContractIsSkoposMaintenance(ccA);
+                bool bSkopos = ContractUtils.ContractIsSkoposMaintenance(ccB);
+                if (aSkopos != bSkopos)
+                {
+                    return bSkopos ? -1 : 1;
+                }
                 bool aRecord = ContractUtils.ContractIsRecord(ccA);
                 bool bRecord = ContractUtils.ContractIsRecord(ccB);
                 if (aRecord != bRecord)

--- a/Source/RP0/Utilities/ContractUtils.cs
+++ b/Source/RP0/Utilities/ContractUtils.cs
@@ -6,6 +6,7 @@
         {
             return cc.contractType.group.name == "Records" || cc.contractType.group.name == "HumanRecords";
         }
+
         public static bool ContractIsSkoposMaintenance(ContractConfigurator.ConfiguredContract cc)
         {
             return cc.contractType.group.name == "CommApp" && cc.contractType.name.StartsWith("maintenance_");

--- a/Source/RP0/Utilities/ContractUtils.cs
+++ b/Source/RP0/Utilities/ContractUtils.cs
@@ -6,5 +6,9 @@
         {
             return cc.contractType.group.name == "Records" || cc.contractType.group.name == "HumanRecords";
         }
+        public static bool ContractIsSkoposMaintenance(ContractConfigurator.ConfiguredContract cc)
+        {
+            return cc.contractType.group.name == "CommApp" && cc.contractType.name.StartsWith("maintenance_");
+        }
     }
 }


### PR DESCRIPTION
<img width="268" height="442" alt="image" src="https://github.com/user-attachments/assets/c7eeb9f4-6066-4380-a60f-c0e990fff217" />
<img width="408" height="938" alt="image" src="https://github.com/user-attachments/assets/4ed80a1b-079a-480e-a103-92d684158267" />

The Skopos maintenance contracts are now sorted after the Records contracts, which should make it easier to see non-Skopos contract parameters when there are many maintenance contracts.