### PR TITLE
Add Crewed Asteroid Exploration Program

### DIFF
--- a/GameData/RP-1/Contracts/Asteroid Crewed/CrewedCeresLanding.cfg
+++ b/GameData/RP-1/Contracts/Asteroid Crewed/CrewedCeresLanding.cfg
@@ -1,0 +1,103 @@
+CONTRACT_TYPE
+{
+	name = CrewedCeresLanding
+	title = First Crewed Ceres Landing
+	group = CrewedAsteroid
+	agent = Flag Planting
+
+	description = <b>Program: Crewed Asteroid Exploration<br>Type: <color=red>Capstone</color></b><br><br>
+
+	synopsis = Send a crew of 2 to land on the surface of Ceres and return home safely
+
+	completedMessage = Congratulations! Human beings have set foot on a dwarf planet in our Solar System. The monumental task that you have accomplished is something to be proud of!
+
+	sortKey = 2000
+
+	cancellable = true
+	declinable = false
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 0
+
+	targetBody = Ceres
+
+	prestige = Exceptional
+	advanceFunds = 0
+	rewardScience = 0
+	rewardReputation = 4000
+	rewardFunds = 0
+	failureReputation = 0
+	failureFunds = 0
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = CrewedAsteroid
+	}
+
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = First Crewed Ceres Landing
+		define = CrewedCeresLanding
+
+		PARAMETER
+		{
+			name = TwoCrew
+			type = HasCrew
+			minCrew = 2
+			maxCrew = 99
+			title = Have at least 2 crewmembers on board
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = LandCrewed
+			type = All
+			title = Land the crewed lander
+			disableOnStateChange = true
+
+			PARAMETER
+			{
+				name = TwoCrew
+				type = HasCrew
+				minCrew = 2
+				maxCrew = 99
+				title = Have at least 2 crewmembers on board
+				hideChildren = true
+			}
+			PARAMETER
+			{
+				name = ReachState
+				type = ReachState
+				targetBody = Ceres
+				situation = LANDED
+				PARAMETER
+				{
+					name = Duration
+					type = Duration
+					duration = 30d
+					preWaitText = Land on Ceres.
+					waitingText = Exploring...
+					completionText = Exploration completed, you may return to Earth when ready.
+				}
+			}
+		}
+		PARAMETER
+		{
+			name = PlantFlagOnMars
+			type = PlantFlag
+			targetBody = Ceres
+			title = Plant a flag on Ceres! Don't forget the picture
+			hideChildren = true
+			disableOnStateChange = true
+		}
+	}
+}

--- a/GameData/RP-1/Contracts/Asteroid Crewed/CrewedCeresLanding.cfg
+++ b/GameData/RP-1/Contracts/Asteroid Crewed/CrewedCeresLanding.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = CrewedAsteroid
 	agent = Flag Planting
 
-	description = <b>Program: Crewed Asteroid Exploration<br>Type: <color=red>Capstone</color></b><br><br>
+	description = <b>Program: Crewed Asteroid Exploration<br>Type: <color=red>Capstone</color></b><br><br>It is time for our astronauts to venture out into the space past Mars and explore the dwarf planet Ceres - this dwarf planet could serve as a vital refueling link in the future or even house permanent bases due to the massive amount of ice. 
 
 	synopsis = Send a crew of 2 to land on the surface of Ceres and return home safely
 

