### PR TITLE
Add Commercial Constellation Programs

### DIFF
--- a/GameData/RP-1/Contracts/Commercial Constellations/cc1_geo.cfg
+++ b/GameData/RP-1/Contracts/Commercial Constellations/cc1_geo.cfg
@@ -1,0 +1,177 @@
+CONTRACT_TYPE
+{
+    name = cc1_geo
+    title = Commercial GEO Constellation (Slot @index / 12)
+    group = CommConst
+    description = <b>Program: Commercial Constellations 1<br>Type: <color=green>Required</color></b><br><br>A commercial telecommunications company requires a progressive rollout of a 12-satellite geostationary network. Deploy a satellite to the specified longitudinal slot. The customer will handle fine-tuning.<br><br><b><color=yellow>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color>
+    genericDescription = Deploy a commercial satellite into a specific Geostationary orbital slot.
+    synopsis = Launch a payload into the targeted GEO slot.
+    completedMessage = Payload control transferred to the customer.
+
+    sortKey = 912
+
+    cancellable = true
+    declinable = true
+    autoAccept = false
+    minExpiry = 0
+    maxExpiry = 0
+    maxCompletions = 12
+    maxSimultaneous = 1
+    targetBody = HomeWorld()
+
+    // ************ REWARDS ************
+    prestige = Significant
+    advanceFunds = 0
+    rewardScience = 0
+    rewardFunds = 0
+    failureFunds = 0
+    rewardReputation = 600
+    failureReputation = 0
+
+    // ************ REQUIREMENTS ************
+    REQUIREMENT
+    {
+        name = ProgramActive
+        type = ProgramActive
+        program = CommercialConstellation1 
+    }
+
+    // ************ DATA & LOGIC ************
+    DATA
+    {
+        type = int
+        index = $cc1_geo_Count + 0
+    }
+
+    DATA
+    {
+        type = double
+        // 360 degrees / 12 completions = 30 degrees of separation per slot
+        targetLon = @index * 30.0
+    }
+
+    BEHAVIOUR
+    {
+        name = IncrementTheCount
+        type = Expression
+
+        CONTRACT_COMPLETED_SUCCESS
+        {
+            cc1_geo_Count = $cc1_geo_Count + 1
+        }
+    }
+
+    BEHAVIOUR
+    {
+        name = WaypointGenerator
+        type = WaypointGenerator
+
+        WAYPOINT
+        {
+            name = GEO Slot @/index
+            icon = thermometer
+            altitude = 0
+            latitude = 0
+            longitude = @/targetLon
+        }
+    }
+
+    // ************ PARAMETERS ************
+    PARAMETER
+    {
+        name = GEOCommSat
+        type = VesselParameterGroup
+        title = Constellation Satellite
+        define = GEO_Slot_@/index 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        
+        PARAMETER
+        {
+            name = Crewmembers
+            type = HasCrew
+            minCrew = 0
+            maxCrew = 0
+            title = Uncrewed
+            hideChildren = true
+        }
+
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 124.9
+            disableOnStateChange = false
+            title = Carry at least 125 units of ComSatPayload
+        }
+
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            
+            minPeriod = 23h 54m
+            maxPeriod = 23h 58m
+            maxInclination = 2.0
+            maxEccentricity = 0.01
+            
+            title = Achieve a Geostationary orbit near the waypoint slot (Lon: @/targetLon°)
+            
+            PARAMETER
+            {
+                name = VisitWaypoint
+                type = VisitWaypoint
+                index = 0
+                horizontalDistance = 4000.0
+                showMessages = false
+                disableOnStateChange = false
+            }
+
+            PARAMETER
+            {
+                name = Duration
+                type = Duration
+                duration = 2m
+                preWaitText = Check for stable orbit slot
+                waitingText = Checking for stable orbit
+                completionText = Stable orbit: Confirmed
+            }
+        }
+    }
+
+    // ************ BEHAVIOURS ************
+    BEHAVIOUR
+    {
+        name = TransferVessel
+        type = DestroyVessel
+        onState = CONTRACT_SUCCESS
+        vessel = GEO_Slot_@/index
+    }
+
+    BEHAVIOUR
+    {
+        name = VesselDestroyed
+        type = DialogBox
+        DIALOG_BOX
+        {
+            title = Vessel Ownership Transferred
+            condition = CONTRACT_SUCCESS
+            position = CENTER
+            width = 0.5
+            TEXT
+            {
+                text = Deployment successful. The satellite in this slot has been transferred to the customer.
+            }
+        }
+    }
+}

