### PR TITLE
Update contract limits after facility upgrade

### DIFF
--- a/Source/CC_RP0/ContractLimitOverrider.cs
+++ b/Source/CC_RP0/ContractLimitOverrider.cs
@@ -10,18 +10,38 @@ namespace ContractConfigurator.RP0
     [KSPAddon(KSPAddon.Startup.AllGameScenes, false)]
     public class ContractLimitOverrider : MonoBehaviour
     {
-        internal void Start()
+        internal void UpdateContractLimits()
         {
             if (HighLogic.CurrentGame.Mode == Game.Modes.CAREER)
             {
                 int maxActive = GameVariables.Instance.GetActiveContractsLimit(ScenarioUpgradeableFacilities.GetFacilityLevel(SpaceCenterFacility.MissionControl));
 
-                RP0Debug.Log($"Setting trivial, significant, and exceptional contract limits to {maxActive}.");
+                RP0Debug.Log($"Setting trivial, significant, and exceptional contract limits to {maxActive}.", true);
 
                 HighLogic.CurrentGame.Parameters.CustomParams<ContractConfiguratorParameters>().trivialContractLimit = maxActive;
                 HighLogic.CurrentGame.Parameters.CustomParams<ContractConfiguratorParameters>().significantContractLimit = maxActive;
                 HighLogic.CurrentGame.Parameters.CustomParams<ContractConfiguratorParameters>().exceptionalContractLimit = maxActive;
             }
+        }
+
+        internal void OnKSCFacilityUpgraded(Upgradeables.UpgradeableFacility facility, int _)
+        {
+            if (facility.name == "MissionControl")
+            {
+                UpdateContractLimits();
+            }
+        }
+
+        internal void Start()
+        {
+            UpdateContractLimits();
+
+            GameEvents.OnKSCFacilityUpgraded.Add(OnKSCFacilityUpgraded);
+        }
+
+        internal void OnDestroy()
+        {
+            GameEvents.OnKSCFacilityUpgraded.Remove(OnKSCFacilityUpgraded);
         }
     }
 }

--- a/Source/CC_RP0/ContractLimitOverrider.cs
+++ b/Source/CC_RP0/ContractLimitOverrider.cs
@@ -16,7 +16,7 @@ namespace ContractConfigurator.RP0
             {
                 int maxActive = GameVariables.Instance.GetActiveContractsLimit(ScenarioUpgradeableFacilities.GetFacilityLevel(SpaceCenterFacility.MissionControl));
 
-                RP0Debug.Log($"Setting trivial, significant, and exceptional contract limits to {maxActive}.", true);
+                RP0Debug.Log($"Setting trivial, significant, and exceptional contract limits to {maxActive}.");
 
                 HighLogic.CurrentGame.Parameters.CustomParams<ContractConfiguratorParameters>().trivialContractLimit = maxActive;
                 HighLogic.CurrentGame.Parameters.CustomParams<ContractConfiguratorParameters>().significantContractLimit = maxActive;


### PR DESCRIPTION
The contract limit code was not getting called immediately after a facility was done upgrading, leading to situations like this: (it would get fixed on the next scene switch, but going into mission control doesn't require a scene switch)
<img width="511" height="132" alt="image" src="https://github.com/user-attachments/assets/e5ba7c97-a0a4-4748-8be2-f83d653329ed" />
