### PR TITLE
Add more Airlaunch Upgrades

### DIFF
--- a/GameData/RP-1/SCMData/AirlaunchLevels.cfg
+++ b/GameData/RP-1/SCMData/AirlaunchLevels.cfg
@@ -53,4 +53,66 @@ KCTAIRLAUNCHTECHS
 		MaxMass = 25000
 		MaxSize = 15, 8, 21
 	}
+
+	// C-141 / IL-76
+	AIRLAUNCHTECHLEVEL
+	{
+		TechRequired = advancedJetEngines
+		MinAltitude = 5000
+		MaxAltitude = 13750
+		MaxKscDistance = 1000000
+		MinVelocity = 125
+		MaxVelocity = 272
+		MaxMass = 45000
+		MaxSize = 20, 12, 28
+	}
+	// 747 SCA
+	AIRLAUNCHTECHLEVEL
+	{
+		TechRequired = matureTurbofans
+		MinAltitude = 5000
+		MaxAltitude = 13750
+		MaxKscDistance = 1000000
+		MinVelocity = 125
+		MaxVelocity = 275
+		MaxMass = 78000
+		MaxSize = 28, 20, 41
+	}
+	// An-225
+	AIRLAUNCHTECHLEVEL
+	{
+		TechRequired = refinedTurbofans
+		MinAltitude = 5000
+		MaxAltitude = 13750
+		MaxKscDistance = 1000000
+		MinVelocity = 125
+		MaxVelocity = 275
+		MaxMass = 280000
+		MaxSize = 38, 20, 46
+	}
+	// Heavy Mach 2 Transport 
+	AIRLAUNCHTECHLEVEL
+	{
+		TechRequired = scramjetEngines
+		MinAltitude = 5000
+		MaxAltitude = 18000
+		MaxKscDistance = 1000000
+		MinVelocity = 125
+		MaxVelocity = 600
+		MaxMass = 280000
+		MaxSize = 38, 20, 46
+	}
+	// Heavy Mach 3 Transport
+	AIRLAUNCHTECHLEVEL
+	{
+		TechRequired = advancedTurbofans
+		MinAltitude = 5000
+		MaxAltitude = 21500
+		MaxKscDistance = 1000000
+		MinVelocity = 125
+		MaxVelocity = 850
+		MaxMass = 280000
+		MaxSize = 38, 20, 46
+	}
+
 }

--- a/GameData/RP-1/Tree/AirlaunchTechlevels.cfg
+++ b/GameData/RP-1/Tree/AirlaunchTechlevels.cfg
@@ -45,3 +45,63 @@ PARTUPGRADE
 	manufacturer = Generic
 	description = Airlaunch limits are extended to allow vessels up to 25 t in mass while other limits stay at 15 x 8 x 21 m (width x height x length). Altitude is still limited to 13,750 m and speed to 272 m/s. NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock. 
 }
+
+PARTUPGRADE
+{
+	name = airlaunchTL5
+	partIcon = SXTmk3Cockpit52
+	techRequired = advancedJetEngines
+	entryCost = 1
+	cost = 0
+	title = Airlaunch Level 5
+	manufacturer = Generic
+	description = Airlaunch limits scale up for early heavy strategic airlifters. Allows vessels up to 45 t in mass and dimensions within 20 x 12 x 28 m (width x height x length). Deployment limits remain at 13,750 m and 272 m/s. NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock. 
+}
+
+PARTUPGRADE
+{
+	name = airlaunchTL6
+	partIcon = SXTmk3Cockpit52
+	techRequired = matureTurbofans
+	entryCost = 1
+	cost = 0
+	title = Airlaunch Level 6
+	manufacturer = Generic
+	description = Airlaunch limits are extended to allow vessels up to 78 t in mass and with dimensions within 28 x 20 x 41 m (width x height x length). Altitude is still limited to 13,750 m and speed to 275 m/s. NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock.
+}
+
+PARTUPGRADE
+{
+	name = airlaunchTL7
+	partIcon = SXTmk3Cockpit52
+	techRequired = refinedTurbofans
+	entryCost = 1
+	cost = 0
+	title = Airlaunch Level 7
+	manufacturer = Generic
+	description = Airlaunch limits are extended to allow vessels up to 280 t in mass and with dimensions within 38 x 20 x 46 m (width x height x length). Altitude is still limited to 13,750 m and speed to 275 m/s. NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock.
+}
+
+PARTUPGRADE
+{
+	name = airlaunchTL8
+	partIcon = SXTmk3Cockpit52
+	techRequired = scramjetEngines
+	entryCost = 1
+	cost = 0
+	title = Airlaunch Level 8
+	manufacturer = Generic
+	description = Airlaunch limits are extended to allow an altitude up to 18,000 m and speed to 600 m/s, while other limits stay at 280 t in mass and 38 x 20 x 46 m (width x height x length). NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock.
+}
+
+PARTUPGRADE
+{
+        name = airlaunchTL9
+        partIcon = SXTmk3Cockpit52
+        techRequired = advancedTurbofans
+        entryCost = 1
+        cost = 0
+        title = Airlaunch Level 9
+        manufacturer = Generic
+        description = Airlaunch limits are extended to allow an altitude up to 21,500 m and speed to 850 m/s, while other limits stay at 280 t in mass and 38 x 20 x 46 m (width x height x length). NOTE: This is not a part you can use, it just symbolizes the new capabilities you can unlock. 
+}


### PR DESCRIPTION
This PR adds three more air-launch levels, increasing in speed, altitude and payload mass. 

I suppose more modern airlaunches such as Aurora (or [Vega](https://www.polaris-raumflugzeuge.de/products/hypersonic-platform-vega)  (POLARIS Spaceplanes) or... [Aurora](https://www.dawnaerospace.com/spaceplane-program) (Dawn Spaceplanes) could also be possible.

The original intent was to have sidegrades (go very fast but with a light craft, or have a heavy craft but go slow, etc.), but I couuld not get this to work. If anyone has an idea on how to achieve this, I would be all ears. Another solution would be to change the XB-70 esque launcher to be the last one, but I deem this to be somewhat silly considering it would have (theoretically) been possible.