--- a/GameData/RP-1/Contracts/Commercial Constellations/cc1_molniya.cfg
+++ b/GameData/RP-1/Contracts/Commercial Constellations/cc1_molniya.cfg
@@ -1,0 +1,319 @@
+CONTRACT_TYPE
+{
+    name = cc1_molniya
+    title = Commercial Molniya Constellation (Plane @index / 4)
+    group = CommConst
+
+    description = <b>Program: Commercial Constellations 1<br>Type: <color=green>Required</color></b><br><br>A commercial telecommunications company requires a batch of satellites deployed into a Molniya orbit to provide high-latitude coverage. Deploy the batch into the specified orbital plane.The customer will handle fine-tuning.<br><br><b><color=yellow>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color><br><br><b><color=yellow>NOTE: Your orbit should have high eccentricity, an inclination of around 63 degrees, with your periapsis on the same or opposite longitude as the target (@/targetLon) in the opposite North/South hemisphere.</color><br><br><b><color=yellow>NOTE: If you are completing this with a single launch, you must separate the 3 vessels while in an orbit with a period of less than 6 hours or the payload requirement will not complete. This is to ensure spacing of the network.</color>
+    genericDescription = Deploy a batch of 3 commercial satellites into a specific Molniya orbital plane.
+    synopsis = Launch 3 payloads into the targeted Molniya orbital plane.
+    completedMessage = Payload control transferred to the customer.
+
+    sortKey = 911
+
+    cancellable = true
+    declinable = true
+    autoAccept = false
+    minExpiry = 0
+    maxExpiry = 0
+    maxCompletions = 4
+    maxSimultaneous = 1
+    targetBody = HomeWorld()
+
+    // ************ REWARDS ************
+    prestige = Significant
+    advanceFunds = 0
+    rewardScience = 0
+    rewardFunds = 0 
+    failureFunds = 0
+    rewardReputation = 450
+    failureReputation = 0
+
+    // ************ REQUIREMENTS ************
+    REQUIREMENT
+    {
+        name = ProgramActive
+        type = ProgramActive
+        program = CommercialConstellation1 
+    }
+
+    // ************ DATA & LOGIC ************
+    DATA
+    {
+        type = int
+        index = $cc1_molniya_Count + 0
+    }
+
+    DATA
+    {
+        type = double
+        // 4 planes spaced evenly
+        targetLAN = @index * 90.0
+    }
+
+    BEHAVIOUR
+    {
+        name = IncrementTheCount
+        type = Expression
+
+        CONTRACT_COMPLETED_SUCCESS
+        {
+            cc1_molniya_Count = $cc1_molniya_Count + 1
+        }
+    }
+
+    // ************ PARAMETERS ************
+    
+    // SATELLITE 1
+    PARAMETER
+    {
+        name = Sat1
+        type = VesselParameterGroup
+        title = Constellation Satellite 1
+        define = Molniya_Plane_@/index_Sat1 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 299.9
+            disableOnStateChange = false
+            title = Carry at least 300 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = ReachOrbit
+            type = Orbit
+            title = Separate vessels while in an intermediate orbit.
+            minPeriod = 1h
+            maxPeriod = 6h
+            completeInSequence = true
+            disableOnStateChange = true
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeriod = 11h 50m
+            maxPeriod = 12h 5m
+            minInclination = 62.5
+            maxInclination = 63.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            minArgumentOfPeriapsis = 268.0
+            maxArgumentOfPeriapsis = 272.0
+            title = Reach target plane
+        }
+        PARAMETER
+        {
+            name = Duration
+            type = Duration
+            duration = 6h
+            preWaitText = Achieve final orbit
+            waitingText = Checking orbit stability
+            completionText = Stable Orbit: Confirmed
+        }
+    }
+
+    // SATELLITE 2
+    PARAMETER
+    {
+        name = Sat2
+        type = VesselParameterGroup
+        title = Constellation Satellite 2
+        define = Molniya_Plane_@/index_Sat2 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 299.9
+            disableOnStateChange = false
+            title = Carry at least 300 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = ReachOrbit
+            type = Orbit
+            title = Separate vessels while in an intermediate orbit.
+            minPeriod = 1h
+            maxPeriod = 6h
+            completeInSequence = true
+            disableOnStateChange = true
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeriod = 11h 50m
+            maxPeriod = 12h 5m
+            minInclination = 62.5
+            maxInclination = 63.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            minArgumentOfPeriapsis = 268.0
+            maxArgumentOfPeriapsis = 272.0
+            
+            title = Reach target plane
+        }
+        PARAMETER
+        {
+            name = Duration
+            type = Duration
+            duration = 6h
+            preWaitText = Achieve final orbit
+            waitingText = Checking orbit stability
+            completionText = Stable Orbit: Confirmed
+        }
+    }
+
+    // SATELLITE 3
+    PARAMETER
+    {
+        name = Sat3
+        type = VesselParameterGroup
+        title = Constellation Satellite 3
+        define = Molniya_Plane_@/index_Sat3 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 299.9
+            disableOnStateChange = false
+            title = Carry at least 300 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = ReachOrbit
+            type = Orbit
+            title = Separate vessels while in an intermediate orbit.
+            minPeriod = 1h
+            maxPeriod = 6h
+            completeInSequence = true
+            disableOnStateChange = true
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            
+            minPeriod = 11h 50m
+            maxPeriod = 12h 5m
+            minInclination = 62.5
+            maxInclination = 63.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            minArgumentOfPeriapsis = 268.0
+            maxArgumentOfPeriapsis = 272.0
+            
+            title = Reach target plane
+        }
+        PARAMETER
+        {
+            name = Duration
+            type = Duration
+            duration = 6h
+            preWaitText = Achieve final orbit
+            waitingText = Checking orbit stability
+            completionText = Stable Orbit: Confirmed
+        }
+    }
+
+    // ************ BEHAVIOURS ************
+    BEHAVIOUR
+    {
+        name = TransferVessel
+        type = DestroyVessel
+        onState = CONTRACT_SUCCESS
+        vessel = Molniya_Plane_@/index_Sat1
+        vessel = Molniya_Plane_@/index_Sat2
+        vessel = Molniya_Plane_@/index_Sat3
+    }
+
+    BEHAVIOUR
+    {
+        name = VesselDestroyed
+        type = DialogBox
+        DIALOG_BOX
+        {
+            title = Vessel Ownership Transferred
+            condition = CONTRACT_SUCCESS
+            position = CENTER
+            width = 0.5
+            TEXT
+            {
+                text = Deployment successful. The batch in this plane has been transferred to the customer.
+            }
+        }
+    }
+}

--- a/GameData/RP-1/Contracts/Commercial Constellations/cc1_walker.cfg
+++ b/GameData/RP-1/Contracts/Commercial Constellations/cc1_walker.cfg
@@ -1,0 +1,255 @@
+CONTRACT_TYPE
+{
+    name = cc1_leo
+    title = Commercial Walker Constellation (Plane @index / 10)
+    group = CommConst
+
+    description = <b>Program: Commercial Constellations 1<br>Type: <color=green>Required</color></b><br><br>A commercial telecommunications company has approached us to launch their satellites into a specific orbital plane to build up their constellation. We just need to launch the satellites into the plane, the customer will fine-tune their positions themselves.<br><br><b><color=yellow>NOTE: The satellites will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color>
+    genericDescription = Deploy a batch of 3 commercial satellites into a specific LEO orbital plane.
+    synopsis = Launch 3 payloads into the targeted orbital plane.
+    completedMessage = Payload control transferred to the customer.
+
+    sortKey = 910
+
+    cancellable = true
+    declinable = true
+    autoAccept = false
+    minExpiry = 0
+    maxExpiry = 0
+    maxCompletions = 10
+    maxSimultaneous = 1
+    targetBody = HomeWorld()
+
+    // ************ REWARDS ************
+    prestige = Significant
+    advanceFunds = 0
+    rewardScience = 0
+    rewardFunds = 0 
+    failureFunds = 0
+    rewardReputation = 250
+    failureReputation = 0
+
+    // ************ REQUIREMENTS ************
+    REQUIREMENT
+    {
+        name = ProgramActive
+        type = ProgramActive
+        program = CommercialConstellation1 
+    }
+
+    // ************ DATA & LOGIC ************
+    DATA
+    {
+        type = int
+        index = $cc1_leo_Count + 0
+    }
+
+    DATA
+    {
+        type = double
+        targetLAN = @index * 36.0
+    }
+
+    BEHAVIOUR
+    {
+        name = IncrementTheCount
+        type = Expression
+
+        CONTRACT_COMPLETED_SUCCESS
+        {
+            cc1_leo_Count = $cc1_leo_Count + 1
+        }
+    }
+
+    // ************ PARAMETERS ************
+    
+    // SATELLITE 1
+    PARAMETER
+    {
+        name = Sat1
+        type = VesselParameterGroup
+        title = Constellation Satellite 1
+        define = LEO_Plane_@/index_Sat1 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = LEO_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = LEO_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 41.9
+            disableOnStateChange = false
+            title = Carry at least 42 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+            title = Reach target plane
+        }
+    }
+
+    // SATELLITE 2
+    PARAMETER
+    {
+        name = Sat2
+        type = VesselParameterGroup
+        title = Constellation Satellite 2
+        define = LEO_Plane_@/index_Sat2 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = LEO_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = LEO_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 41.9
+            disableOnStateChange = false
+            title = Carry at least 42 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+            title = Reach target plane
+        }
+    }
+
+    // SATELLITE 3
+    PARAMETER
+    {
+        name = Sat3
+        type = VesselParameterGroup
+        title = Constellation Satellite 3
+        define = LEO_Plane_@/index_Sat3 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = LEO_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = LEO_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 41.9
+            disableOnStateChange = false
+            title = Carry at least 42 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+            title = Reach target plane
+        }
+    }
+
+    // ************ BEHAVIOURS ************
+    BEHAVIOUR
+    {
+        name = TransferVessel
+        type = DestroyVessel
+        onState = CONTRACT_SUCCESS
+        vessel = LEO_Plane_@/index_Sat1
+        vessel = LEO_Plane_@/index_Sat2
+        vessel = LEO_Plane_@/index_Sat3
+    }
+
+    BEHAVIOUR
+    {
+        name = VesselDestroyed
+        type = DialogBox
+        DIALOG_BOX
+        {
+            title = Vessel Ownership Transferred
+            condition = CONTRACT_SUCCESS
+            position = CENTER
+            width = 0.5
+            TEXT
+            {
+                text = Deployment successful. The constellation batch in this plane has been transferred to the customer.
+            }
+        }
+    }
+}

