### PR TITLE
Operational Earth Space Stations Programs, an alternative to Modular Space Stations program

### DIFF
--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -926,6 +926,154 @@ RP0_PROGRAM_MODIFIER
 	}
 }
 
+{
+	name = OperationalEarthSpaceStation1 // Typically solved with something like later Salyut or SpaceLab
+	isHSF = true
+	title = Operational Earth Space Stations 1
+	description = The first space station missions have been accomplished. The possibilities for living and working in space seem endless. Now, it is time to make a sustainable architecture for long term low Earth orbit human spaceflight science. During this program, launch and operate crewed vehicles or stations that are capable of a variety of long-term science experiments.
+	requirementsPrettyText = Have completed the Early Earth Space Stations program.
+	objectivesPrettyText = Complete many station science experiments.
+	nominalDurationYears = 8
+	baseFunding = 5400000
+	fundingCurve = Flat
+	repDeltaOnCompletePerYearEarly = 590
+	repPenaltyPerYearLate = 590
+	repToConfidence = 3
+	slots = 3
+
+	REQUIREMENTS
+	{
+		complete_program = EarlyEarthSpaceStation
+	}
+
+	OBJECTIVES
+	{
+		complete_contract = CollectOperationalStationScience1 // Large set of experiments resembling those on Salyut 6+, SpaceLab, and Mir
+	}
+	
+	CONFIDENCECOSTS
+	{
+		Normal = 2200
+		Fast = 4400
+	}
+	OPTIONALS
+	{
+		complete_contract = largeCrewOperations1 // 6 crew on the same craft for at least 2 days
+		complete_contract = extraOperationalStationScience1 // additional science to complete for extra rep/confidence
+	}
+}
+
+{
+	name = OperationalEarthSpaceStation2 // Typically solved with something like SpaceLab or Mir
+	isHSF = true
+	title = Operational Earth Space Stations 2
+	description = Continue launching and operating crewed vehicles or stations that are capable of a variety of long-term science experiments.
+	requirementsPrettyText = Have completed the Operational Earth Space Stations 1 program.
+	objectivesPrettyText = Complete many station science experiments.
+	nominalDurationYears = 8
+	baseFunding = 5400000
+	fundingCurve = Flat
+	repDeltaOnCompletePerYearEarly = 590
+	repPenaltyPerYearLate = 590
+	repToConfidence = 3
+	slots = 3
+
+	REQUIREMENTS
+	{
+		complete_program = OperationalEarthSpaceStation1
+	}
+
+	OBJECTIVES
+	{
+		complete_contract = CollectOperationalStationScience2 // Large set of experiments resembling those on Salyut 6+, SpaceLab, and Mir
+	}
+	
+	CONFIDENCECOSTS
+	{
+		Normal = 2200
+		Fast = 4400
+	}
+	OPTIONALS
+	{
+		complete_contract = extraOperationalStationScience2 // additional science to complete for extra rep/confidence
+	}
+}
+
+{
+	name = OperationalEarthSpaceStation3 // Typically solved with something like Mir
+	isHSF = true
+	title = Operational Earth Space Stations 3
+	description = Continue launching and operating crewed vehicles or stations that are capable of a variety of long-term science experiments.
+	requirementsPrettyText = Have completed the Operational Earth Space Stations 2 program.
+	objectivesPrettyText = Complete many station science experiments.
+	nominalDurationYears = 8
+	baseFunding = 5400000
+	fundingCurve = Flat
+	repDeltaOnCompletePerYearEarly = 590
+	repPenaltyPerYearLate = 590
+	repToConfidence = 3
+	slots = 3
+
+	REQUIREMENTS
+	{
+		complete_program = OperationalEarthSpaceStation2
+	}
+
+	OBJECTIVES
+	{
+		complete_contract = CollectOperationalStationScience3 // Large set of experiments resembling those on SpaceLab, Mir, and ISS
+	}
+	
+	CONFIDENCECOSTS
+	{
+		Normal = 2200
+		Fast = 4400
+	}
+	OPTIONALS
+	{
+		complete_contract = largeCrewOperations2 // 10 crew on the same craft for at least 2 days
+		complete_contract = extraOperationalStationScience3 // additional science to complete for extra rep/confidence
+		complete_contract = longDurationCrew1 // A crewmember is in space for 6 months in a row
+	}
+}
+
+{
+	name = OperationalEarthSpaceStation4 // Typically solved with something like ISS
+	isHSF = true
+	title = Operational Earth Space Stations 4
+	description = Continue launching and operating crewed vehicles or stations that are capable of a variety of long-term science experiments.
+	requirementsPrettyText = Have completed the Operational Earth Space Stations 3 program.
+	objectivesPrettyText = Complete many station science experiments.
+	nominalDurationYears = 8
+	baseFunding = 5400000
+	fundingCurve = Flat
+	repDeltaOnCompletePerYearEarly = 590
+	repPenaltyPerYearLate = 590
+	repToConfidence = 3
+	slots = 3
+
+	REQUIREMENTS
+	{
+		complete_program = OperationalEarthSpaceStation3
+	}
+
+	OBJECTIVES
+	{
+		complete_contract = CollectOperationalStationScience4 // Large set of experiments resembling those on ISS
+	}
+	
+	CONFIDENCECOSTS
+	{
+		Normal = 2200
+		Fast = 4400
+	}
+	OPTIONALS
+	{
+		complete_contract = extraOperationalStationScience4 // additional science to complete for extra rep/confidence
+		complete_contract = longDurationCrew1 // A crewmember is in space for 1 year in a row
+	}
+}
+
 RP0_PROGRAM
 {
 	name = MarsSurfaceExp


### PR DESCRIPTION
A set of programs to represent all Low-Earth Orbit crewed science post-Early Earth Space Stations. The 4 programs very vaguely line up with:
- US: Shuttle/SpaceLab, Shuttle/SpaceLab, Shuttle-Mir/ISS, ISS
- USSR: Salyut 6+, Mir, Mir/ISS, ISS

The key differences between this and #2605, as well as other similar WIP programs:
- Focus on completing science objectives rather than generic Multi-Year Habitation
- No stipulation for the exact mission profile to accomplish the program.
  - Flexibility to work on either free-flyer vehicles like Shuttle/SpaceLab or modular stations.
  - Compatible with possible future changes to have old stations degrade.
  - If there is a program for Shuttle, that program could handle the capability demonstration and test flights, then these programs can handle operational usage of that infrastructure to accomplish the research.
- Many programs with flat funding, about 8 years each, which would allow for shifts in program priorities over many years.
  - Can, for example, have a break to free up slots for lunar habitation or crewed mars.

This PR doesn't have any details on added experiments. I figure we can reuse the experiments from:
- #2605 
  - And more recent fork https://github.com/panic-7700/RP-1/tree/modular-station
- #2786 

When experiment replacement from visiting vehicles becomes more relevant around 3 or 4, may need to revert to using ResearchPayload for a few generic experiment categories like "Life Sciences Experiments", "Crystal Growth Experiments", "Space Hardware Testing", etc. Could also introduce a game mechanic where parts can exchange experiments.

