### PR TITLE
Make stratospheric research an optional contract

### DIFF
--- a/GameData/RP-1/Contracts/X-Plane Research/XPlanesStratosphericResearch.cfg
+++ b/GameData/RP-1/Contracts/X-Plane Research/XPlanesStratosphericResearch.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 
 	title = X-Planes (Stratospheric Research)
 
-	description = <b>Program: X-Plane Research<br>Type: <color=green>Required</color></b><br><br>Future airliners may fly at unprecedented altitudes, and it is important to understand atmospheric behavior such as turbulence at high altitudes. In order to do this, design, build, and fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minAltitude meters in level subsonic flight, then return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.
+	description = <b>Program: X-Plane Research<br>Type: <color=blue>Optional</color></b><br><br>Future airliners may fly at unprecedented altitudes, and it is important to understand atmospheric behavior such as turbulence at high altitudes. In order to do this, design, build, and fly a crewed jet aircraft to maintain @VesselGroup/HoldSituation/minAltitude meters in level subsonic flight, then return home safely. Optionally, landing back at the runway will award extra reputation. If playing from the Cape, the Space Shuttle runway provided by the RSS-CanaveralHD mod is also a valid landing target.
 
 	genericDescription = Design, build, and fly a crewed jet aircraft to maintain a specific altitude, then return home safely.
 

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -21,7 +21,6 @@ RP0_PROGRAM
 		}
 		complete_contract = BreakSoundBarrier
 		complete_contract = XPlanesSupersonicMach2
-		complete_contract = XPlanesStratosphericResearch
 		complete_contract = XPlanesHighAltitude
 		complete_contract = XPlanesHypersonic
 		complete_contract = XPlanesKarman
@@ -31,6 +30,7 @@ RP0_PROGRAM
 	{
 		XPlanesSupersonicOptionalLow = true
 		XPlanesSupersonicOptionalHigh = true
+		XPlanesStratosphericResearch = true
 		XPlanesStratosphericResearchOptional = true
 		RocketPlaneDevelopmentOptional = true
 		XPlanesHighAltitudeOptional = true


### PR DESCRIPTION
I understand that this might be an unpopular suggestion, but here goes anyway.

This change makes Stratospheric Research optional, for a couple of reasons:
1. players aren't able to apply what they've learned in previous contracts to low-speed, high-altitude designs
  - these temu U-2s are basically powered gliders, and they have entirely different design considerations 
2. players *also* aren't able to apply what they learn in *this* contract to any future aspects of RP-1
  - the handling of a subsonic stratospheric jet is *very* different from the handling of a hypersonic spaceplane
  - there are no subsequent contracts (or even situations) in which a high-aspect-ratio, high-altitude jet is useful or required

The amount of clock time spent designing and testing, and then flying the contract itself, can be significant, for no future payoff, and while it seems appropriate as a stretch goal for an X-planes program, it does not in my opinion fit into the rest of the current program. 

I could envision a future series of x-planes contracts *in a new program* that might take more advantage of stratospheric data gathering, but the time investment into something like that would need to be justified by significant science or reputation/confidence gains.