--- a/GameData/RP-1/Contracts/Commercial Constellations/cc2_geo.cfg
+++ b/GameData/RP-1/Contracts/Commercial Constellations/cc2_geo.cfg
@@ -1,0 +1,172 @@
+CONTRACT_TYPE
+{
+    name = cc2_geo
+    title = Advanced Commercial GEO Constellation (Slot @index / 18)
+    group = CommConst
+
+    description = <b>Program: Commercial Constellations 2<br>Type: <color=green>Required</color></b><br><br>A commercial telecommunications company requires an expanded rollout of an 18-satellite high-capacity geostationary network. Deploy a satellite to the specified longitudinal slot. The customer will handle fine-tuning.<br><br><b><color=yellow>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color>
+    genericDescription = Deploy a high-capacity commercial satellite into a specific Geostationary orbital slot.
+    synopsis = Launch a payload into the targeted GEO slot.
+    completedMessage = Payload control transferred to the customer.
+
+    sortKey = 922
+
+    cancellable = true
+    declinable = true
+    autoAccept = false
+    minExpiry = 0
+    maxExpiry = 0
+    maxCompletions = 18
+    maxSimultaneous = 1
+    targetBody = HomeWorld()
+
+    // ************ REWARDS ************
+    prestige = Exceptional
+    advanceFunds = 0
+    rewardScience = 0
+    rewardFunds = 0
+    failureFunds = 0
+    rewardReputation = 600
+    failureReputation = 0
+
+    // ************ REQUIREMENTS ************
+    REQUIREMENT
+    {
+        name = ProgramActive
+        type = ProgramActive
+        program = CommercialConstellation2 
+    }
+
+    // ************ DATA & LOGIC ************
+    DATA
+    {
+        type = int
+        index = $cc2_geo_Count + 0
+    }
+
+    DATA
+    {
+        type = double
+        targetLon = @index * 20.0
+    }
+
+    BEHAVIOUR
+    {
+        name = IncrementTheCount
+        type = Expression
+
+        CONTRACT_COMPLETED_SUCCESS
+        {
+            cc2_geo_Count = $cc2_geo_Count + 1
+        }
+    }
+
+    BEHAVIOUR
+    {
+        name = WaypointGenerator
+        type = WaypointGenerator
+
+        WAYPOINT
+        {
+            name = GEO Slot @/index
+            icon = thermometer
+            altitude = 0
+            latitude = 0
+            longitude = @/targetLon
+        }
+    }
+
+    // ************ PARAMETERS ************
+    PARAMETER
+    {
+        name = GEOCommSat
+        type = VesselParameterGroup
+        title = Constellation Satellite
+        define = GEO2_Slot_@/index 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = Crewmembers
+            type = HasCrew
+            minCrew = 0
+            maxCrew = 0
+            title = Uncrewed
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 199.9
+            disableOnStateChange = false
+            title = Carry at least 200 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeriod = 23h 54m
+            maxPeriod = 23h 58m
+            maxInclination = 2.0
+            maxEccentricity = 0.01
+            title = Achieve a Geostationary orbit near the waypoint slot (Lon: @/targetLon°)
+            
+            PARAMETER
+            {
+                name = VisitWaypoint
+                type = VisitWaypoint
+                index = 0
+                horizontalDistance = 4000.0
+                showMessages = false
+                disableOnStateChange = false
+            }
+
+            PARAMETER
+            {
+                name = Duration
+                type = Duration
+                duration = 2m
+                preWaitText = Check for stable orbit slot
+                waitingText = Checking for stable orbit
+                completionText = Stable orbit: Confirmed
+            }
+        }
+    }
+
+    // ************ BEHAVIOURS ************
+    BEHAVIOUR
+    {
+        name = TransferVessel
+        type = DestroyVessel
+        onState = CONTRACT_SUCCESS
+        vessel = GEO2_Slot_@/index
+    }
+
+    BEHAVIOUR
+    {
+        name = VesselDestroyed
+        type = DialogBox
+        DIALOG_BOX
+        {
+            title = Vessel Ownership Transferred
+            condition = CONTRACT_SUCCESS
+            position = CENTER
+            width = 0.5
+            TEXT
+            {
+                text = Deployment successful. The satellite has been transferred to the customer.
+            }
+        }
+    }
+}

