### PR TITLE
Add more Lunar Orbiter experiments

### DIFF
--- a/GameData/RP-1/Science/Configure.cfg
+++ b/GameData/RP-1/Science/Configure.cfg
@@ -944,6 +944,34 @@
 				id_value = RP0TelevisionBroadcast
 			}
 		}
+		SETUP
+		{
+			name = Light Flash Moving Emulsion Detector
+			desc = Our astronauts will be fitted with cosmic-ray sensitive emulsion plates worn over their heads in order to track heavy cosmic rays that interact with the optic nerve or retina.
+			mass = 0
+			tech = scienceLunar
+			
+			MODULE
+			{
+				type = Experiment
+				id_field = experiment_id
+				id_value = RP0ALFMED
+			}
+		}
+		SETUP
+		{
+			name = Bistatic Radar
+			desc = By sending a continuous, unmodulated radio signal at the lunar surface, our communications network on Earth will catch some of the scattered reflections, which will allow scientists to determine electrical properties and surface roughness of the Lunar surface.
+			mass = 0
+			tech = scienceLunar
+			
+			MODULE
+			{
+				type = Experiment
+				id_field = experiment_id
+				id_value = RP0BistaticRadar
+			}
+		}
 	}
 }
 

--- a/GameData/RP-1/Science/Experiments/CrewScience/LunarOrbiterCapsulesExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/LunarOrbiterCapsulesExperiments.cfg
@@ -109,7 +109,7 @@ EXPERIMENT_DEFINITION
 		name = Experiment
 		experiment_id = RP0ALFMED
 		ec_rate = 
-		data_rate = 21.6 // 1 kb/s 
+		data_rate = 1 // 1 kb/s 
 		@data_rate /= 345600 // 4 days
 		requires = CrewMin:2
 		resources = 
@@ -162,7 +162,7 @@ EXPERIMENT_DEFINITION
 		name = Experiment
 		experiment_id = RP0BistaticRadar
 		ec_rate = 1.5 // high RF antenna
-		data_rate = 250 // 250 Mb/s high to enforce a line of sight with Earth, which mimics the radar 
+		data_rate = 500 // 250 Mb/s high to enforce a line of sight with Earth, which mimics the radar 
 		@data_rate /= 345600 // 4 days
 		requires = CrewMin:2
 		resources = 

--- a/GameData/RP-1/Science/Experiments/CrewScience/LunarOrbiterCapsulesExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/LunarOrbiterCapsulesExperiments.cfg
@@ -37,7 +37,7 @@ EXPERIMENT_DEFINITION
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
 		// Body restrictions, multiple lines allowed (just don't use conflicting combinations).
-		BodyAllowed = Moon
+		BodyAllowed = HomeBodyAndMoons
 		IncludeExperiment = 
 	}
 }
@@ -86,7 +86,7 @@ EXPERIMENT_DEFINITION
 	cost = 0
 	tags = secondGenCapsule
 	minCrew = 2
-	celestialBodies = Moon
+	celestialBodies = Earth;Moon
 
 	situations = ORBITING, ESCAPING
 	RESULTS
@@ -98,7 +98,7 @@ EXPERIMENT_DEFINITION
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.002 // biological experiment
 		// Body restrictions, multiple lines allowed (just don't use conflicting combinations).
-		BodyAllowed = Moon
+		BodyAllowed = HomeBodyAndMoons
 		IncludeExperiment = RP0ALFMED
 	}
 }

--- a/GameData/RP-1/Science/Experiments/CrewScience/LunarOrbiterCapsulesExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/LunarOrbiterCapsulesExperiments.cfg
@@ -60,6 +60,127 @@ EXPERIMENT_DEFINITION
 	}
 }
 
