### PR TITLE
Fix Runway recovery bonus

### DIFF
--- a/Source/RP0/SpaceCenter/Projects/ReconRolloutProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/ReconRolloutProject.cs
@@ -65,8 +65,7 @@ namespace RP0
         }
 
         /// <summary>
-        /// Only used for non-airlaunch cases
-        /// (either recovery or reconditioning)
+        /// Only used for reconditioning
         /// </summary>
         /// <param name="vessel"></param>
         /// <param name="type"></param>
@@ -95,18 +94,10 @@ namespace RP0
             {
                 RP0Debug.Log("Error while determining BP for recon_rollout");
             }
-            if (type == RolloutReconType.Rollback)
-                progress = BP;
-            else if (type == RolloutReconType.Recovery)
-            {
-                double KSCDistance = (float)SpaceCenter.Instance.GreatCircleDistance(SpaceCenter.Instance.cb.GetRelSurfaceNVector(vessel.latitude, vessel.longitude));
-                double maxDist = SpaceCenter.Instance.cb.Radius * Math.PI;
-                BP += BP * (KSCDistance / maxDist);
-            }
         }
 
         /// <summary>
-        /// Called for everything but reconditioning and recovery
+        /// Called for everything but reconditioning
         /// </summary>
         /// <param name="vessel"></param>
         /// <param name="type"></param>
@@ -126,6 +117,7 @@ namespace RP0
             switch (type)
             {
                 case RolloutReconType.Reconditioning:
+                    RP0Debug.LogWarning("Non-Reconditioning ReconRolloutProject called with Reconditioning");
                     BP = Formula.GetReconditioningBP(vessel);
                     cost = Formula.GetReconditioningCost(vessel);
                     break;

--- a/Source/RP0/SpaceCenter/Projects/VesselProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/VesselProject.cs
@@ -111,8 +111,9 @@ namespace RP0
         private PersistentHashSetValueType<string> partNames = new PersistentHashSetValueType<string>();
         [Persistent]
         private PersistentCompressedCraftNode ShipNodeCompressed = new PersistentCompressedCraftNode();
-
+        [Persistent]
         public string LandedAt = "";
+
         private double _buildRate = -1d;
         private double _leaderEffect = -1d;
         public double LeaderEffect => _leaderEffect < 0 ? UpdateLeaderEffect() : _leaderEffect;


### PR DESCRIPTION
#1715, which adds a recovery-time decrease for landing on a Runway, currently does not properly award this bonus. See the following pair of videos, wherein I recover the same pre-built Jet Trainer twice, once off the Runway and once on the Runway, and receive the same recovery time:

https://github.com/user-attachments/assets/30d6e341-2192-467b-8888-a160d624f29a

https://github.com/user-attachments/assets/5e5847f8-05c5-4059-9189-96bd9a5484bf

This appears to occur since the `LandedAt` attribute in VesselProject does not persist across the FLIGHT -> SPACE CENTER scene change, which causes it to reset to the empty string prior to the Runway check.

While investigating this, I noticed that the constructor marked as for "reconditioning and recovery" was not actually being used for recovery. Hence I have removed some dead code in that constructor and fixed the comments for the two ReconRolloutProject constructors.

The fixed behaviour is shown below:

https://github.com/user-attachments/assets/8887bc8b-a39e-4151-bde6-c43277d9baf7

https://github.com/user-attachments/assets/56768743-1ba8-4c24-9c50-283af74f838b