### PR TITLE
Fix unlock cost leader modifiers applying twice in editor GUI

### DIFF
--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -113,7 +113,7 @@ namespace RP0
             if (SpaceCenterManagement.EditorUnlockCosts > 0)
             {
                 showCredit = true;
-                GUILayout.Label($"Unlock Cost: √{-CurrencyUtils.Funds(TransactionReasonsRP0.PartOrUpgradeUnlock, -SpaceCenterManagement.EditorUnlockCosts):N1}");
+                GUILayout.Label($"Unlock Cost: √{SpaceCenterManagement.EditorUnlockCosts:N1}");
             }
 
             if (SpaceCenterManagement.EditorToolingCosts > 0)


### PR DESCRIPTION
`SpaceCenterManagement.EditorUnlockCosts` is the unlock cost *after* leader modifiers have been applied. Calling it again applies the modifier twice, as seen here. The LMAE costs 11000 after ECMs, and gets Nambi's 0.875x effect applied to it twice.
<img width="914" height="387" alt="image" src="https://github.com/user-attachments/assets/f8ed9bd3-6a25-485a-826b-fab165154409" />

This appears to only be a visual glitch, as the full (modified) unlock cost is still paid when unlocking. After this change, the unlock cost displays properly:
<img width="927" height="419" alt="fixed" src="https://github.com/user-attachments/assets/5e8c301c-a759-4cc4-97f8-856306ccfa70" />