+// IDEAS: 
+// ALFMED (Earth High orbit)
+// BIOCORE (Earth High Orbit)
+// MEED (Earth High Orbit)
+// Panoramic camera (Moon Low Orbit)
+// Mapping/Stellar camera (Moon Low Orbit)
+
+// ============================================================================
+// Light Flash Moving Emulsion Detector
+// ============================================================================
+EXPERIMENT_DEFINITION
+{
+	id = RP0ALFMED
+	title = Light Flash Moving Emulsion Detector
+	baseValue = 20
+	scienceCap = 20
+	dataScale = 1
+	requireAtmosphere = False
+	situationMask = 32
+	biomeMask = 0
+	description = Our astronauts will be fitted with cosmic-ray sensitive emulsion plates worn over their heads in order to track heavy cosmic rays that interact with the optic nerve or retina.
+	mass = 0
+	techRequired = scienceLunar
+	cost = 0
+	tags = secondGenCapsule
+	minCrew = 2
+	celestialBodies = Earth
+
+	situations = ORBITING, ESCAPING
+	RESULTS
+	{
+		default = The recovered emulsion plates show clear physical tracks from heavy, high-energy cosmic rays, which correlate directly with the timing of the visual flashes reported by the crew.
+	}
+	KERBALISM_EXPERIMENT
+	{
+		// sample mass in tons. if undefined or 0, the experiment produce a file
+		SampleMass = 0.002 // biological experiment
+		// Body restrictions, multiple lines allowed (just don't use conflicting combinations).
+		BodyAllowed = HomeBody
+		IncludeExperiment = RP0ALFMED
+	}
+}
+@PART[*]:HAS[#getsMatureCapsuleExperiments[True]]:FOR[RP-0-Kerbalism]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = RP0ALFMED
+		ec_rate = 
+		data_rate = 21.6 // 1 kb/s 
+		@data_rate /= 345600 // 4 days
+		requires = CrewMin:2
+		resources = 
+		crew_operate = CrewOnly
+		hide_when_unavailable = True
+	}
+}
+
+// Bistatic Radar (Moon Low Orbit)
+
+// ============================================================================
+// Bistatic Radar
+// ============================================================================
+EXPERIMENT_DEFINITION
+{
+	id = RP0BistaticRadar
+	title = Bistatic Radar
+	baseValue = 30
+	scienceCap = 30
+	dataScale = 500 
+	requireAtmosphere = False
+	situationMask = 32
+	biomeMask = 0
+	description = By sending a continuous, unmodulated radio signal at the lunar surface, our communications network on Earth will catch some of the scattered reflections, which will allow scientists to determine electrical properties and surface roughness of the Lunar surface.
+	mass = 0
+	techRequired = improvedComms
+	cost = 0
+	tags = matureCapsule
+	minCrew = 2
+	celestialBodies = Earth
+
+	situations = ORBITING
+	RESULTS
+	{
+		default = Using special ion sensors on the craft, it allows our crew to determine their speed with improved accuracy.
+	}
+	KERBALISM_EXPERIMENT
+	{
+		// sample mass in tons. if undefined or 0, the experiment produce a file
+		SampleMass = 0
+		// Body restrictions, multiple lines allowed (just don't use conflicting combinations).
+		BodyAllowed = HomeBody
+		IncludeExperiment = 
+	}
+}
+@PART[*]:HAS[#getsMatureCapsuleExperiments[True]]:FOR[RP-0-Kerbalism]
+{
+	MODULE
+	{
+		name = Experiment
+		experiment_id = RP0BistaticRadar
+		ec_rate = 1.5 // high RF antenna
+		data_rate = 250 // 250 Mb/s high to enforce a line of sight with Earth, which mimics the radar 
+		@data_rate /= 345600 // 4 days
+		requires = CrewMin:2
+		resources = 
+		crew_operate = CrewOnly
+		hide_when_unavailable = True
+	}
+}
+
+
+
+// Boring: 
+// All of these are just spectrometers
+// Laser Altimeter (Moon Low Orbit)
+// X-Ray Fluoresence Spectrometer (Moon Low Orbit)
+// Gamma Ray Spectrometer (Moon Low Orbit)
+// Alpha Particle Spectrometer (Moon Low Orbit)
+
+
 // delete the tag
 @PART[*]:HAS[#capsuleTier[LunarOrbiter]]:LAST[zzzKerbalism]
 {

--- a/GameData/RP-1/Science/Experiments/CrewScience/LunarOrbiterCapsulesExperiments.cfg
+++ b/GameData/RP-1/Science/Experiments/CrewScience/LunarOrbiterCapsulesExperiments.cfg
@@ -37,7 +37,7 @@ EXPERIMENT_DEFINITION
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
 		// Body restrictions, multiple lines allowed (just don't use conflicting combinations).
-		BodyAllowed = HomeBodyAndMoons
+		BodyAllowed = Moon
 		IncludeExperiment = 
 	}
 }
@@ -86,7 +86,7 @@ EXPERIMENT_DEFINITION
 	cost = 0
 	tags = secondGenCapsule
 	minCrew = 2
-	celestialBodies = Earth
+	celestialBodies = Moon
 
 	situations = ORBITING, ESCAPING
 	RESULTS
@@ -98,7 +98,7 @@ EXPERIMENT_DEFINITION
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0.002 // biological experiment
 		// Body restrictions, multiple lines allowed (just don't use conflicting combinations).
-		BodyAllowed = HomeBody
+		BodyAllowed = Moon
 		IncludeExperiment = RP0ALFMED
 	}
 }
@@ -139,7 +139,7 @@ EXPERIMENT_DEFINITION
 	cost = 0
 	tags = matureCapsule
 	minCrew = 2
-	celestialBodies = Earth
+	celestialBodies = Moon
 
 	situations = ORBITING
 	RESULTS
@@ -151,7 +151,7 @@ EXPERIMENT_DEFINITION
 		// sample mass in tons. if undefined or 0, the experiment produce a file
 		SampleMass = 0
 		// Body restrictions, multiple lines allowed (just don't use conflicting combinations).
-		BodyAllowed = HomeBody
+		BodyAllowed = Moon
 		IncludeExperiment = 
 	}
 }


### PR DESCRIPTION
The Apollo capsules performed a few experiments specifically designed for HEO & LLO, this PR aims to add those as additional fluff for players flying around the Moon.

Presently, it adds the Apollo Light Flash Emulsion Moving Emulsion Detector, which was designed after early Apollo astronauts reported flashing lights, as scientists suspected this to be due to the impact of Cosmic Rays hitting the optical nerves (later confirmed by ALFMED) and the Bistatic Radar experiment, in which the CSM's antennas were pointed at the lunar surface, with the reflections picked up by the DSN and later evaluated. 


ALFMED is dependent on Lunar Science, Bistatic Radar on improvedComms - if I could, I would make ALFMED dependent on having sent crew around the Moon before. If anyone has an idea as to how to achieve this - I am all ears!