### PR TITLE
Improve the build list auto alarms

### DIFF
--- a/Source/RP0/ModIntegrations/AlarmHelper.cs
+++ b/Source/RP0/ModIntegrations/AlarmHelper.cs
@@ -22,7 +22,6 @@ namespace RP0.ModIntegrations
         /// </returns>
         public static string CreateAlarm(string title, string description, double UT, KACAPI.AlarmTypeEnum alarmType = KACAPI.AlarmTypeEnum.Raw)
         {
-            string s = "Alarm created with ID: ";
             if (UseKAC)
             {
                 if (alarmType == KACAPI.AlarmTypeEnum.Contract || alarmType == KACAPI.AlarmTypeEnum.ContractAuto)
@@ -38,12 +37,12 @@ namespace RP0.ModIntegrations
                     {
                         alarm.AlarmAction = KACAPI.AlarmActionEnum.KillWarp;
                         alarm.Notes = description;
-                        RP0Debug.Log(s + alarmID);
+                        RP0Debug.Log($"Alarm created with ID: {alarmID}");
                         return alarmID;
                     }
                     else
                     {
-                        RP0Debug.Log($"KAC Alarm with ID: {alarmID} could not be found."); // this is usually fine, because KAC waits until the end of the frame to add the alarm
+                        RP0Debug.LogWarning($"KAC Alarm with ID: {alarmID} could not be found.");
                         return alarmID;
                     }
                 }
@@ -66,7 +65,7 @@ namespace RP0.ModIntegrations
                 if (alarm.Id != 0u)
                 {
                     string alarmID = alarm.Id.ToString();
-                    RP0Debug.Log(s + alarmID);
+                    RP0Debug.Log($"Alarm created with ID: {alarmID}");
                     return alarmID;
                 }
                 else
@@ -85,7 +84,6 @@ namespace RP0.ModIntegrations
         /// </returns>
         public static bool ChangeAlarm(string id, string title, string description, double UT)
         {
-            string s = $"Alarm with ID: {id} changed to have title: {title}, description: {description}, and time: {UT}.";
             if (UseKAC)
             {
                 KACAlarm alarm = KACWrapper.KAC.Alarms.FirstOrDefault(a => a.ID == id);
@@ -98,7 +96,7 @@ namespace RP0.ModIntegrations
                 alarm.Notes = description;
                 alarm.AlarmTime = UT;
                 // KAC does not let you change the alarm type of an alarm after it has been made
-                RP0Debug.Log(s);
+                RP0Debug.Log($"Alarm with ID: {id} changed to have title: {title}, description: {description}, and time: {UT}.");
                 return true;
             }
             else
@@ -116,7 +114,7 @@ namespace RP0.ModIntegrations
                 alarm.title = title;
                 alarm.description = description;
                 alarm.ut = UT;
-                RP0Debug.Log(s);
+                RP0Debug.Log($"Alarm with ID: {id} changed to have title: {title}, description: {description}, and time: {UT}.");
                 return true;
             }
         }
@@ -129,13 +127,11 @@ namespace RP0.ModIntegrations
         /// </returns>
         public static bool DeleteAlarmWithID(string id)
         {
-            string s1 = "Alarm deleted with ID: ";
-            string s2 = "Could not delete alarm with ID: ";
             bool successful;
             if (UseKAC)
             {
                 successful = KACWrapper.KAC.DeleteAlarm(id);
-                RP0Debug.Log((successful ? s1 : s2) + id);
+                RP0Debug.Log((successful ? "Alarm deleted with ID: " : "Could not delete alarm with ID: ") + id);
                 return successful;
             }
             else
@@ -143,7 +139,7 @@ namespace RP0.ModIntegrations
                 if (uint.TryParse(id, out uint alarmID))
                 {
                     successful = AlarmClockScenario.DeleteAlarm(alarmID);
-                    RP0Debug.Log((successful ? s1 : s2) + id);
+                    RP0Debug.Log((successful ? "Alarm deleted with ID: " : "Could not delete alarm with ID: ") + id);
                     return successful;
                 }
                 else
@@ -162,9 +158,6 @@ namespace RP0.ModIntegrations
         /// </returns>
         public static bool DeleteAllAlarmsWithTitle(string title, bool useStartsWith = false)
         {
-            string s1 = "Alarm deleted with ID: ";
-            string s2 = "Could not delete alarm with ID: ";
-            string s3 = "No alarms found with title: " + title;
             bool successful = true;
             bool foundAlarm = false;
             bool hasTitle(string alarmTitle) => alarmTitle != null && (useStartsWith ? alarmTitle.StartsWith(title) : alarmTitle.Contains(title));
@@ -176,14 +169,14 @@ namespace RP0.ModIntegrations
                     string id = alarm.ID;
                     if (!KACWrapper.KAC.DeleteAlarm(id))
                     {
-                        RP0Debug.LogError(s2 + id);
+                        RP0Debug.LogError($"Could not delete alarm with ID: {id}");
                         successful = false;
                     }
-                    else RP0Debug.Log(s1 + id);
+                    else RP0Debug.Log($"Alarm deleted with ID: {id}");
                 }
                 if (!foundAlarm)
                 {
-                    RP0Debug.Log(s3); // this is usually fine, because KAC waits until the end of the frame to delete the alarm
+                    RP0Debug.LogWarning($"No alarms found with title: {title}");
                     successful = false;
                 }
                 return successful;
@@ -196,14 +189,14 @@ namespace RP0.ModIntegrations
                     foundAlarm = true;
                     if (!AlarmClockScenario.DeleteAlarm(id))
                     {
-                        RP0Debug.LogError(s2 + id);
+                        RP0Debug.LogError($"Could not delete alarm with ID: {id}");
                         successful = false;
                     }
-                    else RP0Debug.Log(s1 + id);
+                    else RP0Debug.Log($"Alarm deleted with ID: {id}");
                 }
                 if (!foundAlarm)
                 {
-                    RP0Debug.LogWarning(s3);
+                    RP0Debug.LogWarning($"No alarms found with title: {title}");
                     successful = false;
                 }
                 return successful;

