### PR TITLE
Set agents correctly for scenario-generated contracts

### DIFF
--- a/Source/RP0/ConfigurableStart/ScenarioHandler.cs
+++ b/Source/RP0/ConfigurableStart/ScenarioHandler.cs
@@ -657,8 +657,6 @@ namespace RP0.ConfigurableStart
                 fi.SetValue(contract, state);
             if ((fi = baseT.GetField("seed", BindingFlags.NonPublic | BindingFlags.Instance)) is FieldInfo)
                 fi.SetValue(contract, seed);
-            if ((fi = baseT.GetField("agent", BindingFlags.NonPublic | BindingFlags.Instance)) is FieldInfo)
-                fi.SetValue(contract, Contracts.Agents.AgentList.Instance.GetSuitableAgentForContract(contract));
             contract.FundsFailure = Math.Max(contract.FundsFailure, contract.FundsAdvance);
             contract.GetType().GetMethod("SetupID", BindingFlags.NonPublic | BindingFlags.Instance)?.Invoke(contract, null);
 
@@ -676,6 +674,8 @@ namespace RP0.ConfigurableStart
                 fi.SetValue(contract, contractType.completedMessage);
             if ((fi = t.GetField("notes", BindingFlags.NonPublic | BindingFlags.Instance)) is FieldInfo)
                 fi.SetValue(contract, contractType.notes);
+            if ((fi = t.GetField("agent", BindingFlags.NonPublic | BindingFlags.Instance)) is FieldInfo)
+                fi.SetValue(contract, contractType.agent);
 
             // set expiry and deadline type to none
             if ((fi = t.GetField("expiryType", BindingFlags.NonPublic | BindingFlags.Instance)) is FieldInfo)


### PR DESCRIPTION
Noticed this unrelated bug while testing https://github.com/KSP-RO/RP-1/pull/2776

Before:
<img width="810" height="828" alt="image" src="https://github.com/user-attachments/assets/ef6c4fd9-ebb6-4c59-8c09-3b1a4d021844" />

After:
<img width="792" height="832" alt="image" src="https://github.com/user-attachments/assets/472f9ca3-0d59-433f-9268-6fb66eec549b" />