--- a/GameData/RP-1/Contracts/Asteroid Crewed/CrewedVestaLanding.cfg
+++ b/GameData/RP-1/Contracts/Asteroid Crewed/CrewedVestaLanding.cfg
@@ -1,0 +1,103 @@
+CONTRACT_TYPE
+{
+	name = CrewedVestaLanding
+	title = First Crewed Vesta Landing
+	group = CrewedAsteroid
+	agent = Flag Planting
+
+	description = <b>Program: Crewed Asteroid Exploration<br>Type: <color=red>Capstone</color></b><br><br>
+
+	synopsis = Send a crew of 2 to land on the surface of Vesta and return home safely
+
+	completedMessage = Congratulations! Human beings have set foot on a dwarf planet in our Solar System. The monumental task that you have accomplished is something to be proud of!
+
+	sortKey = 2001
+
+	cancellable = true
+	declinable = false
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 0
+
+	targetBody = Vesta
+
+	prestige = Exceptional
+	advanceFunds = 0
+	rewardScience = 0
+	rewardReputation = 4000
+	rewardFunds = 0
+	failureReputation = 0
+	failureFunds = 0
+
+	// ************ REQUIREMENTS ************
+
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = CrewedAsteroid
+	}
+
+	PARAMETER
+	{
+		name = vesselGroup
+		type = VesselParameterGroup
+		title = First Crewed Vesta Landing
+		define = CrewedVestaLanding
+
+		PARAMETER
+		{
+			name = TwoCrew
+			type = HasCrew
+			minCrew = 2
+			maxCrew = 99
+			title = Have at least 2 crewmembers on board
+			hideChildren = true
+		}
+		PARAMETER
+		{
+			name = LandCrewed
+			type = All
+			title = Land the crewed lander
+			disableOnStateChange = true
+
+			PARAMETER
+			{
+				name = TwoCrew
+				type = HasCrew
+				minCrew = 2
+				maxCrew = 99
+				title = Have at least 2 crewmembers on board
+				hideChildren = true
+			}
+			PARAMETER
+			{
+				name = ReachState
+				type = ReachState
+				targetBody = Vesta
+				situation = LANDED
+				PARAMETER
+				{
+					name = Duration
+					type = Duration
+					duration = 30d
+					preWaitText = Land on Vesta.
+					waitingText = Exploring...
+					completionText = Exploration completed, you may return to Earth when ready.
+				}
+			}
+		}
+		PARAMETER
+		{
+			name = PlantFlagOnMars
+			type = PlantFlag
+			targetBody = Vesta
+			title = Plant a flag on Vesta! Don't forget the picture
+			hideChildren = true
+			disableOnStateChange = true
+		}
+	}
+}

--- a/GameData/RP-1/Contracts/Asteroid Crewed/CrewedVestaLanding.cfg
+++ b/GameData/RP-1/Contracts/Asteroid Crewed/CrewedVestaLanding.cfg
@@ -5,7 +5,7 @@ CONTRACT_TYPE
 	group = CrewedAsteroid
 	agent = Flag Planting
 
-	description = <b>Program: Crewed Asteroid Exploration<br>Type: <color=red>Capstone</color></b><br><br>
+	description = <b>Program: Crewed Asteroid Exploration<br>Type: <color=red>Capstone</color></b><br><br>Vesta is of immense interest to us due to its rich geological profile. Near undisturbed for over 4.5 billion years, it is a perfect place for astronauts to conduct geological experiments and, in the far future, could be used as a forge for further exploration of the Solar System.
 
 	synopsis = Send a crew of 2 to land on the surface of Vesta and return home safely
 

--- a/GameData/RP-1/Contracts/Groups.cfg
+++ b/GameData/RP-1/Contracts/Groups.cfg
@@ -287,12 +287,21 @@ CONTRACT_GROUP
 		sortKey = 43
 		agent = Exploration
 	}
+	
+	CONTRACT_GROUP
+	{
+		name = CrewedAsteroid
+		displayName = Crewed Asteroid Exploration
+		minVersion = 1.12.2
+		sortKey = 44
+		agent = Exploration
+	}
 	CONTRACT_GROUP
 	{
 		name = CrewedExploration
 		displayName = Crewed Solar System Exploration
 		minVersion = 1.12.2
-		sortKey = 44
+		sortKey = 45
 		agent = Exploration
 	}
 	CONTRACT_GROUP
@@ -300,7 +309,7 @@ CONTRACT_GROUP
 		name = Records
 		displayName = Records
 		minVersion = 1.12.2
-		sortKey = 45
+		sortKey = 46
 		agent = Federation Aeronautique Internationale
 	}
 	CONTRACT_GROUP
@@ -308,7 +317,7 @@ CONTRACT_GROUP
 		name = HumanRecords
 		displayName = Human Records
 		minVersion = 1.12.2
-		sortKey = 46
+		sortKey = 47
 		agent = Federation Aeronautique Internationale
 	}
 

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -1152,8 +1152,8 @@ RP0_PROGRAM
 	description = The time has come to send crew to explore regions of the Solar System previously only visited by probes. Ceres is the most water rich object in the System after Earth, which makes it a prime target for astrobiology. Having trained astronauts visit it will be of incredible scientific value! Vesta's geological make-up is unique, making it a great place for Solar System archeology. 
 	requirementsPrettyText = Complete Crewed Lunar Exploration and Asteroid Exploration
 	objectivesPrettyText = Complete either Crewed Vesta Landing or Crewed Ceres Landing
-	nominalDurationYears = 20
-	baseFunding = 35000000
+	nominalDurationYears = 25
+	baseFunding = 80000000
 	repDeltaOnCompletePerYearEarly = 565
 	repPenaltyPerYearLate = 565
 	repToConfidence = 3

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -1157,7 +1157,7 @@ RP0_PROGRAM
 	repDeltaOnCompletePerYearEarly = 565
 	repPenaltyPerYearLate = 565
 	repToConfidence = 3