--- a/Source/RP0/ModIntegrations/AlarmHelper.cs
+++ b/Source/RP0/ModIntegrations/AlarmHelper.cs
@@ -42,7 +42,7 @@ namespace RP0.ModIntegrations
                     }
                     else
                     {
-                        RP0Debug.LogWarning($"KAC Alarm with ID: {alarmID} could not be found.");
+                        RP0Debug.LogError($"KAC Alarm with ID: {alarmID} could not be found.");
                         return alarmID;
                     }
                 }

--- a/Source/RP0/ModIntegrations/AlarmHelper.cs
+++ b/Source/RP0/ModIntegrations/AlarmHelper.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq;
-using KACAPI = RP0.KACWrapper.KACAPI;
+﻿using UniLinq;
 using KACAlarm = RP0.KACWrapper.KACAPI.KACAlarm;
+using KACAPI = RP0.KACWrapper.KACAPI;
 
 namespace RP0.ModIntegrations
 {
@@ -43,8 +43,7 @@ namespace RP0.ModIntegrations
                     }
                     else
                     {
-                        //RP0Debug.LogError($"KAC Alarm with ID: {alarmID} could not be found."); // this is usually fine, because KAC waits until the end of the frame to add the alarm
-                        RP0Debug.Log($"KAC Alarm with ID: {alarmID} could not be found.");
+                        RP0Debug.Log($"KAC Alarm with ID: {alarmID} could not be found."); // this is usually fine, because KAC waits until the end of the frame to add the alarm
                         return alarmID;
                     }
                 }
@@ -79,7 +78,51 @@ namespace RP0.ModIntegrations
         }
 
         /// <summary>
-        /// Deletes the alarm with a certain id (uint must be converted to string first).
+        /// Finds the alarm with a certain id and updates its properties.
+        /// </summary>
+        /// <returns>
+        /// Success
+        /// </returns>
+        public static bool ChangeAlarm(string id, string title, string description, double UT)
+        {
+            string s = $"Alarm with ID: {id} changed to have title: {title}, description: {description}, and time: {UT}.";
+            if (UseKAC)
+            {
+                KACAlarm alarm = KACWrapper.KAC.Alarms.FirstOrDefault(a => a.ID == id);
+                if (alarm == null)
+                {
+                    RP0Debug.LogError($"KAC Alarm with ID: {id} could not be found.");
+                    return false;
+                }
+                alarm.Name = title;
+                alarm.Notes = description;
+                alarm.AlarmTime = UT;
+                // KAC does not let you change the alarm type of an alarm after it has been made
+                RP0Debug.Log(s);
+                return true;
+            }
+            else
+            {
+                if (!uint.TryParse(id, out uint alarmID))
+                {
+                    RP0Debug.LogError("Could not parse stock alarm ID " + id + " to uint");
+                    return false;
+                }
+                if (!AlarmClockScenario.Instance.alarms.TryGetValue(alarmID, out AlarmTypeBase alarm) || alarm == null)
+                {
+                    RP0Debug.LogError("Could not find stock alarm with ID " + id);
+                    return false;
+                }
+                alarm.title = title;
+                alarm.description = description;
+                alarm.ut = UT;
+                RP0Debug.Log(s);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Deletes the alarm with a certain id.
         /// </summary>
         /// <returns>
         /// Success
@@ -140,8 +183,7 @@ namespace RP0.ModIntegrations
                 }
                 if (!foundAlarm)
                 {
-                    //RP0Debug.LogWarning(s3); // this is usually fine, because KAC waits until the end of the frame to delete the alarm
-                    RP0Debug.Log(s3);
+                    RP0Debug.Log(s3); // this is usually fine, because KAC waits until the end of the frame to delete the alarm
                     successful = false;
                 }
                 return successful;
@@ -169,7 +211,7 @@ namespace RP0.ModIntegrations
         }
 
         /// <summary>
