### PR TITLE
Add Early XPlanes Program Modifier

### DIFF
--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -50,6 +50,42 @@ RP0_PROGRAM
 	}
 }
 
+RP0_PROGRAM_MODIFIER
+{
+	srcProgram = EarlySatellites
+	tgtProgram = EarlyXPlanes
+	nominalDurationYears = 7
+	baseFunding = 400000
+	fundingCurve = Flat
+	repDeltaOnCompletePerYearEarly = 105
+	repPenaltyPerYearLate = 105
+	slots = 1
+
+	CONFIDENCECOSTS
+	{
+		Normal = 350
+		Fast = 700
+	}
+}
+
+RP0_PROGRAM_MODIFIER
+{
+	srcProgram = EarlySatellites-Heavy
+	tgtProgram = EarlyXPlanes
+	nominalDurationYears = 7
+	baseFunding = 400000
+	fundingCurve = Flat
+	repDeltaOnCompletePerYearEarly = 105
+	repPenaltyPerYearLate = 105
+	slots = 1
+
+	CONFIDENCECOSTS
+	{
+		Normal = 350
+		Fast = 700
+	}
+}
+
 RP0_PROGRAM
 {
 	name = SuborbRocketDev

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -63,8 +63,8 @@ RP0_PROGRAM_MODIFIER
 
 	CONFIDENCECOSTS
 	{
-		Normal = 250
-		Fast = 500
+		Normal = 300
+		Fast = 600
 	}
 }
 

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -54,17 +54,17 @@ RP0_PROGRAM_MODIFIER
 {
 	srcProgram = EarlySatellites
 	tgtProgram = EarlyXPlanes
-	nominalDurationYears = 7
-	baseFunding = 400000
+	nominalDurationYears = 5
+	baseFunding = 285000
 	fundingCurve = Flat
-	repDeltaOnCompletePerYearEarly = 105
-	repPenaltyPerYearLate = 105
+	repDeltaOnCompletePerYearEarly = 65
+	repPenaltyPerYearLate = 65
 	slots = 1
 
 	CONFIDENCECOSTS
 	{
-		Normal = 350
-		Fast = 700
+		Normal = 250
+		Fast = 500
 	}
 }
 
@@ -72,17 +72,17 @@ RP0_PROGRAM_MODIFIER
 {
 	srcProgram = EarlySatellites-Heavy
 	tgtProgram = EarlyXPlanes
-	nominalDurationYears = 7
-	baseFunding = 400000
+	nominalDurationYears = 5
+	baseFunding = 285000
 	fundingCurve = Flat
-	repDeltaOnCompletePerYearEarly = 105
-	repPenaltyPerYearLate = 105
+	repDeltaOnCompletePerYearEarly = 65
+	repPenaltyPerYearLate = 65
 	slots = 1
 
 	CONFIDENCECOSTS
 	{
-		Normal = 350
-		Fast = 700
+		Normal = 250
+		Fast = 500
 	}
 }
 

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -63,8 +63,8 @@ RP0_PROGRAM_MODIFIER
 
 	CONFIDENCECOSTS
 	{
-		Normal = 300
-		Fast = 600
+		Normal = 250
+		Fast = 500
 	}
 }
 
@@ -81,8 +81,8 @@ RP0_PROGRAM_MODIFIER
 
 	CONFIDENCECOSTS
 	{
-		Normal = 300
-		Fast = 600
+		Normal = 250
+		Fast = 500
 	}
 }
 

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -55,10 +55,10 @@ RP0_PROGRAM_MODIFIER
 	srcProgram = EarlySatellites
 	tgtProgram = EarlyXPlanes
 	nominalDurationYears = 5
-	baseFunding = 285000
+	baseFunding = 350000
 	fundingCurve = Flat
-	repDeltaOnCompletePerYearEarly = 65
-	repPenaltyPerYearLate = 65
+	repDeltaOnCompletePerYearEarly = 80
+	repPenaltyPerYearLate = 80
 	slots = 1
 
 	CONFIDENCECOSTS
@@ -73,16 +73,16 @@ RP0_PROGRAM_MODIFIER
 	srcProgram = EarlySatellites-Heavy
 	tgtProgram = EarlyXPlanes
 	nominalDurationYears = 5
-	baseFunding = 285000
+	baseFunding = 350000
 	fundingCurve = Flat
-	repDeltaOnCompletePerYearEarly = 65
-	repPenaltyPerYearLate = 65
+	repDeltaOnCompletePerYearEarly = 80
+	repPenaltyPerYearLate = 80
 	slots = 1
 
 	CONFIDENCECOSTS
 	{
-		Normal = 250
-		Fast = 500
+		Normal = 300
+		Fast = 600
 	}
 }
 


### PR DESCRIPTION
Right now Early X-planes is a major financial advantage for the default 1951 start, but it is not tempting to take once you are in the orbital era.

This modifier makes it more flexible to accept in later stages of a career, by reducing the program slot to 1 and adjusting the funding. From a cost per slot per year, this pays similar to the early satellite programs.