### PR TITLE
Reduce X-Planes funding

### DIFF
--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -6,7 +6,7 @@ RP0_PROGRAM
 	description = This program tasks the space agency with the development of experimental aircraft to test aerodynamic behavior at velocities and altitudes previously unreachable by crewed craft.
 	objectivesPrettyText = Complete X-Planes (Mach 2 Supersonic) and X-Planes (Karman Line) contracts.
 	nominalDurationYears = 9
-	baseFunding = 800000
+	baseFunding = 700000
 	fundingCurve = BimodalBackloaded
 	repDeltaOnCompletePerYearEarly = 130
 	repPenaltyPerYearLate = 130


### PR DESCRIPTION
I believe that X-Planes should have rough financial parity with the sounding rocket starts, accounting for its increased costs (both hiring astronauts earlier than otherwise needed and researching nodes that have little other benefit). It's clear that the current funding is generous for that aim--even for people who do fly in the first year, X-Planes provides enough extra funding to meaningfully accelerate the sounding rocket programs, and pulling early sats funding forward more than compensates for any later trouble.

Looking back at my original program cost estimates I do not seem to have accounted for research efficiency, increasing the number of researchers required and increasing overall personnel costs by about 100k. I thus think that makes a reasonable starting point for funding reduction. If anything I expect it's still possibly generous to X-Planes--it doesn't account for Flight Director bonuses, and since those aren't available to no-planes runs until crewed orbit research there isn't much opportunity cost. It also doesn't account for the fact that X-Planes offers extra research no-planes runs can't do, permanently increasing the research bonus, and that they generally provide more reputation than Suborbital Research.