-        /// Determines if an alarm with a certain id exists (uint must be converted to string first).
+        /// Determines if an alarm with a certain id exists.
         /// </summary>
         /// <returns>
         /// Alarm exists

--- a/Source/RP0/ModIntegrations/AlarmHelper.cs
+++ b/Source/RP0/ModIntegrations/AlarmHelper.cs
@@ -43,7 +43,8 @@ namespace RP0.ModIntegrations
                     }
                     else
                     {
-                        RP0Debug.LogError($"KAC Alarm with ID: {alarmID} could not be found.");
+                        //RP0Debug.LogError($"KAC Alarm with ID: {alarmID} could not be found."); // this is usually fine, because KAC waits until the end of the frame to add the alarm
+                        RP0Debug.Log($"KAC Alarm with ID: {alarmID} could not be found.");
                         return alarmID;
                     }
                 }
@@ -80,9 +81,6 @@ namespace RP0.ModIntegrations
         /// <summary>
         /// Deletes the alarm with a certain id (uint must be converted to string first).
         /// </summary>
-        /// <remarks>
-        /// KAC gives a null reference if you delete an alarm while the end alarm window is open. This isn't a problem with the stock end alarm window, so I'll just say it's KAC's fault.
-        /// </remarks>
         /// <returns>
         /// Success
         /// </returns>
@@ -116,9 +114,6 @@ namespace RP0.ModIntegrations
         /// <summary>
         /// Deletes all alarms that contain (or start with) a certain string in their title.
         /// </summary>
-        /// <remarks>
-        /// KAC gives a null reference if you delete an alarm while the end alarm window is open. This isn't a problem with the stock end alarm window, so I'll just say it's KAC's fault.
-        /// </remarks>
         /// <returns>
         /// Success
         /// </returns>
@@ -145,7 +140,8 @@ namespace RP0.ModIntegrations
                 }
                 if (!foundAlarm)
                 {
-                    RP0Debug.LogWarning(s3);
+                    //RP0Debug.LogWarning(s3); // this is usually fine, because KAC waits until the end of the frame to delete the alarm
+                    RP0Debug.Log(s3);
                     successful = false;
                 }
                 return successful;

--- a/Source/RP0/ModIntegrations/AlarmHelper.cs
+++ b/Source/RP0/ModIntegrations/AlarmHelper.cs
@@ -15,7 +15,7 @@ namespace RP0.ModIntegrations
         /// Creates an alarm.
         /// </summary>
         /// <remarks>
-        /// Do not pass in Contract or ContractAuto as the alarmType, KAC seems to immediately delete the alarm for some reason.
+        /// Do not pass in Contract or ContractAuto as the alarmType, KAC immediately deletes the alarm due to https://github.com/linuxgurugamer/KerbalAlarmClock/issues/14.
         /// </remarks>
         /// <returns>
         /// AlarmID