--- a/GameData/RP-1/Contracts/Commercial Constellations/cc2_molniya.cfg
+++ b/GameData/RP-1/Contracts/Commercial Constellations/cc2_molniya.cfg
@@ -1,0 +1,315 @@
+CONTRACT_TYPE
+{
+    name = cc2_molniya
+    title = Advanced Commercial Molniya Constellation (Plane @index / 6)
+    group = CommConst
+
+    description = <b>Program: Commercial Constellations 2<br>Type: <color=green>Required</color></b><br><br>A commercial telecommunications company requires an expanded 18-satellite Molniya constellation. Deploy a batch of 3 satellites into the specified orbital plane and argument of periapsis. The customer will handle fine-tuning.<br><br><b><color=yellow>NOTE: The satellites will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color><br><br><b><color=yellow>NOTE: You must separate the 3 vessels while in an intermediate orbit with a period of less than 6 hours to ensure network spacing before boosting to the final 12-hour period.</color>
+    genericDescription = Deploy a batch of 3 commercial satellites into a specific Molniya orbital plane.
+    synopsis = Launch 3 payloads into the targeted Molniya orbital plane.
+    completedMessage = Payload control transferred to the customer.
+
+    sortKey = 921
+
+    cancellable = true
+    declinable = true
+    autoAccept = false
+    minExpiry = 0
+    maxExpiry = 0
+    maxCompletions = 6
+    maxSimultaneous = 1
+    targetBody = HomeWorld()
+
+    // ************ REWARDS ************
+    prestige = Exceptional
+    advanceFunds = 0
+    rewardScience = 0
+    rewardFunds = 0 
+    failureFunds = 0
+    rewardReputation = 300
+    failureReputation = 0
+
+    // ************ REQUIREMENTS ************
+    REQUIREMENT
+    {
+        name = ProgramActive
+        type = ProgramActive
+        program = CommercialConstellation2 
+    }
+
+    // ************ DATA & LOGIC ************
+    DATA
+    {
+        type = int
+        index = $cc2_molniya_Count + 0
+    }
+
+    DATA
+    {
+        type = double
+        targetLAN = @index * 60.0
+    }
+
+    BEHAVIOUR
+    {
+        name = IncrementTheCount
+        type = Expression
+
+        CONTRACT_COMPLETED_SUCCESS
+        {
+            cc2_molniya_Count = $cc2_molniya_Count + 1
+        }
+    }
+
+    // ************ PARAMETERS ************
+    
+    // SATELLITE 1
+    PARAMETER
+    {
+        name = Sat1
+        type = VesselParameterGroup
+        title = Constellation Satellite 1
+        define = Molniya2_Plane_@/index_Sat1 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya2_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya2_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 449.9
+            disableOnStateChange = false
+            title = Carry at least 450 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = ReachOrbit
+            type = Orbit
+            title = Separate vessels while in an intermediate orbit.
+            minPeriod = 1h
+            maxPeriod = 6h
+            completeInSequence = true
+            disableOnStateChange = true
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeriod = 11h 50m
+            maxPeriod = 12h 5m
+            minInclination = 62.5
+            maxInclination = 63.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            minArgumentOfPeriapsis = 268.0
+            maxArgumentOfPeriapsis = 272.0
+            title = Reach target plane
+        }
+        PARAMETER
+        {
+            name = Duration
+            type = Duration
+            duration = 6h
+            preWaitText = Achieve final orbit
+            waitingText = Checking orbit stability
+            completionText = Stable Orbit: Confirmed
+        }
+    }
+
+    // SATELLITE 2
+    PARAMETER
+    {
+        name = Sat2
+        type = VesselParameterGroup
+        title = Constellation Satellite 2
+        define = Molniya2_Plane_@/index_Sat2 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya2_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya2_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 449.9
+            disableOnStateChange = false
+            title = Carry at least 450 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = ReachOrbit
+            type = Orbit
+            title = Separate vessels while in an intermediate orbit.
+            minPeriod = 1h
+            maxPeriod = 6h
+            completeInSequence = true
+            disableOnStateChange = true
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeriod = 11h 50m
+            maxPeriod = 12h 5m
+            minInclination = 62.5
+            maxInclination = 63.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            minArgumentOfPeriapsis = 268.0
+            maxArgumentOfPeriapsis = 272.0
+            title = Reach target plane
+        }
+        PARAMETER
+        {
+            name = Duration
+            type = Duration
+            duration = 6h
+            preWaitText = Achieve final orbit
+            waitingText = Checking orbit stability
+            completionText = Stable Orbit: Confirmed
+        }
+    }
+
+    // SATELLITE 3
+    PARAMETER
+    {
+        name = Sat3
+        type = VesselParameterGroup
+        title = Constellation Satellite 3
+        define = Molniya2_Plane_@/index_Sat3 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya2_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya2_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 449.9
+            disableOnStateChange = false
+            title = Carry at least 450 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = ReachOrbit
+            type = Orbit
+            title = Separate vessels while in an intermediate orbit.
+            minPeriod = 1h
+            maxPeriod = 6h
+            completeInSequence = true
+            disableOnStateChange = true
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeriod = 11h 50m
+            maxPeriod = 12h 5m
+            minInclination = 62.5
+            maxInclination = 63.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            minArgumentOfPeriapsis = 268.0
+            maxArgumentOfPeriapsis = 272.0
+            title = Reach target plane
+        }
+        PARAMETER
+        {
+            name = Duration
+            type = Duration
+            duration = 6h
+            preWaitText = Achieve final orbit
+            waitingText = Checking orbit stability
+            completionText = Stable Orbit: Confirmed
+        }
+    }
+
+    // ************ BEHAVIOURS ************
+    BEHAVIOUR
+    {
+        name = TransferVessel
+        type = DestroyVessel
+        onState = CONTRACT_SUCCESS
+        vessel = Molniya2_Plane_@/index_Sat1
+        vessel = Molniya2_Plane_@/index_Sat2
+        vessel = Molniya2_Plane_@/index_Sat3
+    }
+
+    BEHAVIOUR
+    {
+        name = VesselDestroyed
+        type = DialogBox
+        DIALOG_BOX
+        {
+            title = Vessel Ownership Transferred
+            condition = CONTRACT_SUCCESS
+            position = CENTER
+            width = 0.5
+            TEXT
+            {
+                text = Deployment successful. The batch in this plane has been transferred to the customer.
+            }
+        }
+    }
+}

