### PR TITLE
Add Small Asteroids Exploration

### DIFF
--- a/GameData/RP-1/Contracts/Groups.cfg
+++ b/GameData/RP-1/Contracts/Groups.cfg
@@ -311,7 +311,14 @@ CONTRACT_GROUP
 		sortKey = 46
 		agent = Federation Aeronautique Internationale
 	}
-
+	CONTRACT_GROUP
+	{
+		name = SmallAsteroidExp
+		displayName = Small Asteroid Exploration
+		minVersion = 1.12.2
+		sortKey = 47
+		agent = Surveys
+	}
 	DATA
 	{
 		title = Modifiers for contracts

--- a/GameData/RP-1/Contracts/Small Asteroid Exploration/Asteroid_Intercept.cfg
+++ b/GameData/RP-1/Contracts/Small Asteroid Exploration/Asteroid_Intercept.cfg
@@ -1,0 +1,108 @@
+CONTRACT_TYPE
+{
+	name = AsteroidIntercept
+	title = Asteroid Intercept
+	group = SmallAsteroidExp
+	agent = Flag Planting
+	
+	description = <b>Program: Small Asteroid Exploration</b><br>Intercept an asteroid and Grab onto it and transmit back science!
+	
+	synopsis = Build and launch a mission to send a mission to intercept and grab onto an asteroid.
+	
+	completedMessage = Success!
+	
+	sortKey = 1400
+	
+	cancellable = true
+	declinable = false
+	autoAccept = false
+	minExpiry = 0
+	maxExpiry = 0
+	maxCompletions = 1
+	maxSimultaneous = 1
+	deadline = 0
+	
+	targetBody = Sun
+	
+	//Rewards
+	prestige = Significant       // 1.0x
+	advanceFunds = 0
+	rewardScience = 0
+	rewardFunds = 0
+	failureFunds = 0
+	rewardReputation = 1000
+	failureReputation = 0
+	
+	//Requirements
+	
+	REQUIREMENT
+	{
+		name = ProgramActive
+		type = ProgramActive
+		program = SmallAsteroidExp
+	}
+	
+	//Checking for Uncrewed Grabbing Craft
+	PARAMETER
+	{
+		name = CheckProbe
+		type = VesselParameterGroup
+		title = Asteroid Intercept Probe
+		define = AsteroidTug
+		
+		PARAMETER
+		{
+			name = NewVessel
+			title = Launch a new Vessel
+			type = NewVessel
+			hideChildren = true
+		}
+		
+		PARAMETER 
+		{
+			name = Crewmembers
+			type = HasCrew
+			minCrew = 0
+			maxCrew = 0
+			title = Uncrewed
+			hideChildren = true
+		}
+		
+		PARAMETER
+		{
+			name = HasKlaw
+			type = PartValidation
+			part = GrapplingDevice
+			title = Vessel must have the Advanced Grabbing Unit
+			hideChildren = true
+		}
+	}
+	
+	//Checking for Asteroid Grapple
+	PARAMETER
+	{
+		name = AsteroidGrapple
+		type = VesselParameterGroup
+		vessel = AsteroidTug
+		title = Intercept and Grapple onto the Asteroid
+		
+		PARAMETER
+		{
+			name = GrappleAsteroid
+			type = Docking
+			targetType = Asteroid
+			minClass = A
+			title = Secure a Gapple Connection to an Asteroid
+		}
+		
+		PARAMETER
+		{
+			name = Duration
+			type = Duration
+			duration = 2m
+			preWaitText = Adjust for stability
+			waitingText = Adjusting for stability
+			completionText = Stability: Confirmed!
+		}
+	}
+}

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -1783,6 +1783,51 @@ disabled_RP0_PROGRAM
 	}
 }
 
+RP0_PROGRAM
+{
+	name = SmallAsteroidExp
+	isHSF = true
+	title = Small Asteroid Exploration
+	description = Observe and track asteroids with scientific potential that justify sending a robotic mission to! 
+	requirementsPrettyText = Complete contracts X and Y
+	objectivesPrettyText = Do this and that
+	nominalDurationYears = 15
+	baseFunding = 11000000
+	repDeltaOnCompletePerYearEarly = 300
+	repPenaltyPerYearLate = 300
+	repToConfidence = 3
+	slots = 4
+
+	REQUIREMENTS
+	{
+		complete_program = SmallBodiesFlyby
+		
+		FACILITY_LEVEL
+		{
+			facility = TrackingStation
+			level = 6
+		}
+	}
+
+	OBJECTIVES
+	{
+		complete_contract = AsteroidIntercept
+		complete_cotract = AsteroidSampleReturn
+	}
+	
+	CONFIDENCECOSTS
+	{
+		Normal = 2600
+		Fast = 5000
+	}
+	
+	Optionals
+	{
+		AsteroidFlyby = True
+		AsteroidRedirect = True
+	}
+}
+
 //************************************Deprecated************************************
 
 RP0_PROGRAM


### PR DESCRIPTION
This program is intended to send missions to the spawnable asteroids that you can track. 

Still highly a wip for me right now as i need to make the rest of the contracts such as sample return and impactor.

Contract layout will be intercept/grapple, then sample return.

Currently there is not RO/RP1 support for the Sentinel telescope part, but would like to know if its worthwhile to do so to create a contract specifically for that part as a telescope probe to supplement the program.

Funding is similar to the inner planets surface exploration at the moment and took an extra slot due to added complexity since it requires a sample return although I might just be overthinking it.

I am aware of how buggy asteroids are with the scaling and mess colliders not lining up I would love to hear what a solution could be. 