### PR TITLE
Allow the hiring cooldown alarm to be toggleable

### DIFF
--- a/Source/RP0/Leaders/StrategyRP0.cs
+++ b/Source/RP0/Leaders/StrategyRP0.cs
@@ -207,8 +207,6 @@ namespace RP0
 
             Unregister();
 
-            KACWrapper.KACAPI.AlarmTypeEnum alarmType = KACWrapper.KACAPI.AlarmTypeEnum.Crew;
-
             if (!(this is Programs.ProgramStrategy))
             {
                 SpaceCenterManagement.Instance.RecalculateBuildRates();
@@ -218,8 +216,13 @@ namespace RP0
                 if (ConfigRP0.ReactivateCooldown > 0)
                 {
                     AlarmHelper.DeleteAllAlarmsWithTitle(ConfigRP0.Title);
+                    RP0Settings _settings = HighLogic.CurrentGame.Parameters.CustomParams<RP0Settings>();
 
-                    AlarmHelper.CreateAlarm($"Hiring Cooldown Over: {ConfigRP0.Title}", $"{ConfigRP0.Title} can be re-hired at this time.", dateDeactivated + ConfigRP0.ReactivateCooldown, alarmType);
+                    if (_settings.MakeAlarmHiringCooldownOver)
+                    {
+                        KACWrapper.KACAPI.AlarmTypeEnum alarmType = KACWrapper.KACAPI.AlarmTypeEnum.Crew;
+                        AlarmHelper.CreateAlarm($"Hiring Cooldown Over: {ConfigRP0.Title}", $"{ConfigRP0.Title} can be re-hired at this time.", dateDeactivated + ConfigRP0.ReactivateCooldown, alarmType);
+                    }
                 }
             }
 

--- a/Source/RP0/Settings/GameParameters.cs
+++ b/Source/RP0/Settings/GameParameters.cs
@@ -80,8 +80,11 @@ namespace RP0
         [GameParameters.CustomParameterUI("Show tooling reminders", toolTip = "When enabled, a warning is shown on integration when the vessel has untooled parts.")]
         public bool ShowToolingReminders = true;
 
-        [GameParameters.CustomParameterUI("Make cooldown alarm", toolTip = "When enabled, an alarm will be automatically created when a leader is recruited that shows when that leader can be removed with a penalty.")]
-        public bool MakeAlarmCooldownOver = false;
+        [GameParameters.CustomParameterUI("Make firing cooldown alarm", toolTip = "When enabled, an alarm will be automatically created when a leader is recruited that shows when that leader can be removed with a penalty.")]
+        public bool MakeAlarmCooldownOver = false; // TODO this should be changed to MakeFiringCooldownOver on a save breaking update
+
+        [GameParameters.CustomParameterUI("Make hiring cooldown alarm", toolTip = "When enabled, an alarm will be automatically created when a leader is removed that shows when the leader can be re-hired.")]
+        public bool MakeAlarmHiringCooldownOver = true;
 
         [GameParameters.CustomParameterUI("Make free to remove alarm", toolTip = "When enabled, an alarm will be automatically created when a leader is recruited that shows when that leader can be removed without penalties.")]
         public bool MakeAlarmFreeRemove = true;


### PR DESCRIPTION
I must have missed this one in https://github.com/KSP-RO/RP-1/pull/2720

<img width="1333" height="739" alt="image" src="https://github.com/user-attachments/assets/4ca96e03-ef16-4bf7-98b7-2760c0b4e20d" />