--- a/GameData/RP-1/Contracts/Commercial Constellations/cc2_walker.cfg
+++ b/GameData/RP-1/Contracts/Commercial Constellations/cc2_walker.cfg
@@ -1,0 +1,425 @@
+CONTRACT_TYPE
+{
+    name = cc2_walker
+    title = Advanced Commercial Walker Constellation (Plane @index / 10)
+    group = CommConst
+
+    description = <b>Program: Commercial Constellations 2<br>Type: <color=green>Required</color></b><br><br>A commercial telecommunications company requires a 50-satellite Walker constellation. Deploy a batch of 5 satellites into the required inclination and ascending node. The customer will handle fine-tuning.<br><br><b><color=yellow>NOTE: The satellites will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color>
+    genericDescription = Deploy a batch of 5 commercial satellites into a specific LEO orbital plane.
+    synopsis = Launch 5 payloads into the targeted orbital slice.
+    completedMessage = Payload control transferred to the customer.
+
+    sortKey = 920
+
+    cancellable = true
+    declinable = true
+    autoAccept = false
+    minExpiry = 0
+    maxExpiry = 0
+    maxCompletions = 10
+    maxSimultaneous = 1
+    targetBody = HomeWorld()
+
+    // ************ REWARDS ************
+    prestige = Exceptional
+    advanceFunds = 0
+    rewardScience = 0
+    rewardFunds = 0
+    failureFunds = 0
+    rewardReputation = 200
+    failureReputation = 0
+
+    // ************ REQUIREMENTS ************
+    REQUIREMENT
+    {
+        name = ProgramActive
+        type = ProgramActive
+        program = CommercialConstellation2 
+    }
+
+    // ************ DATA & LOGIC ************
+    DATA
+    {
+        type = int
+        index = $cc2_walker_Count + 0
+    }
+
+    DATA
+    {
+        type = double
+        targetLAN = @index * 36.0
+    }
+
+    BEHAVIOUR
+    {
+        name = IncrementTheCount
+        type = Expression
+
+        CONTRACT_COMPLETED_SUCCESS
+        {
+            cc2_walker_Count = $cc2_walker_Count + 1
+        }
+    }
+
+    // ************ PARAMETERS ************
+    
+    // SATELLITE 1
+    PARAMETER
+    {
+        name = Sat1
+        type = VesselParameterGroup
+        title = Constellation Satellite 1
+        define = Walker_Plane_@/index_Sat1 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat5
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 99.9
+            disableOnStateChange = false
+            title = Carry at least 100 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+            title = Reach target plane
+        }
+    }
+
+    // SATELLITE 2
+    PARAMETER
+    {
+        name = Sat2
+        type = VesselParameterGroup
+        title = Constellation Satellite 2
+        define = Walker_Plane_@/index_Sat2 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat5
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 99.9
+            disableOnStateChange = false
+            title = Carry at least 100 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+            title = Reach target plane
+        }
+    }
+
+    // SATELLITE 3
+    PARAMETER
+    {
+        name = Sat3
+        type = VesselParameterGroup
+        title = Constellation Satellite 3
+        define = Walker_Plane_@/index_Sat3 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat5
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 99.9
+            disableOnStateChange = false
+            title = Carry at least 100 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+            title = Reach target plane
+        }
+    }
+
+    // SATELLITE 4
+    PARAMETER
+    {
+        name = Sat4
+        type = VesselParameterGroup
+        title = Constellation Satellite 4
+        define = Walker_Plane_@/index_Sat4 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat5
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 99.9
+            disableOnStateChange = false
+            title = Carry at least 100 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+            title = Reach target plane
+        }
+    }
+
+    // SATELLITE 5
+    PARAMETER
+    {
+        name = Sat5
+        type = VesselParameterGroup
+        title = Constellation Satellite 5
+        define = Walker_Plane_@/index_Sat5 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 99.9
+            disableOnStateChange = false
+            title = Carry at least 100 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+            title = Reach target plane
+        }
+    }
+
+    // ************ BEHAVIOURS ************
+    BEHAVIOUR
+    {
+        name = TransferVessel
+        type = DestroyVessel
+        onState = CONTRACT_SUCCESS
+        vessel = Walker_Plane_@/index_Sat1
+        vessel = Walker_Plane_@/index_Sat2
+        vessel = Walker_Plane_@/index_Sat3
+        vessel = Walker_Plane_@/index_Sat4
+        vessel = Walker_Plane_@/index_Sat5
+    }
+
+    BEHAVIOUR
+    {
+        name = VesselDestroyed
+        type = DialogBox
+        DIALOG_BOX
+        {
+            title = Vessel Ownership Transferred
+            condition = CONTRACT_SUCCESS
+            position = CENTER
+            width = 0.5
+            TEXT
+            {
+                text = Deployment successful. The batch in this plane has been transferred to the customer.
+            }
+        }
+    }
+}

--- a/GameData/RP-1/Contracts/Commercial Constellations/cc3_geo.cfg
+++ b/GameData/RP-1/Contracts/Commercial Constellations/cc3_geo.cfg
@@ -1,0 +1,177 @@
+CONTRACT_TYPE
+{
+    name = cc3_geo
+    title = Massive Commercial GEO Constellation (Slot @index / 24)
+    group = CommConst
+
+    description = <b>Program: Commercial Constellations 3<br>Type: <color=green>Required</color></b><br><br>A commercial telecommunications company requires a deployment of a 24-satellite geostationary network. Deploy a satellite to the specified longitudinal slot. The customer will handle fine-tuning.<br><br><b><color=yellow>NOTE: The satellite will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color>
+    genericDescription = Deploy a commercial satellite into a specific Geostationary orbital slot.
+    synopsis = Launch a payload into the targeted GEO slot.
+    completedMessage = Payload control transferred to the customer.
+
+    sortKey = 932
+
+    cancellable = true
+    declinable = true
+    autoAccept = false
+    minExpiry = 0
+    maxExpiry = 0
+    maxCompletions = 24
+    maxSimultaneous = 1
+    targetBody = HomeWorld()
+
+    // ************ REWARDS ************
+    prestige = Exceptional
+    advanceFunds = 0
+    rewardScience = 0
+    rewardFunds = 220000 
+    failureFunds = 0
+    rewardReputation = 150
+    failureReputation = 0
+
+    // ************ REQUIREMENTS ************
+    REQUIREMENT
+    {
+        name = ProgramActive
+        type = ProgramActive
+        program = CommercialConstellation3 
+    }
+
+    // ************ DATA & LOGIC ************
+    DATA
+    {
+        type = int
+        index = $cc3_geo_Count + 0
+    }
+
+    DATA
+    {
+        type = double
+        targetLon = @index * 15.0
+    }
+
+    BEHAVIOUR
+    {
+        name = IncrementTheCount
+        type = Expression
+
+        CONTRACT_COMPLETED_SUCCESS
+        {
+            cc3_geo_Count = $cc3_geo_Count + 1
+        }
+    }
+
+    BEHAVIOUR
+    {
+        name = WaypointGenerator
+        type = WaypointGenerator
+
+        WAYPOINT
+        {
+            name = GEO Slot @/index
+            icon = thermometer
+            altitude = 0
+            latitude = 0
+            longitude = @/targetLon
+        }
+    }
+
+    // ************ PARAMETERS ************
+    PARAMETER
+    {
+        name = GEOCommSat
+        type = VesselParameterGroup
+        title = Constellation Satellite
+        define = GEO3_Slot_@/index 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        
+        PARAMETER
+        {
+            name = Crewmembers
+            type = HasCrew
+            minCrew = 0
+            maxCrew = 0
+            title = Uncrewed
+            hideChildren = true
+        }
+
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 299.9
+            disableOnStateChange = false
+            title = Carry at least 300 units of ComSatPayload
+        }
+
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            
+            minPeriod = 23h 54m
+            maxPeriod = 23h 58m
+            maxInclination = 2.0
+            maxEccentricity = 0.01
+            
+            title = Achieve a Geostationary orbit near the waypoint slot (Lon: @/targetLon°)
+            
+            PARAMETER
+            {
+                name = VisitWaypoint
+                type = VisitWaypoint
+                index = 0
+                horizontalDistance = 4000.0
+                showMessages = false
+                disableOnStateChange = false
+            }
+
+            PARAMETER
+            {
+                name = Duration
+                type = Duration
+                duration = 2m
+                preWaitText = Check for stable orbit slot
+                waitingText = Checking for stable orbit
+                completionText = Stable orbit: Confirmed
+            }
+        }
+    }
+
+    // ************ BEHAVIOURS ************
+    BEHAVIOUR
+    {
+        name = TransferVessel
+        type = DestroyVessel
+        onState = CONTRACT_SUCCESS
+        vessel = GEO3_Slot_@/index
+    }
+
+    BEHAVIOUR
+    {
+        name = VesselDestroyed
+        type = DialogBox
+        DIALOG_BOX
+        {
+            title = Vessel Ownership Transferred
+            condition = CONTRACT_SUCCESS
+            position = CENTER
+            width = 0.5
+            TEXT
+            {
+                text = Deployment successful. The satellite has been transferred to the customer.
+            }
+        }
+    }
+}

