### PR TITLE
Fix build cost calculation building non-human-rated vessels in HR LCs

### DIFF
--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -58,7 +58,10 @@ namespace RP0
             double rateWithCurEngis = KCTUtilities.GetBuildRate(SpaceCenterManagement.Instance.ActiveSC.ActiveLC, SpaceCenterManagement.Instance.EditorVessel.mass, SpaceCenterManagement.Instance.EditorVessel.buildPoints, SpaceCenterManagement.Instance.EditorVessel.humanRated, 0)
                 * effic
                 * SpaceCenterManagement.Instance.ActiveSC.ActiveLC.StrategyRateMultiplier;
-            int maxEngineers = SpaceCenterManagement.Instance.ActiveSC.ActiveLC.MaxEngineersFor(SpaceCenterManagement.Instance.EditorVessel.mass, SpaceCenterManagement.Instance.EditorVessel.buildPoints, SpaceCenterManagement.Instance.EditorVessel.humanRated);
+            int engineersUsed = Math.Min(
+                SpaceCenterManagement.Instance.ActiveSC.ActiveLC.MaxEngineersFor(SpaceCenterManagement.Instance.EditorVessel.mass, SpaceCenterManagement.Instance.EditorVessel.buildPoints, SpaceCenterManagement.Instance.EditorVessel.humanRated),
+                SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Engineers
+            );
 
             RenderBuildRateInputRow(buildPoints, rateWithCurEngis);
 
@@ -97,7 +100,7 @@ namespace RP0
 
             if (bR > 0d && rateWithCurEngis > 0d)
             {
-                double effectiveEngCount = bR / rateWithCurEngis * maxEngineers;
+                double effectiveEngCount = bR / rateWithCurEngis * engineersUsed;
                 double salaryPerDayAboveIdle = Database.SettingsSC.salaryEngineers * (1d / 365.25d) * (1d - Database.SettingsSC.EngineerIdleSalaryMult);
                 double cost = buildPoints / bR / 86400d * effectiveEngCount * salaryPerDayAboveIdle;
                 GUILayout.Label(new GUIContent($"Net Salary: √{-CurrencyUtils.Funds(TransactionReasonsRP0.SalaryEngineers, -cost):N1}", "The extra salary paid above the idle rate for these engineers"));

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -58,6 +58,7 @@ namespace RP0
             double rateWithCurEngis = KCTUtilities.GetBuildRate(SpaceCenterManagement.Instance.ActiveSC.ActiveLC, SpaceCenterManagement.Instance.EditorVessel.mass, SpaceCenterManagement.Instance.EditorVessel.buildPoints, SpaceCenterManagement.Instance.EditorVessel.humanRated, 0)
                 * effic
                 * SpaceCenterManagement.Instance.ActiveSC.ActiveLC.StrategyRateMultiplier;
+            int maxEngineers = SpaceCenterManagement.Instance.ActiveSC.ActiveLC.MaxEngineersFor(SpaceCenterManagement.Instance.EditorVessel.mass, SpaceCenterManagement.Instance.EditorVessel.buildPoints, SpaceCenterManagement.Instance.EditorVessel.humanRated);
 
             RenderBuildRateInputRow(buildPoints, rateWithCurEngis);
 
@@ -96,7 +97,7 @@ namespace RP0
 
             if (bR > 0d && rateWithCurEngis > 0d)
             {
-                double effectiveEngCount = bR / rateWithCurEngis * SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Engineers;
+                double effectiveEngCount = bR / rateWithCurEngis * maxEngineers;
                 double salaryPerDayAboveIdle = Database.SettingsSC.salaryEngineers * (1d / 365.25d) * (1d - Database.SettingsSC.EngineerIdleSalaryMult);
                 double cost = buildPoints / bR / 86400d * effectiveEngCount * salaryPerDayAboveIdle;
                 GUILayout.Label(new GUIContent($"Net Salary: √{-CurrencyUtils.Funds(TransactionReasonsRP0.SalaryEngineers, -cost):N1}", "The extra salary paid above the idle rate for these engineers"));


### PR DESCRIPTION
`effectiveEngCount` doesn't actually account for the fact that non-human-rated vessels may not be able to use all the engineers at a human-rated LC. (`bR / rateWithCurEngis` is more or less one--it seems to be just the ratio between the build rate and the build rate after being round-tripped through a string.)

Testing:
- Verified that the net salary estimate of a non-human-rated vessel was the same in a human-rated and non-human-rated LC (aside from a small difference from efficiency)
- Verified that the net salary estimate did not vary with the number of assigned engineers in both human-rated and non-human-rated LCs