@@ -26,7 +26,7 @@ namespace RP0.ModIntegrations
             if (UseKAC)
             {
                 if (alarmType == KACAPI.AlarmTypeEnum.Contract || alarmType == KACAPI.AlarmTypeEnum.ContractAuto)
-                { // no idea what causes KAC to immediately delete these alarms, so just don't allow them
+                {
                     alarmType = KACAPI.AlarmTypeEnum.Raw;
                 }
                 string alarmID = KACWrapper.KAC.CreateAlarm(alarmType, title, UT);

--- a/Source/RP0/UI/KCT/GUI_BuildList.cs
+++ b/Source/RP0/UI/KCT/GUI_BuildList.cs
@@ -32,8 +32,8 @@ namespace RP0
         private const int _width1 = 120;
         private const int _width2 = 100;
         private const int _butW = 20;
-        private static ISpaceCenterProject buildItem;
-        private static string itemText;
+        private static ISpaceCenterProject _prevBuildItem;
+        private static string _prevItemText;
 
         public static void SelectList(string list)
         {
@@ -234,9 +234,9 @@ namespace RP0
             }
             GUILayout.EndHorizontal();
             double UT = Planetarium.GetUniversalTime();
-            bool staleAlarm = buildItem != nextThing || itemText != txt || (timeLeft > 100 && !KCTUtilities.IsApproximatelyEqual(SpaceCenterManagement.Instance.AlarmUT - UT, timeLeft));
+            bool staleAlarm = _prevBuildItem != nextThing || _prevItemText != txt || (timeLeft > 100 && !KCTUtilities.IsApproximatelyEqual(SpaceCenterManagement.Instance.AlarmUT - UT, timeLeft));
             // if the timeLeft is less than 100, the difference might be less than a second due to frame times, so we don't care about it
-            if (KCTSettings.Instance.AutoAlarms && buildItem != null && (staleAlarm || !AlarmHelper.AlarmExistsID(SpaceCenterManagement.Instance.AlarmId)))
+            if (KCTSettings.Instance.AutoAlarms && _prevBuildItem != null && (staleAlarm || !AlarmHelper.AlarmExistsID(SpaceCenterManagement.Instance.AlarmId)))
             {
                 SpaceCenterManagement.Instance.AlarmUT = timeLeft + UT;
                 if (nextThing == null)
@@ -265,8 +265,8 @@ namespace RP0
                     AlarmHelper.ChangeAlarm(SpaceCenterManagement.Instance.AlarmId, $"RP-1: {txt}", "", SpaceCenterManagement.Instance.AlarmUT);
                 }
             }
-            buildItem = nextThing;
-            itemText = txt;
+            _prevBuildItem = nextThing;
+            _prevItemText = txt;
 
             GUILayout.BeginHorizontal();
 

--- a/Source/RP0/UI/KCT/GUI_BuildList.cs
+++ b/Source/RP0/UI/KCT/GUI_BuildList.cs
@@ -235,15 +235,14 @@ namespace RP0
             if (KCTSettings.Instance.AutoAlarms && buildItem != null && (buildItem != nextThing || txt != itemText || !AlarmHelper.AlarmExistsTitle(txt, out string _)))
             {
                 RP0Debug.Log($"Triggering old alarm deletion");
-                // old alarm, need to delete to get the new alarm for the new nextThing
                 string alarmPrefix = "RP-1: ";
                 if (string.IsNullOrEmpty(SpaceCenterManagement.Instance.AlarmId) || (!AlarmHelper.DeleteAlarmWithID(SpaceCenterManagement.Instance.AlarmId) && !AlarmHelper.DeleteAllAlarmsWithTitle(alarmPrefix, true)))
                 {
-                    RP0Debug.Log("No old alarm found, new alarm being created!");
+                    RP0Debug.Log("No old alarm found");
                 }
                 else
                 {
-                    RP0Debug.Log("Old alarm deleted, new alarm being created!");
+                    RP0Debug.Log("Old alarm deleted");
                 }
 
                 if (nextThing != null)

--- a/Source/RP0/UI/KCT/GUI_BuildList.cs
+++ b/Source/RP0/UI/KCT/GUI_BuildList.cs
@@ -32,6 +32,8 @@ namespace RP0
         private const int _width1 = 120;
         private const int _width2 = 100;
         private const int _butW = 20;
+        private static ISpaceCenterProject buildItem;
+        private static string itemText;
 
         public static void SelectList(string list)
         {
@@ -127,88 +129,95 @@ namespace RP0
             GUILayout.BeginVertical();
             GUILayout.BeginHorizontal();
             GUILayout.Label("Next:", _windowSkin.label);
-            ISpaceCenterProject buildItem = KCTUtilities.GetNextThingToFinish();
-            if (buildItem != null)
+            ISpaceCenterProject nextThing = KCTUtilities.GetNextThingToFinish();
+            string txt = "";
+            if (nextThing != null)
             {
-                string txt = buildItem.GetItemName(), locTxt = "VAB";
-                if (buildItem.GetProjectType() == ProjectType.None)
+                txt = nextThing.GetItemName();
+                string locTxt = "VAB";
+                switch (nextThing.GetProjectType())
                 {
-                    locTxt = string.Empty;
-                }
-                else if (buildItem.GetProjectType() == ProjectType.Reconditioning)
-                {
-                    ReconRolloutProject reconRoll = buildItem as ReconRolloutProject;
-                    if (reconRoll.RRType == ReconRolloutProject.RolloutReconType.Reconditioning)
-                    {
-                        txt = "Reconditioning";
-                        locTxt = reconRoll.launchPadID;
-                    }
-                    else if (reconRoll.RRType == ReconRolloutProject.RolloutReconType.Rollout)
-                    {
-                        VesselProject associated = reconRoll.LC.Warehouse.FirstOrDefault(vp => vp.shipID == reconRoll.AssociatedIdAsGuid);
-                        txt = $"{associated.shipName} Rollout";
-                        locTxt = reconRoll.launchPadID;
-                    }
-                    else if (reconRoll.RRType == ReconRolloutProject.RolloutReconType.Rollback)
-                    {
-                        VesselProject associated = reconRoll.LC.Warehouse.FirstOrDefault(vp => vp.shipID == reconRoll.AssociatedIdAsGuid);
-                        txt = $"{associated.shipName} Rollback";
-                        locTxt = reconRoll.launchPadID;
-                    }
-                    else if (reconRoll.RRType == ReconRolloutProject.RolloutReconType.Recovery)
-                    {
-                        VesselProject associated = reconRoll.LC.Warehouse.FirstOrDefault(vp => vp.shipID == reconRoll.AssociatedIdAsGuid);
-                        txt = $"{associated.shipName} Recovery";
-                        locTxt = associated.LC.Name;
-                    }
-                    else
-                    {
-                        locTxt = "Storage";
-                    }
-                }
-                else if (buildItem.GetProjectType() == ProjectType.AirLaunch)
-                {
-                    ReconRolloutProject ar = buildItem as ReconRolloutProject;
-                    VesselProject associated = ar.AssociatedVP;
-                    if (associated != null)
-                    {
-                        if (ar.RRType == ReconRolloutProject.RolloutReconType.AirlaunchMount)
-                            txt = $"{associated.shipName} Mounting";
-                        else
-                            txt = $"{associated.shipName} Unmounting";
-                    }
-                    else
-                        txt = "Airlaunch Operations";
+                    case ProjectType.None:
+                        locTxt = string.Empty;
+                        break;
+                    case ProjectType.Reconditioning:
+                        if (nextThing is ReconRolloutProject reconRoll)
+                        {
+                            switch (reconRoll.RRType)
+                            {
+                                case ReconRolloutProject.RolloutReconType.Reconditioning:
+                                    locTxt = reconRoll.launchPadID;
+                                    break;
+                                case ReconRolloutProject.RolloutReconType.Rollout:
+                                {
+                                    VesselProject associated = reconRoll.LC.Warehouse.FirstOrDefault(vp => vp.shipID == reconRoll.AssociatedIdAsGuid);
+                                    txt = $"{associated.shipName} Rollout at {reconRoll.launchPadID}";
+                                    locTxt = reconRoll.launchPadID;
+                                    break;
+                                }
+                                case ReconRolloutProject.RolloutReconType.Rollback:
+                                {
+                                    VesselProject associated = reconRoll.LC.Warehouse.FirstOrDefault(vp => vp.shipID == reconRoll.AssociatedIdAsGuid);
+                                    txt = $"{associated.shipName} Rollback at {reconRoll.launchPadID}";
+                                    locTxt = reconRoll.launchPadID;
+                                    break;
+                                }
+                                case ReconRolloutProject.RolloutReconType.Recovery:
+                                {
+                                    VesselProject associated = reconRoll.LC.Warehouse.FirstOrDefault(vp => vp.shipID == reconRoll.AssociatedIdAsGuid);
+                                    txt = $"{associated.shipName} Recovery";
+                                    locTxt = associated.LC.Name;
+                                    break;
+                                }
+                                default:
+                                    locTxt = "Storage";
+                                    break;
+                            }
+                        }
+                        break;
+                    case ProjectType.AirLaunch:
+                        if (nextThing is ReconRolloutProject ar)
+                        {
+                            VesselProject associated = ar.AssociatedVP;
+                            if (associated != null)
+                            {
+                                if (ar.RRType == ReconRolloutProject.RolloutReconType.AirlaunchMount)
+                                    txt = $"{associated.shipName} Mounting";
+                                else
+                                    txt = $"{associated.shipName} Unmounting";
+                            }
+                            else
+                                txt = "Airlaunch Operations";
 
-                    locTxt = ar.LC.Name;
-
-                }
-                else if (buildItem.GetProjectType() == ProjectType.VAB || buildItem.GetProjectType() == ProjectType.SPH)
-                {
-                    VesselProject vp = buildItem as VesselProject;
-                    locTxt = vp == null || vp.LC == null ? "Vessel" : vp.LC.Name;
-                }
-                else if (buildItem.GetProjectType() == ProjectType.TechNode)
-                {
-                    locTxt = "Tech";
-                }
-                else if (buildItem.GetProjectType() == ProjectType.KSC)
-                {
-                    locTxt = "KSC";
-                }
-                else if (buildItem.GetProjectType() == ProjectType.Crew)
-                {
-                    locTxt = txt;
-                    txt = "Training";
+                            locTxt = ar.LC.Name;
+                        }
+                        break;
+                    case ProjectType.VAB:
+                    case ProjectType.SPH:
+                        if (nextThing is VesselProject vp)
+                        {
+                            locTxt = vp == null || vp.LC == null ? "Vessel" : vp.LC.Name;
+                        }
+                        break;
+                    case ProjectType.TechNode:
+                        locTxt = "Tech";
+                        break;
+                    case ProjectType.KSC:
+                        locTxt = "KSC";
+                        break;
+                    case ProjectType.Crew:
+                        locTxt = txt;
+                        txt = "Training";
+                        break;
                 }
 
                 GUILayout.Label(txt);
                 GUILayout.Label(locTxt, _windowSkin.label);
-                GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(buildItem.GetTimeLeft(), txt+locTxt+buildItem.GetItemName()));
+                GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(nextThing.GetTimeLeft(), txt+locTxt+nextThing.GetItemName()));
 
                 if (!HighLogic.LoadedSceneIsEditor && TimeWarp.CurrentRateIndex == 0)
                 {
-                    string tooltip = buildItem.GetTimeLeft() > 86400d * 365.25 * 5 ? null : $"√ Gain/Loss:\n{(SpaceCenterManagement.Instance.GetBudgetDelta(buildItem.GetTimeLeft())):N0}";
+                    string tooltip = nextThing.GetTimeLeft() > 86400d * 365.25 * 5 ? null : $"√ Gain/Loss:\n{(SpaceCenterManagement.Instance.GetBudgetDelta(nextThing.GetTimeLeft())):N0}";
                     if (GUILayout.Button(new GUIContent($"Warp to{Environment.NewLine}Complete", tooltip)))
                         KCTWarpController.Create(null); // warp to next item
                 }
@@ -217,61 +226,38 @@ namespace RP0
                     KCTWarpController.Instance?.StopWarp();
                     TimeWarp.SetRate(0, true);  // If the controller doesn't exist, stop warp anyway.
                 }
-
-                if (KCTSettings.Instance.AutoAlarms && buildItem.GetTimeLeft() > 30)    //don't check if less than 30 seconds to completion. Might fix errors people are seeing
-                {
-                    double UT = Planetarium.GetUniversalTime();
-                    if (!KCTUtilities.IsApproximatelyEqual(SpaceCenterManagement.Instance.AlarmUT - UT, buildItem.GetTimeLeft()))
-                    {
-                        // old alarm, need to delete to get the new alarm for the new buildItem
-                        SpaceCenterManagement.Instance.AlarmUT = buildItem.GetTimeLeft() + UT;
-                        txt = "RP-1: ";
-                        if (string.IsNullOrEmpty(SpaceCenterManagement.Instance.AlarmId) || (!AlarmHelper.DeleteAlarmWithID(SpaceCenterManagement.Instance.AlarmId) && !AlarmHelper.DeleteAllAlarmsWithTitle(txt, true)))
-                        {
-                            RP0Debug.Log("No old alarm found, new alarm being created!");
-                        }
-                        else
-                        {
-                            RP0Debug.Log("Old alarm deleted, new alarm being created!");
-                        }
-
-                        if (buildItem.GetProjectType() == ProjectType.Reconditioning && buildItem is ReconRolloutProject reconRoll)
-                        {
-                            if (reconRoll.RRType == ReconRolloutProject.RolloutReconType.Reconditioning)
-                            {
-                                txt += $"{reconRoll.launchPadID} Reconditioning";
-                            }
-                            else if (reconRoll.RRType == ReconRolloutProject.RolloutReconType.Rollout)
-                            {
-                                VesselProject associated = reconRoll.LC.Warehouse.FirstOrDefault(vp => vp.shipID == reconRoll.AssociatedIdAsGuid);
-                                txt += $"{associated.shipName} rollout at {reconRoll.launchPadID}";
-                            }
-                            else if (reconRoll.RRType == ReconRolloutProject.RolloutReconType.Rollback)
-                            {
-                                VesselProject associated = reconRoll.LC.Warehouse.FirstOrDefault(vp => vp.shipID == reconRoll.AssociatedIdAsGuid);
-                                txt += $"{associated.shipName} rollback at {reconRoll.launchPadID}";
-                            }
-                            else
-                            {
-                                txt += $"{buildItem.GetItemName()} Complete";
-                            }
-                        }
-                        else
-                        {
-                            txt += $"{buildItem.GetItemName()} Complete";
-                        }
-                        KACWrapper.KACAPI.AlarmTypeEnum alarmType = KACWrapper.KACAPI.AlarmTypeEnum.Raw;
-                        if (buildItem.GetProjectType() == ProjectType.Crew) alarmType = KACWrapper.KACAPI.AlarmTypeEnum.Crew; // TODO, get the specific crew member being trained?
-                        else if (buildItem.GetProjectType() == ProjectType.TechNode) alarmType = KACWrapper.KACAPI.AlarmTypeEnum.ScienceLab;
-                        SpaceCenterManagement.Instance.AlarmId = AlarmHelper.CreateAlarm(txt, "", SpaceCenterManagement.Instance.AlarmUT, alarmType);
-                    }
-                }
             }
             else
             {
                 GUILayout.Label("No Active Projects");
             }
             GUILayout.EndHorizontal();