--- a/GameData/RP-1/Contracts/Commercial Constellations/cc3_molniya.cfg
+++ b/GameData/RP-1/Contracts/Commercial Constellations/cc3_molniya.cfg
@@ -1,0 +1,414 @@
+CONTRACT_TYPE
+{
+    name = cc3_molniya
+    title = Massive Commercial Molniya Constellation (Plane @index / 6)
+    group = CommConst
+
+    description = <b>Program: Commercial Constellations 3<br>Type: <color=green>Required</color></b><br><br>A commercial telecommunications company requires a 24-satellite Molniya constellation. Deploy a batch of 4 satellites into the specified orbital plane and argument of periapsis. The customer will handle fine-tuning.<br><br><b><color=yellow>NOTE: The satellites will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color><br><br><b><color=yellow>NOTE: You must separate the 4 vessels while in an intermediate orbit with a period of less than 6 hours to ensure network spacing before boosting to the final 12-hour period.</color>
+    genericDescription = Deploy a batch of 4 commercial satellites into a specific Molniya orbital plane.
+    synopsis = Launch 4 payloads into the targeted Molniya orbital plane.
+    completedMessage = Payload control transferred to the customer.
+
+    sortKey = 931
+
+    cancellable = true
+    declinable = true
+    autoAccept = false
+    minExpiry = 0
+    maxExpiry = 0
+    maxCompletions = 6
+    maxSimultaneous = 1
+    targetBody = HomeWorld()
+
+    // ************ REWARDS ************
+    prestige = Exceptional
+    advanceFunds = 0
+    rewardScience = 0
+    rewardFunds = 0 
+    failureFunds = 0
+    rewardReputation = 400
+    failureReputation = 0
+
+    // ************ REQUIREMENTS ************
+    REQUIREMENT
+    {
+        name = ProgramActive
+        type = ProgramActive
+        program = CommercialConstellation3 
+    }
+
+    // ************ DATA & LOGIC ************
+    DATA
+    {
+        type = int
+        index = $cc3_molniya_Count + 0
+    }
+
+    DATA
+    {
+        type = double
+        targetLAN = @index * 60.0
+    }
+
+    BEHAVIOUR
+    {
+        name = IncrementTheCount
+        type = Expression
+
+        CONTRACT_COMPLETED_SUCCESS
+        {
+            cc3_molniya_Count = $cc3_molniya_Count + 1
+        }
+    }
+
+    // ************ PARAMETERS ************
+    
+    // SATELLITE 1
+    PARAMETER
+    {
+        name = Sat1
+        type = VesselParameterGroup
+        title = Constellation Satellite 1
+        define = Molniya3_Plane_@/index_Sat1 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 599.9
+            disableOnStateChange = false
+            title = Carry at least 600 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = ReachOrbit
+            type = Orbit
+            title = Separate vessels while in an intermediate orbit.
+            minPeriod = 1h
+            maxPeriod = 6h
+            completeInSequence = true
+            disableOnStateChange = true
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeriod = 11h 50m
+            maxPeriod = 12h 5m
+            minInclination = 62.5
+            maxInclination = 63.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            minArgumentOfPeriapsis = 268.0
+            maxArgumentOfPeriapsis = 272.0
+            title = Reach target plane
+        }
+        PARAMETER
+        {
+            name = Duration
+            type = Duration
+            duration = 6h
+            preWaitText = Achieve final orbit
+            waitingText = Checking orbit stability
+            completionText = Stable Orbit: Confirmed
+        }
+    }
+
+    // SATELLITE 2
+    PARAMETER
+    {
+        name = Sat2
+        type = VesselParameterGroup
+        title = Constellation Satellite 2
+        define = Molniya3_Plane_@/index_Sat2 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 599.9
+            disableOnStateChange = false
+            title = Carry at least 600 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = ReachOrbit
+            type = Orbit
+            title = Separate vessels while in an intermediate orbit.
+            minPeriod = 1h
+            maxPeriod = 6h
+            completeInSequence = true
+            disableOnStateChange = true
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeriod = 11h 50m
+            maxPeriod = 12h 5m
+            minInclination = 62.5
+            maxInclination = 63.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            minArgumentOfPeriapsis = 268.0
+            maxArgumentOfPeriapsis = 272.0
+            title = Reach target plane
+        }
+        PARAMETER
+        {
+            name = Duration
+            type = Duration
+            duration = 6h
+            preWaitText = Achieve final orbit
+            waitingText = Checking orbit stability
+            completionText = Stable Orbit: Confirmed
+        }
+    }
+
+    // SATELLITE 3
+    PARAMETER
+    {
+        name = Sat3
+        type = VesselParameterGroup
+        title = Constellation Satellite 3
+        define = Molniya3_Plane_@/index_Sat3 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 599.9
+            disableOnStateChange = false
+            title = Carry at least 600 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = ReachOrbit
+            type = Orbit
+            title = Separate vessels while in an intermediate orbit.
+            minPeriod = 1h
+            maxPeriod = 6h
+            completeInSequence = true
+            disableOnStateChange = true
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeriod = 11h 50m
+            maxPeriod = 12h 5m
+            minInclination = 62.5
+            maxInclination = 63.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            minArgumentOfPeriapsis = 268.0
+            maxArgumentOfPeriapsis = 272.0
+            title = Reach target plane
+        }
+        PARAMETER
+        {
+            name = Duration
+            type = Duration
+            duration = 6h
+            preWaitText = Achieve final orbit
+            waitingText = Checking orbit stability
+            completionText = Stable Orbit: Confirmed
+        }
+    }
+
+    // SATELLITE 4
+    PARAMETER
+    {
+        name = Sat4
+        type = VesselParameterGroup
+        title = Constellation Satellite 4
+        define = Molniya3_Plane_@/index_Sat4 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Molniya3_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 599.9
+            disableOnStateChange = false
+            title = Carry at least 600 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = ReachOrbit
+            type = Orbit
+            title = Separate vessels while in an intermediate orbit.
+            minPeriod = 1h
+            maxPeriod = 6h
+            completeInSequence = true
+            disableOnStateChange = true
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeriod = 11h 50m
+            maxPeriod = 12h 5m
+            minInclination = 62.5
+            maxInclination = 63.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            minArgumentOfPeriapsis = 268.0
+            maxArgumentOfPeriapsis = 272.0
+            title = Reach target plane
+        }
+        PARAMETER
+        {
+            name = Duration
+            type = Duration
+            duration = 6h
+            preWaitText = Achieve final orbit
+            waitingText = Checking orbit stability
+            completionText = Stable Orbit: Confirmed
+        }
+    }
+
+    // ************ BEHAVIOURS ************
+    BEHAVIOUR
+    {
+        name = TransferVessel
+        type = DestroyVessel
+        onState = CONTRACT_SUCCESS
+        vessel = Molniya3_Plane_@/index_Sat1
+        vessel = Molniya3_Plane_@/index_Sat2
+        vessel = Molniya3_Plane_@/index_Sat3
+        vessel = Molniya3_Plane_@/index_Sat4
+    }
+
+    BEHAVIOUR
+    {
+        name = VesselDestroyed
+        type = DialogBox
+        DIALOG_BOX
+        {
+            title = Vessel Ownership Transferred
+            condition = CONTRACT_SUCCESS
+            position = CENTER
+            width = 0.5
+            TEXT
+            {
+                text = Deployment successful. The batch in this plane has been transferred to the customer.
+            }
+        }
+    }
+}

