### PR TITLE
Make "Atmospheric Analysis Satellite" Contract Non-Random

### DIFF
--- a/GameData/RP-1/Contracts/Early Satellites (Light)/AtmosphereAnalysis.cfg
+++ b/GameData/RP-1/Contracts/Early Satellites (Light)/AtmosphereAnalysis.cfg
@@ -96,8 +96,8 @@ CONTRACT_TYPE
 			name = Orbit
 			type = Orbit
 			targetBody = HomeWorld()
-			minPeA = Round(Random(200000, 400000), 1000)
-			minApA = Round(Random(600000, 700000), 1000)
+			minPeA = 200000
+			minApA = 600000
 			disableOnStateChange = true
 			title = Reach orbit within the parameters
 		}


### PR DESCRIPTION
For some reason, the contract currently randomizes its Pe and Ap requirements between 200km-400km and 600km-700km respectively. This commit makes it a fixed 200-600km requirement. This is not communicated to the player in any way, is easy to cheese, and seems to serve no practical purpose, so removing the randomness seems like the best call.