+            if (KCTSettings.Instance.AutoAlarms && buildItem != null && (buildItem != nextThing || txt != itemText || !AlarmHelper.AlarmExistsTitle(txt, out string _)))
+            {
+                RP0Debug.Log($"Triggering old alarm deletion");
+                // old alarm, need to delete to get the new alarm for the new nextThing
+                string alarmPrefix = "RP-1: ";
+                if (string.IsNullOrEmpty(SpaceCenterManagement.Instance.AlarmId) || (!AlarmHelper.DeleteAlarmWithID(SpaceCenterManagement.Instance.AlarmId) && !AlarmHelper.DeleteAllAlarmsWithTitle(alarmPrefix, true)))
+                {
+                    RP0Debug.Log("No old alarm found, new alarm being created!");
+                }
+                else
+                {
+                    RP0Debug.Log("Old alarm deleted, new alarm being created!");
+                }
+
+                if (nextThing != null)
+                {
+                    RP0Debug.Log($"Triggering new alarm creation");
+                    SpaceCenterManagement.Instance.AlarmUT = nextThing.GetTimeLeft() + Planetarium.GetUniversalTime();
+                    KACWrapper.KACAPI.AlarmTypeEnum alarmType = KACWrapper.KACAPI.AlarmTypeEnum.Raw;
+                    if (nextThing.GetProjectType() == ProjectType.Crew) alarmType = KACWrapper.KACAPI.AlarmTypeEnum.Crew; // TODO, get the specific crew member(s) being trained?
+                    else if (nextThing.GetProjectType() == ProjectType.TechNode) alarmType = KACWrapper.KACAPI.AlarmTypeEnum.ScienceLab;
+                    SpaceCenterManagement.Instance.AlarmId = AlarmHelper.CreateAlarm($"{alarmPrefix}{txt}", "", SpaceCenterManagement.Instance.AlarmUT, alarmType);
+                }
+            }
+            buildItem = nextThing;
+            itemText = txt;
 
             GUILayout.BeginHorizontal();
 