--- a/GameData/RP-1/Contracts/Commercial Constellations/cc3_walker.cfg
+++ b/GameData/RP-1/Contracts/Commercial Constellations/cc3_walker.cfg
@@ -1,0 +1,756 @@
+CONTRACT_TYPE
+{
+    name = cc3_walker
+    title = Massive Commercial LEO Constellation (Plane @index / 10)
+    group = CommConst
+
+    description = <b>Program: Commercial Constellations 3<br>Type: <color=green>Required</color></b><br><br>A commercial telecommunications company requires an 80-satellite Walker constellation. Deploy batch of 8 satellites into the required inclination and ascending node. The customer will handle fine-tuning.<br><br><b><color=yellow>NOTE: The satellites will be destroyed upon completion of the contract. This simulates transfer of the payload back to the customer.</color>
+    genericDescription = Deploy a batch of 8 commercial satellites into a specific LEO orbital plane.
+    synopsis = Launch 8 payloads into the targeted orbital slice.
+    completedMessage = Payload control transferred to the customer.
+
+    sortKey = 930
+
+    cancellable = true
+    declinable = true
+    autoAccept = false
+    minExpiry = 0
+    maxExpiry = 0
+    maxCompletions = 10
+    maxSimultaneous = 1
+    targetBody = HomeWorld()
+
+    // ************ REWARDS ************
+    prestige = Exceptional
+    advanceFunds = 0
+    rewardScience = 0
+    rewardFunds = 0 
+    failureFunds = 0
+    rewardReputation = 400
+    failureReputation = 0
+
+    // ************ REQUIREMENTS ************
+    REQUIREMENT
+    {
+        name = ProgramActive
+        type = ProgramActive
+        program = CommercialConstellation3 
+    }
+
+    // ************ DATA & LOGIC ************
+    DATA
+    {
+        type = int
+        index = $cc3_walker_Count + 0
+    }
+
+    DATA
+    {
+        type = double
+        targetLAN = @index * 36.0
+    }
+
+    BEHAVIOUR
+    {
+        name = IncrementTheCount
+        type = Expression
+
+        CONTRACT_COMPLETED_SUCCESS
+        {
+            cc3_walker_Count = $cc3_walker_Count + 1
+        }
+    }
+
+    // ************ PARAMETERS ************
+    
+    // SATELLITE 1
+    PARAMETER
+    {
+        name = Sat1
+        type = VesselParameterGroup
+        title = Constellation Satellite 1
+        define = Walker3_Plane_@/index_Sat1 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            title = Launch a new vessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat5
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat6
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat7
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat8
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 199.9
+            disableOnStateChange = false
+            title = Carry at least 200 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+            title = Reach target plane (LAN: @/targetLAN°, Inc: 53°)
+        }
+    }
+
+    // SATELLITE 2
+    PARAMETER
+    {
+        name = Sat2
+        type = VesselParameterGroup
+        title = Constellation Satellite 2
+        define = Walker3_Plane_@/index_Sat2 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat5
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat6
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat7
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat8
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 199.9
+            disableOnStateChange = false
+            title = Carry at least 200 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+        }
+    }
+
+    // SATELLITE 3
+    PARAMETER
+    {
+        name = Sat3
+        type = VesselParameterGroup
+        title = Constellation Satellite 3
+        define = Walker3_Plane_@/index_Sat3 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat5
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat6
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat7
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat8
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 199.9
+            disableOnStateChange = false
+            title = Carry at least 200 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+        }
+    }
+
+    // SATELLITE 4
+    PARAMETER
+    {
+        name = Sat4
+        type = VesselParameterGroup
+        title = Constellation Satellite 4
+        define = Walker3_Plane_@/index_Sat4 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat5
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat6
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat7
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat8
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 199.9
+            disableOnStateChange = false
+            title = Carry at least 200 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+        }
+    }
+
+    // SATELLITE 5
+    PARAMETER
+    {
+        name = Sat5
+        type = VesselParameterGroup
+        title = Constellation Satellite 5
+        define = Walker3_Plane_@/index_Sat5 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat6
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat7
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat8
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 199.9
+            disableOnStateChange = false
+            title = Carry at least 200 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+        }
+    }
+
+    // SATELLITE 6
+    PARAMETER
+    {
+        name = Sat6
+        type = VesselParameterGroup
+        title = Constellation Satellite 6
+        define = Walker3_Plane_@/index_Sat6 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat5
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat7
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat8
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 199.9
+            disableOnStateChange = false
+            title = Carry at least 200 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+        }
+    }
+
+    // SATELLITE 7
+    PARAMETER
+    {
+        name = Sat7
+        type = VesselParameterGroup
+        title = Constellation Satellite 7
+        define = Walker3_Plane_@/index_Sat7 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat5
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat6
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat8
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 199.9
+            disableOnStateChange = false
+            title = Carry at least 200 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+        }
+    }
+
+    // SATELLITE 8
+    PARAMETER
+    {
+        name = Sat8
+        type = VesselParameterGroup
+        title = Constellation Satellite 8
+        define = Walker3_Plane_@/index_Sat8 
+        disableOnStateChange = false
+
+        PARAMETER
+        {
+            name = NewVessel
+            type = NewVessel
+            hideChildren = true
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat1
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat2
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat3
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat4
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat5
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat6
+        }
+        PARAMETER
+        {
+            name = IsNotVessel
+            type = IsNotVessel
+            vessel = Walker3_Plane_@/index_Sat7
+        }
+        PARAMETER
+        {
+            name = HasComSatPayload
+            type = HasResource
+            resource = ComSatPayload
+            minQuantity = 199.9
+            disableOnStateChange = false
+            title = Carry at least 200 units of ComSatPayload
+        }
+        PARAMETER
+        {
+            name = Orbit
+            type = Orbit
+            targetBody = HomeWorld()
+            disableOnStateChange = false
+            minPeA = 500000
+            maxApA = 550000
+            minInclination = 52.5
+            maxInclination = 53.5
+            minLAN = @/targetLAN - 2.0
+            maxLAN = @/targetLAN + 2.0
+            maxEccentricity = 0.005
+        }
+    }
+
+    // ************ BEHAVIOURS ************
+    BEHAVIOUR
+    {
+        name = TransferVessel
+        type = DestroyVessel
+        onState = CONTRACT_SUCCESS
+        vessel = Walker3_Plane_@/index_Sat1
+        vessel = Walker3_Plane_@/index_Sat2
+        vessel = Walker3_Plane_@/index_Sat3
+        vessel = Walker3_Plane_@/index_Sat4
+        vessel = Walker3_Plane_@/index_Sat5
+        vessel = Walker3_Plane_@/index_Sat6
+        vessel = Walker3_Plane_@/index_Sat7
+        vessel = Walker3_Plane_@/index_Sat8
+    }
+
+    BEHAVIOUR
+    {
+        name = VesselDestroyed
+        type = DialogBox
+        DIALOG_BOX
+        {
+            title = Vessel Ownership Transferred
+            condition = CONTRACT_SUCCESS
+            position = CENTER
+            width = 0.5
+            TEXT
+            {
+                text = Deployment successful. The batch in this plane has been transferred to the customer.
+            }
+        }
+    }
+}

