### PR TITLE
Fix orphan status of 4.8m antenna and reintroduce it to the tech tree

### DIFF
--- a/GameData/RP-1/Tree/TREE-Parts.cfg
+++ b/GameData/RP-1/Tree/TREE-Parts.cfg
@@ -23908,6 +23908,17 @@
     %MODULE[ModuleTagList] { tag = EngineLiquidTurbo }
 
 }
+@PART[commDish]:FOR[xxxRP0]
+{
+    %TechRequired = deepSpaceComms
+    %cost = 150
+    %entryCost = 20000
+    RP0conf = true
+    @description ^=:$: <b><color=green>From Stock (RO Config) mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = Instruments }
+
+}
 @PART[conformaldecals-flag]:FOR[xxxRP0]
 {
     %TechRequired = unlockParts

--- a/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
+++ b/Source/Tech Tree/Parts Browser/data/Stock__RO_Config.json
@@ -4071,7 +4071,7 @@
         "era": "08-LONGTERM",
         "ro": true,
         "rp0": true,
-        "orphan": true,
+        "orphan": false,
         "rp0_conf": true,
         "spacecraft": "Galileo",
         "engine_config": "",


### PR DESCRIPTION
When updating the antenna placements, the Orphan tickbox on the 4.8m antenna accidentally got turned on, removing it from the tech tree.