--- a/Source/RP0/UI/KCT/GUI_BuildList.cs
+++ b/Source/RP0/UI/KCT/GUI_BuildList.cs
@@ -131,6 +131,7 @@ namespace RP0
             GUILayout.Label("Next:", _windowSkin.label);
             ISpaceCenterProject nextThing = KCTUtilities.GetNextThingToFinish();
             string txt = "";
+            double timeLeft = nextThing?.GetTimeLeft() ?? 0d;
             if (nextThing != null)
             {
                 txt = nextThing.GetItemName();
@@ -152,14 +153,14 @@ namespace RP0
                                 {
                                     VesselProject associated = reconRoll.LC.Warehouse.FirstOrDefault(vp => vp.shipID == reconRoll.AssociatedIdAsGuid);
                                     txt = $"{associated.shipName} Rollout at {reconRoll.launchPadID}";
-                                    locTxt = reconRoll.launchPadID;
+                                    locTxt = "";
                                     break;
                                 }
                                 case ReconRolloutProject.RolloutReconType.Rollback:
                                 {
                                     VesselProject associated = reconRoll.LC.Warehouse.FirstOrDefault(vp => vp.shipID == reconRoll.AssociatedIdAsGuid);
                                     txt = $"{associated.shipName} Rollback at {reconRoll.launchPadID}";
-                                    locTxt = reconRoll.launchPadID;
+                                    locTxt = "";
                                     break;
                                 }
                                 case ReconRolloutProject.RolloutReconType.Recovery:
@@ -196,7 +197,7 @@ namespace RP0
                     case ProjectType.SPH:
                         if (nextThing is VesselProject vp)
                         {
-                            locTxt = vp == null || vp.LC == null ? "Vessel" : vp.LC.Name;
+                            locTxt = vp.LC == null ? "Vessel" : vp.LC.Name;
                         }
                         break;
                     case ProjectType.TechNode:
@@ -213,11 +214,11 @@ namespace RP0
 
                 GUILayout.Label(txt);
                 GUILayout.Label(locTxt, _windowSkin.label);
-                GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(nextThing.GetTimeLeft(), txt+locTxt+nextThing.GetItemName()));
+                GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(timeLeft, txt+locTxt+nextThing.GetItemName()));
 
                 if (!HighLogic.LoadedSceneIsEditor && TimeWarp.CurrentRateIndex == 0)
                 {
-                    string tooltip = nextThing.GetTimeLeft() > 86400d * 365.25 * 5 ? null : $"√ Gain/Loss:\n{(SpaceCenterManagement.Instance.GetBudgetDelta(nextThing.GetTimeLeft())):N0}";
+                    string tooltip = timeLeft > 86400d * 365.25 * 5 ? null : $"√ Gain/Loss:\n{(SpaceCenterManagement.Instance.GetBudgetDelta(timeLeft)):N0}";
                     if (GUILayout.Button(new GUIContent($"Warp to{Environment.NewLine}Complete", tooltip)))
                         KCTWarpController.Create(null); // warp to next item
                 }