--- a/GameData/RP-1/Contracts/Groups.cfg
+++ b/GameData/RP-1/Contracts/Groups.cfg
@@ -97,6 +97,14 @@ CONTRACT_GROUP
 	}
 	CONTRACT_GROUP
 	{
+		name = CommConst
+		displayName = Commercial Constellations
+		minVersion = 1.12.2
+		sortKey = 20
+		agent = Satellites
+	}
+	CONTRACT_GROUP
+	{
 		name = GEOCommNetwork
 		displayName = Geostationary Communications Network
 		minVersion = 1.12.2

--- a/GameData/RP-1/Programs/Programs.cfg
+++ b/GameData/RP-1/Programs/Programs.cfg
@@ -543,6 +543,111 @@ RP0_PROGRAM
 	}
 }
 
+RP0_Program 
+{
+	name = CommercialConstellation1
+	title = First Commercial Satellite Constellation
+	description = Customer wants constellation 
+	requirementsPrettyText = Complete the Early Commercial Applications Program
+	objectivesPrettyText = Deploy an initial constellation for a customer
+	nominalDurationYears = 8
+	baseFunding = 3000000
+	repDeltaOnCompletePerYearEarly = 210
+	repPenaltyPerYearLate = 210
+	slots = 1
+
+	REQUIREMENTS
+	{
+		complete_program = SkoposCommercialApplications0
+	}
+
+	OBJECTIVES
+	{
+		ANY
+		{
+			complete_contract = cc1_waker
+			complete_contract = cc1_molniya
+			complete_contract = cc1_geo
+		}
+	}
+
+	CONFIDENCECOSTS
+	{
+		Normal = 900
+		Fast = 1800
+	}
+}
+
+RP0_Program 
+{
+	name = CommercialConstellation2
+	title = Second Commercial Satellite Constellation
+	description = Customer wants constellation 
+	requirementsPrettyText = Complete the First Commercial Satellite Constellation program
+	objectivesPrettyText = Deploy an initial constellation for a customer
+	nominalDurationYears = 8
+	baseFunding = 4000000
+	repDeltaOnCompletePerYearEarly = 210
+	repPenaltyPerYearLate = 210
+	slots = 1
+
+	REQUIREMENTS
+	{
+		complete_program = CommercialConstellation1
+	}
+
+	OBJECTIVES
+	{
+		ANY
+		{
+			complete_contract = cc2_waker
+			complete_contract = cc2_molniya
+			complete_contract = cc2_geo
+		}
+	}
+
+	CONFIDENCECOSTS
+	{
+		Normal = 1250
+		Fast = 2500
+	}
+}
+
+RP0_Program 
+{
+	name = CommercialConstellation3
+	title = Third Commercial Satellite Constellation
+	description = Customer wants constellation 
+	requirementsPrettyText = Complete the Second Commercial Satellite Constellation program
+	objectivesPrettyText = Deploy an initial constellation for a customer
+	nominalDurationYears = 8
+	baseFunding = 5000000
+	repDeltaOnCompletePerYearEarly = 210
+	repPenaltyPerYearLate = 210
+	slots = 1
+
+	REQUIREMENTS
+	{
+		complete_program = CommercialConstellation1
+	}
+
+	OBJECTIVES
+	{
+		ANY
+		{
+			complete_contract = cc3_waker
+			complete_contract = cc3_molniya
+			complete_contract = cc3_geo
+		}
+	}
+
+	CONFIDENCECOSTS
+	{
+		Normal = 1500
+		Fast = 3000
+	}
+}
+
 RP0_PROGRAM
 {
 	name = EarlyLunarProbes


### PR DESCRIPTION
Whereas Skopos sees the player deploy a constellation of their own, these three programs focus entirely on deploying a customer's constellation with increasing requirements in terms of size and number. In order to allow players from all launch sites to (at least attempt to) complete this, there are three different types, either a LEO Walker, Molniya or GEO constellation. 

I do very much think that Skopos telecom *and* this can coexist peacefully and one should not attempt to replace the other. The reason for this is simple: not all players want to maintain a telecom constellation. Skopos is far more fun than these three programs, but these allow a player who does not want to maintain a constellation to have some "busy work" to do in the Earth system. 

That hits it on the head in my eyes: more stuff to do around Earth - of which there is far too little past the early game.

If someone knows how - I would prefer to restrict this to the 2000s at the earliest. While one could argue that ArianeGroup already saw commercial launches, they were not of this order of magnitude and they should thus not appear at an ahistorically early point in time. 