-	slots = 4
+	slots = 6
 
 	REQUIREMENTS
 	{

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -1153,7 +1153,7 @@ RP0_PROGRAM
 	requirementsPrettyText = Complete Crewed Lunar Exploration and Asteroid Exploration
 	objectivesPrettyText = Complete either Crewed Vesta Landing or Crewed Ceres Landing
 	nominalDurationYears = 20
-	baseFunding = 25000000
+	baseFunding = 35000000
 	repDeltaOnCompletePerYearEarly = 565
 	repPenaltyPerYearLate = 565
 	repToConfidence = 3

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -1149,7 +1149,7 @@ RP0_PROGRAM
 {
 	name = CrewedAsteroid
 	title = Crewed Asteroid Exploration
-	description = The time has come to send crew to explore regions of the Solar System previously only visited by probes. TODO: Add more
+	description = The time has come to send crew to explore regions of the Solar System previously only visited by probes. Ceres is the most water rich object in the System after Earth, which makes it a prime target for astrobiology. Having trained astronauts visit it will be of incredible scientific value! Vesta's geological make-up is unique, making it a great place for Solar System archeology. 
 	requirementsPrettyText = Complete Crewed Lunar Exploration and Asteroid Exploration
 	objectivesPrettyText = Complete either Crewed Vesta Landing or Crewed Ceres Landing
 	nominalDurationYears = 20

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -1147,6 +1147,49 @@ RP0_PROGRAM
 
 RP0_PROGRAM
 {
+	name = CrewedAsteroid
+	title = Crewed Asteroid Exploration
+	description = The time has come to send crew to explore regions of the Solar System previously only visited by probes. TODO: Add more
+	requirementsPrettyText = Complete Crewed Lunar Exploration and Asteroid Exploration
+	objectivesPrettyText = Complete either Crewed Vesta Landing or Crewed Ceres Landing
+	nominalDurationYears = 20
+	baseFunding = 25000000
+	repDeltaOnCompletePerYearEarly = 565
+	repPenaltyPerYearLate = 565
+	repToConfidence = 3
+	slots = 4
+
+	REQUIREMENTS
+	{
+		complete_program = AsteroidExploration
+		complete_program = CrewedLunar
+	}
+
+	OBJECTIVES
+	{
+		ANY
+		{
+			complete_contract = CrewedCeresLanding
+			complete_contract = CrewedVestaLanding
+		}
+	}
+	
+	CONFIDENCECOSTS
+	{
+		Normal = 4000
+		Fast = 8000
+	}
+	
+	OPTIONALS
+	{
+		CrewedCeresLanding_Rep = True
+		CrewedVestaLanding_Rep = True
+	}
+}
+
+
+RP0_PROGRAM
+{
 	name = JupiterObservation
 	title = Jupiter Observation
 	description = Jupiter presents many opportunities for exploration, but also many challenges: it requires almost the same amount of energy for a spacecraft to reach Jupiter from Earth's orbit as it does to lift it into orbit in the first place. Gravity assists can be used to save delta-v at the cost of flight duration. Once there, a rich and diverse system awaits any explorer. Along with the largest planet in the Solar System, the Jovian system is also home to the largest moon, Ganymede, a planetary-mass moon. This program will send uncrewed scientific probes to Jupiter and its moons.<br><br>Historically, Jupiter is the most-visited outer planet, with 9 missions having completed flybys or entered orbits, most notably by the Voyager missions in 1979 on their flybys towards the outer Solar System, and by the Juno orbiter whose mission continues today. Most recently, NASA's Europa Clipper mission departed in 2024 enroute to the Galilean moons. 


### PR DESCRIPTION
Based on proposals to visit NEO and [others](https://www.universetoday.com/articles/a-novel-concept-for-a-multiplanetary-crewed-mission-to-mars-and-ceres), before the player sends crew out to the Gas Giants, Ceres & Vesta pose an interesting alternative destination that is a bit more feasible. This also builds on CXG's [Asteroid Exploration overhaul](https://github.com/KSP-RO/RP-1/pull/2710), which already calls for the player to land probes on both.

The program currently calls for the player to land on either Ceres or Vesta. The funding per year per slot is between Crewed Lunar (220k, ish) and Crewed Mars (370k) at 230k - depending on how complicated such a mission architecture is, this is subject to change.

Based on preliminary maths, these missions should take ~1800 days, which is - as far as I understand it - a bit outside of the realm of possibility of stress management. With some more additions to ROKerbalism, this should not be a major challenge, though. Due to the fact that I cannot guarantee the feasability of such a mission in the present RO/RP-1 suite, I am leaving this as a draft for now. 