@@ -232,27 +233,36 @@ namespace RP0
                 GUILayout.Label("No Active Projects");
             }
             GUILayout.EndHorizontal();
-            if (KCTSettings.Instance.AutoAlarms && buildItem != null && (buildItem != nextThing || txt != itemText || !AlarmHelper.AlarmExistsTitle(txt, out string _)))
+            double UT = Planetarium.GetUniversalTime();
+            bool staleAlarm = buildItem != nextThing || itemText != txt || (timeLeft > 100 && !KCTUtilities.IsApproximatelyEqual(SpaceCenterManagement.Instance.AlarmUT - UT, timeLeft));
+            // if the timeLeft is less than 100, the difference might be less than a second due to frame times, so we don't care about it
+            if (KCTSettings.Instance.AutoAlarms && buildItem != null && (staleAlarm || !AlarmHelper.AlarmExistsID(SpaceCenterManagement.Instance.AlarmId)))
             {
-                RP0Debug.Log($"Triggering old alarm deletion");
-                string alarmPrefix = "RP-1: ";
-                if (string.IsNullOrEmpty(SpaceCenterManagement.Instance.AlarmId) || (!AlarmHelper.DeleteAlarmWithID(SpaceCenterManagement.Instance.AlarmId) && !AlarmHelper.DeleteAllAlarmsWithTitle(alarmPrefix, true)))
+                SpaceCenterManagement.Instance.AlarmUT = timeLeft + UT;
+                if (nextThing == null)
                 {
-                    RP0Debug.Log("No old alarm found");
+                    if (string.IsNullOrEmpty(SpaceCenterManagement.Instance.AlarmId) || (!AlarmHelper.DeleteAlarmWithID(SpaceCenterManagement.Instance.AlarmId)))
+                    {
+                        RP0Debug.Log("No old alarm found");
+                    }
+                    else
+                    {
+                        RP0Debug.Log("Old alarm deleted");
+                    }
+                    SpaceCenterManagement.Instance.AlarmId = "";
                 }
-                else
+                else if (!AlarmHelper.AlarmExistsID(SpaceCenterManagement.Instance.AlarmId))
                 {
-                    RP0Debug.Log("Old alarm deleted");
-                }
-
-                if (nextThing != null)
-                {
-                    RP0Debug.Log($"Triggering new alarm creation");
-                    SpaceCenterManagement.Instance.AlarmUT = nextThing.GetTimeLeft() + Planetarium.GetUniversalTime();
+                    RP0Debug.Log($"Creating new alarm");
                     KACWrapper.KACAPI.AlarmTypeEnum alarmType = KACWrapper.KACAPI.AlarmTypeEnum.Raw;
                     if (nextThing.GetProjectType() == ProjectType.Crew) alarmType = KACWrapper.KACAPI.AlarmTypeEnum.Crew; // TODO, get the specific crew member(s) being trained?
                     else if (nextThing.GetProjectType() == ProjectType.TechNode) alarmType = KACWrapper.KACAPI.AlarmTypeEnum.ScienceLab;
-                    SpaceCenterManagement.Instance.AlarmId = AlarmHelper.CreateAlarm($"{alarmPrefix}{txt}", "", SpaceCenterManagement.Instance.AlarmUT, alarmType);
+                    SpaceCenterManagement.Instance.AlarmId = AlarmHelper.CreateAlarm($"RP-1: {txt}", "", SpaceCenterManagement.Instance.AlarmUT, alarmType);
+                }
+                else
+                {
+                    RP0Debug.Log($"Changing existing alarm");
+                    AlarmHelper.ChangeAlarm(SpaceCenterManagement.Instance.AlarmId, $"RP-1: {txt}", "", SpaceCenterManagement.Instance.AlarmUT);
                 }
             }
             buildItem = nextThing;


### PR DESCRIPTION
~~This has a soft dependency on https://github.com/linuxgurugamer/KerbalAlarmClock/pull/12.~~

* Resolve https://github.com/KSP-RO/RP-1/issues/2813
* Rework the very weird auto alarm logic to just have a cached ISpaceCenterProject and string for the current build item.
  * Fix excessive delete alarm log spam
* Rename buildItem to nextThing
* Turn the long string of if elses into a switch statement
* When auto-alarms is on, deleting an alarm tied to a build item automatically re-generates it

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/491a5488-8567-4fb9-be3d-4c80c43d8cf3" />
