### PR TITLE
Group tooling types and add Refit button

### DIFF
--- a/Source/RP0/RP0.csproj
+++ b/Source/RP0/RP0.csproj
@@ -236,6 +236,7 @@
     <Compile Include="UI\ContractGUI.cs" />
     <Compile Include="UI\Tooltip.cs" />
     <Compile Include="UI\ToolingGUI.cs" />
+    <Compile Include="UI\ToolingPartResizer.cs" />
     <Compile Include="UI\AvionicsGUI.cs" />
     <Compile Include="SpaceCenter\AirlaunchParams.cs" />
     <Compile Include="SpaceCenter\AirlaunchTechLevel.cs" />

--- a/Source/RP0/Tooling/ToolingDatabase.cs
+++ b/Source/RP0/Tooling/ToolingDatabase.cs
@@ -38,6 +38,11 @@ namespace RP0
 
         public static Dictionary<string, List<ToolingEntry>> toolings = new Dictionary<string, List<ToolingEntry>>();
 
+        // Bumps on every mutation (UnlockTooling adding entries, Load wiping the table).
+        // Lets the UI cache derived views (e.g. merged grouped entries) and invalidate
+        // without scanning the whole tree each frame.
+        public static int Generation { get; private set; }
+
         protected static int GetEntryIndex(float value, List<ToolingEntry> list, out int min)
         {
             min = 0;
@@ -165,6 +170,7 @@ namespace RP0
                 entries = entries[entryIndex].Children;
             }
 
+            if (toolingUnlocked) Generation++;
             return toolingUnlocked;
         }
 
@@ -177,6 +183,7 @@ namespace RP0
         private static void LoadDBFromNode(ConfigNode node)
         {
             toolings.Clear();
+            Generation++;
 
             if (node == null) return;
 

--- a/Source/RP0/Tooling/ToolingDatabase.cs
+++ b/Source/RP0/Tooling/ToolingDatabase.cs
@@ -7,6 +7,11 @@ namespace RP0
         public float Value { get; set; }
         public List<ToolingEntry> Children { get; } = new List<ToolingEntry>();
 
+        // Set on merged-leaf entries to record which DB type(s) supplied this exact
+        // (mass, diameter, length) combination. Null on entries that live in the database
+        // proper, and on non-leaf merged entries.
+        public HashSet<string> Sources { get; set; }
+
         public ToolingEntry(float value)
         {
             Value = value;
@@ -95,6 +100,48 @@ namespace RP0
             }
 
             return level;
+        }
+
+        // Returns a freshly-merged tree combining the entries of every supplied type.
+        // Used by the tooling UI to collapse grouped types (e.g. all Avionics-N* tech levels
+        // under one Avionics-N entry) without mutating the underlying database.
+        public static List<ToolingEntry> GetMergedEntries(IEnumerable<string> types)
+        {
+            var merged = new List<ToolingEntry>();
+            foreach (var type in types)
+            {
+                if (toolings.TryGetValue(type, out var entries))
+                {
+                    foreach (var entry in entries)
+                        MergeEntryInto(merged, entry, type);
+                }
+            }
+            return merged;
+        }
+
+        private static void MergeEntryInto(List<ToolingEntry> target, ToolingEntry source, string sourceType)
+        {
+            int existing = GetEntryIndex(source.Value, target, out int insertionIndex);
+            ToolingEntry dest;
+            if (existing >= 0)
+            {
+                dest = target[existing];
+            }
+            else
+            {
+                dest = new ToolingEntry(source.Value);
+                target.Insert(insertionIndex, dest);
+            }
+            if (source.Children.Count == 0)
+            {
+                if (dest.Sources == null) dest.Sources = new HashSet<string>();
+                dest.Sources.Add(sourceType);
+            }
+            else
+            {
+                foreach (var child in source.Children)
+                    MergeEntryInto(dest.Children, child, sourceType);
+            }
         }
 
         public static bool UnlockTooling(string type, params float[] parameters)

--- a/Source/RP0/UI/ProceduralAvionicsWindow.cs
+++ b/Source/RP0/UI/ProceduralAvionicsWindow.cs
@@ -304,7 +304,7 @@ namespace RP0.ProceduralAvionics
             bool isCurrent = techNode == _module.CurrentProceduralAvionicsTechNode;
             if (isCurrent)
             {
-                _gc.text = BuildTechName(techNode);
+                _gc.text = BuildTechName(curCfg, techNode);
                 GUILayout.BeginHorizontal();
                 GUILayout.Toggle(true, _gc, HighLogic.Skin.button);
                 DrawUnlockButton(curCfg.name, techNode, unlockCost);
@@ -324,7 +324,7 @@ namespace RP0.ProceduralAvionics
             }
             else
             {
-                _gc.text = $"Switch to {BuildTechName(techNode)}";
+                _gc.text = $"Switch to {BuildTechName(curCfg, techNode)}";
                 GUILayout.BeginHorizontal();
                 switchedConfig = GUILayout.Button(_gc, HighLogic.Skin.button);
                 switchedConfig |= DrawUnlockButton(curCfg.name, techNode, unlockCost);
@@ -490,9 +490,11 @@ namespace RP0.ProceduralAvionics
             return tooltip;
         }
 
-        private string BuildTechName(ProceduralAvionicsTechNode techNode) 
+        private string BuildTechName(ProceduralAvionicsConfig curCfg, ProceduralAvionicsTechNode techNode)
         {
-            string title = techNode.dispName ?? techNode.name;
+            // Abbreviation matches the tooling type suffix (see ModuleToolingProcAvionics.ToolingType)
+            // so players can cross-reference configure-avionics names with tooling entries.
+            string title = $"{techNode.dispName ?? techNode.name} ({curCfg.name[0]}{techNode.techLevel})";
             return techNode.IsAvailable ? title : $"<color=orange>{title}</color>";
         }
 

--- a/Source/RP0/UI/ToolingGUI.cs
+++ b/Source/RP0/UI/ToolingGUI.cs
@@ -41,6 +41,48 @@ namespace RP0
         private string _mergedCacheKey;
         private int _mergedCacheGeneration = -1;
         private List<ToolingEntry> _mergedCache;
+
+        // Cached grouped-tooling button list, keyed on ToolingDatabase.Generation so the per-frame
+        // RenderToolingTab / RenderTypeTab passes don't re-walk ToolingDatabase.toolings.Keys and
+        // re-allocate the group dictionary every OnGUI call.
+        private int _groupedCacheGeneration = -1;
+        private List<KeyValuePair<string, List<string>>> _groupedCache;
+
+        // Category keys for tank groupings. Prefix "Tank-" is reused so GetParametersForToolingType
+        // routes them to the diameter/length parameter set the same way bare "Tank-*" DB keys would.
+        // Conventional / Isogrid / Balloon / Fuselage each have a non-HP and an HP variant; ServiceModule
+        // and Shielded have no HP. HP buttons only appear when at least one underlying type matched.
+        private const string TankConventional   = "Tank-Conventional";
+        private const string TankConventionalHP = "Tank-ConventionalHP";
+        private const string TankIsogrid        = "Tank-Isogrid";
+        private const string TankIsogridHP      = "Tank-IsogridHP";
+        private const string TankBalloon        = "Tank-Balloon";
+        private const string TankBalloonHP      = "Tank-BalloonHP";
+        private const string TankFuselage       = "Tank-Fuselage";
+        private const string TankFuselageHP     = "Tank-FuselageHP";
+        private const string TankServiceModule  = "Tank-ServiceModule";
+        private const string TankShieldedKey    = "Tank-Shielded";
+        private const string TankCryogenic      = "Tank-Cryogenic";
+        private const string TankOther          = "Tank-Other";
+
+        // Titles are prefixed "Tank (...)" so every tank bucket sorts together, and the HP / Non-HP
+        // qualifier sits first inside the parens so all HP variants cluster and all Non-HP variants
+        // cluster within that block (siimav review: HP and base families sorted non-adjacently).
+        private static readonly Dictionary<string, string> _groupTitles = new Dictionary<string, string>
+        {
+            { TankConventional,   "Tank (Non-HP Conventional)" },
+            { TankConventionalHP, "Tank (HP Conventional)"     },
+            { TankIsogrid,        "Tank (Non-HP Isogrid)"      },
+            { TankIsogridHP,      "Tank (HP Isogrid)"          },
+            { TankBalloon,        "Tank (Non-HP Balloon)"      },
+            { TankBalloonHP,      "Tank (HP Balloon)"          },
+            { TankFuselage,       "Tank (Non-HP Fuselage)"     },
+            { TankFuselageHP,     "Tank (HP Fuselage)"         },
+            { TankServiceModule,  "Tank (Service Module)"      },
+            { TankShieldedKey,    "Tank (Shielded)"            },
+            { TankCryogenic,      "Tank (Cryogenic)"           },
+            { TankOther,          "Tank (Other)"               },
+        };
         private bool _isToolingTempDisabled = false;
         private float _nextUpdate = 0f;
         private float _allTooledCost;
@@ -108,12 +150,12 @@ namespace RP0
             GUILayout.FlexibleSpace();
             GUILayout.EndHorizontal();
 
-            var grouped_list = GetGroupedToolingTypes().ToList();
-            TryAutoSwitchBucket(grouped_list);
+            List<KeyValuePair<string, List<string>>> groupedList = GetGroupedToolingTypesCached();
+            TryAutoSwitchBucket(groupedList);
 
             int counter = 0;
             GUILayout.BeginHorizontal();
-            foreach (var grouped in grouped_list)
+            foreach (KeyValuePair<string, List<string>> grouped in groupedList)
             {
                 if (counter % 3 == 0 && counter != 0)
                 {
@@ -207,38 +249,58 @@ namespace RP0
             return _currentToolingType == null ? UITab.Tooling : UITab.ToolingType;
         }
 
-        // Switches the current bucket to match whatever part has its PAW open, if that part's tank
-        // type maps to one of the buckets we know about. Only fires once per PAW target so a
-        // manual bucket pick survives until the user opens a different part's PAW.
-        private void TryAutoSwitchBucket(List<KeyValuePair<string, List<string>>> grouped_list)
+        /// <summary>
+        /// Switches the current bucket to match whatever part has its PAW open, if that part's tank
+        /// type maps to one of the buckets we know about. Only fires once per PAW target so a
+        /// manual bucket pick survives until the user opens a different part's PAW.
+        /// </summary>
+        private void TryAutoSwitchBucket(List<KeyValuePair<string, List<string>>> groupedList)
         {
-            var pawForAutoSwitch = ToolingPartResizer.PawTarget();
+            Part pawForAutoSwitch = ToolingPartResizer.PawTarget();
             if (pawForAutoSwitch == null) { _lastAutoSwitchPart = null; return; }
             if (pawForAutoSwitch == _lastAutoSwitchPart) return;
             _lastAutoSwitchPart = pawForAutoSwitch;
-            var pawType = ToolingPartResizer.CurrentTankType(pawForAutoSwitch);
+            string pawType = ToolingPartResizer.CurrentTankType(pawForAutoSwitch);
             if (string.IsNullOrEmpty(pawType)) return;
-            var bucketKey = GetGroupingKey(pawType);
-            var match = grouped_list.FirstOrDefault(g => g.Key == bucketKey);
+            string bucketKey = GetGroupingKey(pawType);
+            KeyValuePair<string, List<string>> match = groupedList.FirstOrDefault(g => g.Key == bucketKey);
             if (match.Value == null) return;
             _currentToolingType = bucketKey;
             _currentToolingTitle = GetGroupTitle(bucketKey);
             _currentUnderlyingTypes = match.Value;
         }
 
-        // Returns the ordered list of tooling-type buttons to show, paired with the DB keys each one covers.
-        // Avionics types are collapsed by category letter (all tech levels of "Avionics-N*" share one entry).
-        // Tank types are collapsed by construction (Stringer / Isogrid / Balloon / Fuselage / ServiceModule)
-        // so a player can search for an existing tooled diameter without picking material first. Non-tank,
-        // non-avionics types pass through unchanged.
-        private static IEnumerable<KeyValuePair<string, List<string>>> GetGroupedToolingTypes()
+        /// <summary>
+        /// Returns the cached grouped-tooling button list, rebuilding only when ToolingDatabase.Generation
+        /// changes. Both RenderToolingTab and RenderTypeTab call this every frame, so caching avoids
+        /// re-walking ToolingDatabase.toolings.Keys and re-allocating the group dictionary each pass.
+        /// </summary>
+        private List<KeyValuePair<string, List<string>>> GetGroupedToolingTypesCached()
+        {
+            int gen = ToolingDatabase.Generation;
+            if (_groupedCache == null || _groupedCacheGeneration != gen)
+            {
+                _groupedCache = GetGroupedToolingTypes();
+                _groupedCacheGeneration = gen;
+            }
+            return _groupedCache;
+        }
+
+        /// <summary>
+        /// Builds the ordered list of tooling-type buttons to show, paired with the DB keys each one covers.
+        /// Avionics types are collapsed by category letter (all tech levels of "Avionics-N*" share one entry).
+        /// Tank types are collapsed by construction (Conventional / Isogrid / Balloon / Fuselage / ServiceModule)
+        /// so a player can search for an existing tooled diameter without picking material first. Non-tank,
+        /// non-avionics types pass through unchanged.
+        /// </summary>
+        private static List<KeyValuePair<string, List<string>>> GetGroupedToolingTypes()
         {
             var groups = new Dictionary<string, List<string>>();
             var order = new List<string>();
             foreach (string type in ToolingDatabase.toolings.Keys)
             {
                 string key = GetGroupingKey(type);
-                if (!groups.TryGetValue(key, out var list))
+                if (!groups.TryGetValue(key, out List<string> list))
                 {
                     list = new List<string>();
                     groups[key] = list;
@@ -247,46 +309,25 @@ namespace RP0
                 list.Add(type);
             }
             order.Sort((a, b) => string.Compare(GetGroupTitle(a), GetGroupTitle(b), StringComparison.OrdinalIgnoreCase));
-            foreach (var key in order)
-                yield return new KeyValuePair<string, List<string>>(key, groups[key]);
+            var result = new List<KeyValuePair<string, List<string>>>(order.Count);
+            foreach (string key in order)
+                result.Add(new KeyValuePair<string, List<string>>(key, groups[key]));
+            return result;
         }
 
-        // Category keys for tank groupings. Prefix "Tank-" is reused so GetParametersForToolingType
-        // routes them to the diameter/length parameter set the same way bare "Tank-*" DB keys would.
-        // Conventional / Isogrid / Balloon / Fuselage each have a non-HP and an HP variant; ServiceModule
-        // and Shielded have no HP. HP buttons only appear when at least one underlying type matched.
-        private const string TankConventional   = "Tank-Conventional";
-        private const string TankConventionalHP = "Tank-ConventionalHP";
-        private const string TankIsogrid        = "Tank-Isogrid";
-        private const string TankIsogridHP     = "Tank-IsogridHP";
-        private const string TankBalloon        = "Tank-Balloon";
-        private const string TankBalloonHP      = "Tank-BalloonHP";
-        private const string TankFuselage       = "Tank-Fuselage";
-        private const string TankFuselageHP     = "Tank-FuselageHP";
-        private const string TankServiceModule  = "Tank-ServiceModule";
-        private const string TankShieldedKey    = "Tank-Shielded";
-        private const string TankCryogenic      = "Tank-Cryogenic";
-        private const string TankOther          = "Tank-Other";
-
-        private static readonly Dictionary<string, string> _groupTitles = new Dictionary<string, string>
-        {
-            { TankConventional,   "Conventional Tanks"    },
-            { TankConventionalHP, "HP Conventional Tanks" },
-            { TankIsogrid,        "Isogrid Tanks"         },
-            { TankIsogridHP,      "HP Isogrid Tanks"      },
-            { TankBalloon,        "Balloon Tanks"         },
-            { TankBalloonHP,      "HP Balloon Tanks"      },
-            { TankFuselage,       "Fuselage"              },
-            { TankFuselageHP,     "HP Fuselage"           },
-            { TankServiceModule,  "Service Modules"       },
-            { TankShieldedKey,    "Shielded Tanks"        },
-            { TankCryogenic,      "Cryogenic Tanks"       },
-            { TankOther,          "Other Tanks"           },
-        };
-
+        /// <summary>Resolves a grouping key to its button title, falling back to the DB title.</summary>
         private static string GetGroupTitle(string groupKey)
-            => _groupTitles.TryGetValue(groupKey, out var t) ? t : ToolingManager.Instance.GetTitleForTooling(groupKey);
+            => _groupTitles.TryGetValue(groupKey, out string t) ? t : ToolingManager.Instance.GetTitleForTooling(groupKey);
 
+        private static bool IsServiceModuleTank(string t) => t == "ServiceModule" || t.StartsWith("SM-");
+        private static bool IsShieldedTank(string t)      => t == "TankShielded";
+        private static bool IsCryoTank(string t)          => t == "Cryogenic" || t == "BalloonCryo";
+        private static bool IsIsogridTank(string t)       => t.StartsWith("Tank-Iso-");
+        private static bool IsBalloonTank(string t)       => t.StartsWith("Tank-Balloon-") || t == "Balloon";
+        private static bool IsFuselageTank(string t)      => t == "Fuselage";
+        private static bool IsConventionalTank(string t)  => t.StartsWith("Tank-Sep-");
+
+        /// <summary>Maps a raw tooling type to the category-bucket key its button belongs under.</summary>
         private static string GetGroupingKey(string toolingType)
         {
             string avionicsPrefix = ModuleToolingProcAvionics.MainToolingType + "-";
@@ -296,16 +337,15 @@ namespace RP0
             if (!IsTankTooling(toolingType)) return toolingType;
 
             // Single-bucket categories (no HP variants in the data).
-            if (toolingType == "ServiceModule" || toolingType.StartsWith("SM-")) return TankServiceModule;
-            if (toolingType == "TankShielded") return TankShieldedKey;
-            if (toolingType == "Cryogenic" || toolingType == "BalloonCryo") return TankCryogenic;
+            if (IsServiceModuleTank(toolingType)) return TankServiceModule;
+            if (IsShieldedTank(toolingType))      return TankShieldedKey;
+            if (IsCryoTank(toolingType))          return TankCryogenic;
 
             bool hp = toolingType.EndsWith("-HP");
-            if (toolingType.StartsWith("Tank-Iso-"))                          return hp ? TankIsogridHP  : TankIsogrid;
-            if (toolingType.StartsWith("Tank-Balloon-") || toolingType == "Balloon")
-                                                                              return hp ? TankBalloonHP  : TankBalloon;
-            if (toolingType == "Fuselage")                                    return hp ? TankFuselageHP : TankFuselage;
-            if (toolingType.StartsWith("Tank-Sep-"))                          return hp ? TankConventionalHP : TankConventional;
+            if (IsIsogridTank(toolingType))      return hp ? TankIsogridHP      : TankIsogrid;
+            if (IsBalloonTank(toolingType))      return hp ? TankBalloonHP      : TankBalloon;
+            if (IsFuselageTank(toolingType))     return hp ? TankFuselageHP     : TankFuselage;
+            if (IsConventionalTank(toolingType)) return hp ? TankConventionalHP : TankConventional;
             return TankOther;  // legacy RF types we don't know how to place: Default, ElectricPropulsion, etc.
         }
 
@@ -342,7 +382,7 @@ namespace RP0
             // Same auto-switch behaviour as RenderToolingTab: opening a PAW on a different tank
             // jumps into that tank's bucket. Needed here because the user is already inside a
             // bucket page (RenderToolingTab doesn't run), and otherwise the page is stuck.
-            TryAutoSwitchBucket(GetGroupedToolingTypes().ToList());
+            TryAutoSwitchBucket(GetGroupedToolingTypesCached());
 
             GUILayout.BeginHorizontal();
             GUILayout.FlexibleSpace();
@@ -581,7 +621,7 @@ namespace RP0
             }
             if (leaf?.Sources != null && leaf.Sources.Count > 0)
             {
-                var materials = leaf.Sources
+                IEnumerable<string> materials = leaf.Sources
                     .OrderBy(ExtractTrailingInt)
                     .ThenBy(MaterialLabel)
                     .Select(MaterialLabel);
@@ -597,7 +637,7 @@ namespace RP0
                 if (parameters.Length == 2)
                 {
                     GUILayout.FlexibleSpace();
-                    var prev = GUI.enabled;
+                    bool prev = GUI.enabled;
                     GUI.enabled = _rowRefitEnabled;
                     string tip;
                     string targetType = null;
@@ -608,7 +648,18 @@ namespace RP0
                     else
                     {
                         targetType = ToolingPartResizer.PickRfType(_rowPawTarget, leaf.Sources);
-                        tip = $"Refit {_rowPawTarget.partInfo?.title} to {targetType} at d={values[0]:F3}m, L={values[1]:F3}m";
+                        if (targetType == null)
+                        {
+                            // Bucket matches but the part can't accept any material this row is
+                            // tooled for (tech-locked or incompatible) -- refuse instead of forcing
+                            // an invalid tank type onto it.
+                            GUI.enabled = false;
+                            tip = $"{_rowPawTarget.partInfo?.title} can't use any material this tooling is for (tech-locked or incompatible).";
+                        }
+                        else
+                        {
+                            tip = $"Refit {_rowPawTarget.partInfo?.title} to {targetType} at d={values[0]:F3}m, L={values[1]:F3}m";
+                        }
                     }
                     if (GUILayout.Button(new GUIContent("Refit", tip), HighLogic.Skin.button, GUILayout.Width(60), GUILayout.Height(20)))
                         ToolingPartResizer.Resize(_rowPawTarget, values[0], values[1], targetType);
@@ -643,9 +694,9 @@ namespace RP0
         {
             if (sourceType.StartsWith("Tank-"))
             {
-                var rest = sourceType.Substring(5);
+                string rest = sourceType.Substring(5);
                 int dash = rest.IndexOf('-');
-                var material = dash >= 0 ? rest.Substring(dash + 1) : rest;
+                string material = dash >= 0 ? rest.Substring(dash + 1) : rest;
                 if (material.EndsWith("-HP")) material = material.Substring(0, material.Length - 3);
                 return material;
             }

--- a/Source/RP0/UI/ToolingGUI.cs
+++ b/Source/RP0/UI/ToolingGUI.cs
@@ -24,6 +24,23 @@ namespace RP0
         private string _currentToolingType;
         private string _currentToolingTitle;
         private List<string> _currentUnderlyingTypes;
+        // Last part we auto-switched the bucket on. Reset to null when no PAW is open or the user
+        // manually clicked a bucket button, so subsequent PAWs trigger the auto-switch again.
+        private Part _lastAutoSwitchPart;
+
+        // Per-frame cache of the Refit-button context, recomputed at the top of RenderTypeTab so
+        // DisplayRow doesn't redo PawTarget / GetModule<ModuleFuelTanks> / GetGroupingKey on every
+        // row x OnGUI pass. _rowRefitDisabledTip is non-null when the button is disabled (no PAW or
+        // wrong bucket) -- DisplayRow shows it instead of computing a per-row "Refit X to ..." tip.
+        private Part _rowPawTarget;
+        private bool _rowRefitEnabled;
+        private string _rowRefitDisabledTip;
+
+        // Cached merged-entries list for the current bucket. ToolingDatabase.Generation bumps on
+        // any tooling-DB mutation, so we recompute only when the DB or the bucket changes.
+        private string _mergedCacheKey;
+        private int _mergedCacheGeneration = -1;
+        private List<ToolingEntry> _mergedCache;
         private bool _isToolingTempDisabled = false;
         private float _nextUpdate = 0f;
         private float _allTooledCost;
@@ -91,9 +108,12 @@ namespace RP0
             GUILayout.FlexibleSpace();
             GUILayout.EndHorizontal();
 
+            var grouped_list = GetGroupedToolingTypes().ToList();
+            TryAutoSwitchBucket(grouped_list);
+
             int counter = 0;
             GUILayout.BeginHorizontal();
-            foreach (var grouped in GetGroupedToolingTypes())
+            foreach (var grouped in grouped_list)
             {
                 if (counter % 3 == 0 && counter != 0)
                 {
@@ -107,6 +127,8 @@ namespace RP0
                     _currentToolingType = grouped.Key;
                     _currentToolingTitle = title;
                     _currentUnderlyingTypes = grouped.Value;
+                    // Suppress auto-switch until the PAW target changes, so a manual pick sticks.
+                    _lastAutoSwitchPart = ToolingPartResizer.PawTarget();
                 }
             }
             GUILayout.EndHorizontal();
@@ -185,9 +207,28 @@ namespace RP0
             return _currentToolingType == null ? UITab.Tooling : UITab.ToolingType;
         }
 
+        // Switches the current bucket to match whatever part has its PAW open, if that part's tank
+        // type maps to one of the buckets we know about. Only fires once per PAW target so a
+        // manual bucket pick survives until the user opens a different part's PAW.
+        private void TryAutoSwitchBucket(List<KeyValuePair<string, List<string>>> grouped_list)
+        {
+            var pawForAutoSwitch = ToolingPartResizer.PawTarget();
+            if (pawForAutoSwitch == null) { _lastAutoSwitchPart = null; return; }
+            if (pawForAutoSwitch == _lastAutoSwitchPart) return;
+            _lastAutoSwitchPart = pawForAutoSwitch;
+            var pawType = ToolingPartResizer.CurrentTankType(pawForAutoSwitch);
+            if (string.IsNullOrEmpty(pawType)) return;
+            var bucketKey = GetGroupingKey(pawType);
+            var match = grouped_list.FirstOrDefault(g => g.Key == bucketKey);
+            if (match.Value == null) return;
+            _currentToolingType = bucketKey;
+            _currentToolingTitle = GetGroupTitle(bucketKey);
+            _currentUnderlyingTypes = match.Value;
+        }
+
         // Returns the ordered list of tooling-type buttons to show, paired with the DB keys each one covers.
         // Avionics types are collapsed by category letter (all tech levels of "Avionics-N*" share one entry).
-        // Tank types are collapsed by construction (Conventional / Isogrid / Balloon / Fuselage / ServiceModule)
+        // Tank types are collapsed by construction (Stringer / Isogrid / Balloon / Fuselage / ServiceModule)
         // so a player can search for an existing tooled diameter without picking material first. Non-tank,
         // non-avionics types pass through unchanged.
         private static IEnumerable<KeyValuePair<string, List<string>>> GetGroupedToolingTypes()
@@ -298,6 +339,11 @@ namespace RP0
 
         public void RenderTypeTab()
         {
+            // Same auto-switch behaviour as RenderToolingTab: opening a PAW on a different tank
+            // jumps into that tank's bucket. Needed here because the user is already inside a
+            // bucket page (RenderToolingTab doesn't run), and otherwise the page is stuck.
+            TryAutoSwitchBucket(GetGroupedToolingTypes().ToList());
+
             GUILayout.BeginHorizontal();
             GUILayout.FlexibleSpace();
             GUILayout.Label($"Toolings for type {_currentToolingTitle}", HighLogic.Skin.label);
@@ -306,24 +352,58 @@ namespace RP0
 
             Parameter[] parameters = Parameters.GetParametersForToolingType(_currentToolingType);
             DisplayTypeHeadings(parameters);
+            UpdateRowRefitContext();
             // Match the Untooled Parts list width above (3*80 + 312 + scrollbar padding) so the
             // tooling rows have room for the subcategory-prefixed badges ("Modular Booster Tank - Al").
             _toolingTypesScroll = GUILayout.BeginScrollView(_toolingTypesScroll, GUILayout.Width(572), GUILayout.Height(300));
             try
             {
-                // For grouped types (e.g. "Avionics-N") merge entries across all underlying tech-level keys.
-                // For pass-through types _currentUnderlyingTypes contains the single matching DB key.
-                var entries = _currentUnderlyingTypes != null
-                    ? ToolingDatabase.GetMergedEntries(_currentUnderlyingTypes)
-                    : ToolingDatabase.toolings[_currentToolingType];
                 var values = new float[parameters.Length];
-                DisplayRows(entries, 0, values, parameters);
+                DisplayRows(GetEntriesForCurrentBucket(), 0, values, parameters);
             }
             catch (Exception ex)
             {
                 Debug.LogException(ex);
             }
             GUILayout.EndScrollView();
+        }
+
+        // For grouped types (e.g. "Avionics-N") merge entries across all underlying tech-level keys.
+        // For pass-through types _currentUnderlyingTypes contains the single matching DB key.
+        // Cached per (bucket, ToolingDatabase.Generation): the merge is O(N*M*log M) work, and the
+        // result is invariant unless toolings is mutated.
+        private List<ToolingEntry> GetEntriesForCurrentBucket()
+        {
+            if (_currentUnderlyingTypes == null)
+                return ToolingDatabase.toolings[_currentToolingType];
+            int gen = ToolingDatabase.Generation;
+            if (_mergedCache == null || _mergedCacheKey != _currentToolingType || _mergedCacheGeneration != gen)
+            {
+                _mergedCache = ToolingDatabase.GetMergedEntries(_currentUnderlyingTypes);
+                _mergedCacheKey = _currentToolingType;
+                _mergedCacheGeneration = gen;
+            }
+            return _mergedCache;
+        }
+
+        // Resolves the PAW target, current RF tank type, and bucket-match check ONCE per frame so
+        // DisplayRow can read pre-computed state instead of re-walking UIPartActionController and
+        // Part.Modules per row.
+        private void UpdateRowRefitContext()
+        {
+            _rowPawTarget = ToolingPartResizer.PawTarget();
+            if (_rowPawTarget == null)
+            {
+                _rowRefitEnabled = false;
+                _rowRefitDisabledTip = "Open a part's PAW (right-click) to enable.";
+                return;
+            }
+            string currentType = ToolingPartResizer.CurrentTankType(_rowPawTarget);
+            bool bucketMatch = currentType != null && GetGroupingKey(currentType) == _currentToolingType;
+            _rowRefitEnabled = bucketMatch;
+            _rowRefitDisabledTip = bucketMatch
+                ? null
+                : $"{_rowPawTarget.partInfo?.title} is a {currentType ?? "non-tank"} part -- switch to its bucket to refit.";
         }
 
         private static void RenderToolAllButton()
@@ -506,6 +586,34 @@ namespace RP0
                     .ThenBy(MaterialLabel)
                     .Select(MaterialLabel);
                 GUILayout.Label($"  [{string.Join(", ", materials)}]", HighLogic.Skin.label);
+
+                // Refit button: writes these dims (and switches material if needed) to the part
+                // whose PAW is currently open. Disabled when the PAW's tank type belongs to a
+                // different bucket - refit only crosses materials within the same construction
+                // family (for a Tank-Sep-* part we don't want an Isogrid Tanks refit to apply).
+                // PAW target, current type, and bucket-match are resolved once per frame in
+                // UpdateRowRefitContext; only the per-row "Refit X to ..." tip and targetType need
+                // the row's leaf.Sources, and we skip both when the button is disabled.
+                if (parameters.Length == 2)
+                {
+                    GUILayout.FlexibleSpace();
+                    var prev = GUI.enabled;
+                    GUI.enabled = _rowRefitEnabled;
+                    string tip;
+                    string targetType = null;
+                    if (_rowRefitDisabledTip != null)
+                    {
+                        tip = _rowRefitDisabledTip;
+                    }
+                    else
+                    {
+                        targetType = ToolingPartResizer.PickRfType(_rowPawTarget, leaf.Sources);
+                        tip = $"Refit {_rowPawTarget.partInfo?.title} to {targetType} at d={values[0]:F3}m, L={values[1]:F3}m";
+                    }
+                    if (GUILayout.Button(new GUIContent("Refit", tip), HighLogic.Skin.button, GUILayout.Width(60), GUILayout.Height(20)))
+                        ToolingPartResizer.Resize(_rowPawTarget, values[0], values[1], targetType);
+                    GUI.enabled = prev;
+                }
             }
             GUILayout.EndHorizontal();
         }
@@ -527,7 +635,7 @@ namespace RP0
         // it ("Conventional Tanks", "Isogrid Tanks", ...). SM-* keeps its numeral suffix. Other
         // dashed keys (Avionics-N3) drop the prefix; bare names pass through.
         //   "Tank-Sep-Al"      -> "Al"
-        //   "Tank-Iso-AlCu-HP" -> "AlCu"   (HP redundant -- button title says HP)
+        //   "Tank-Iso-AlCu-HP" -> "AlCu"   (HP redundant — button title says HP)
         //   "SM-II"            -> "SM-II"  (bare numeral would be ambiguous)
         //   "Avionics-N3"      -> "N3"
         //   "Cryogenic"        -> "Cryogenic"

--- a/Source/RP0/UI/ToolingGUI.cs
+++ b/Source/RP0/UI/ToolingGUI.cs
@@ -4,6 +4,7 @@ using UnityEngine.EventSystems;
 using Smooth.Slinq;
 using RP0.Tooling;
 using System;
+using UniLinq;
 
 namespace RP0
 {
@@ -22,6 +23,7 @@ namespace RP0
 
         private string _currentToolingType;
         private string _currentToolingTitle;
+        private List<string> _currentUnderlyingTypes;
         private bool _isToolingTempDisabled = false;
         private float _nextUpdate = 0f;
         private float _allTooledCost;
@@ -82,6 +84,7 @@ namespace RP0
             }
 
             _currentToolingType = _currentToolingTitle = null;
+            _currentUnderlyingTypes = null;
             GUILayout.BeginHorizontal();
             GUILayout.FlexibleSpace();
             GUILayout.Label("Tooling Types", HighLogic.Skin.label);
@@ -90,7 +93,7 @@ namespace RP0
 
             int counter = 0;
             GUILayout.BeginHorizontal();
-            foreach (string type in ToolingDatabase.toolings.Keys)
+            foreach (var grouped in GetGroupedToolingTypes())
             {
                 if (counter % 3 == 0 && counter != 0)
                 {
@@ -98,11 +101,12 @@ namespace RP0
                     GUILayout.BeginHorizontal();
                 }
                 counter++;
-                string title = ToolingManager.Instance.GetTitleForTooling(type);
+                string title = GetGroupTitle(grouped.Key);
                 if (GUILayout.Button(title, HighLogic.Skin.button))
                 {
-                    _currentToolingType = type;
+                    _currentToolingType = grouped.Key;
                     _currentToolingTitle = title;
+                    _currentUnderlyingTypes = grouped.Value;
                 }
             }
             GUILayout.EndHorizontal();
@@ -181,6 +185,117 @@ namespace RP0
             return _currentToolingType == null ? UITab.Tooling : UITab.ToolingType;
         }
 
+        // Returns the ordered list of tooling-type buttons to show, paired with the DB keys each one covers.
+        // Avionics types are collapsed by category letter (all tech levels of "Avionics-N*" share one entry).
+        // Tank types are collapsed by construction (Conventional / Isogrid / Balloon / Fuselage / ServiceModule)
+        // so a player can search for an existing tooled diameter without picking material first. Non-tank,
+        // non-avionics types pass through unchanged.
+        private static IEnumerable<KeyValuePair<string, List<string>>> GetGroupedToolingTypes()
+        {
+            var groups = new Dictionary<string, List<string>>();
+            var order = new List<string>();
+            foreach (string type in ToolingDatabase.toolings.Keys)
+            {
+                string key = GetGroupingKey(type);
+                if (!groups.TryGetValue(key, out var list))
+                {
+                    list = new List<string>();
+                    groups[key] = list;
+                    order.Add(key);
+                }
+                list.Add(type);
+            }
+            order.Sort((a, b) => string.Compare(GetGroupTitle(a), GetGroupTitle(b), StringComparison.OrdinalIgnoreCase));
+            foreach (var key in order)
+                yield return new KeyValuePair<string, List<string>>(key, groups[key]);
+        }
+
+        // Category keys for tank groupings. Prefix "Tank-" is reused so GetParametersForToolingType
+        // routes them to the diameter/length parameter set the same way bare "Tank-*" DB keys would.
+        // Conventional / Isogrid / Balloon / Fuselage each have a non-HP and an HP variant; ServiceModule
+        // and Shielded have no HP. HP buttons only appear when at least one underlying type matched.
+        private const string TankConventional   = "Tank-Conventional";
+        private const string TankConventionalHP = "Tank-ConventionalHP";
+        private const string TankIsogrid        = "Tank-Isogrid";
+        private const string TankIsogridHP     = "Tank-IsogridHP";
+        private const string TankBalloon        = "Tank-Balloon";
+        private const string TankBalloonHP      = "Tank-BalloonHP";
+        private const string TankFuselage       = "Tank-Fuselage";
+        private const string TankFuselageHP     = "Tank-FuselageHP";
+        private const string TankServiceModule  = "Tank-ServiceModule";
+        private const string TankShieldedKey    = "Tank-Shielded";
+        private const string TankCryogenic      = "Tank-Cryogenic";
+        private const string TankOther          = "Tank-Other";
+
+        private static readonly Dictionary<string, string> _groupTitles = new Dictionary<string, string>
+        {
+            { TankConventional,   "Conventional Tanks"    },
+            { TankConventionalHP, "HP Conventional Tanks" },
+            { TankIsogrid,        "Isogrid Tanks"         },
+            { TankIsogridHP,      "HP Isogrid Tanks"      },
+            { TankBalloon,        "Balloon Tanks"         },
+            { TankBalloonHP,      "HP Balloon Tanks"      },
+            { TankFuselage,       "Fuselage"              },
+            { TankFuselageHP,     "HP Fuselage"           },
+            { TankServiceModule,  "Service Modules"       },
+            { TankShieldedKey,    "Shielded Tanks"        },
+            { TankCryogenic,      "Cryogenic Tanks"       },
+            { TankOther,          "Other Tanks"           },
+        };
+
+        private static string GetGroupTitle(string groupKey)
+            => _groupTitles.TryGetValue(groupKey, out var t) ? t : ToolingManager.Instance.GetTitleForTooling(groupKey);
+
+        private static string GetGroupingKey(string toolingType)
+        {
+            string avionicsPrefix = ModuleToolingProcAvionics.MainToolingType + "-";
+            if (toolingType.StartsWith(avionicsPrefix) && toolingType.Length > avionicsPrefix.Length)
+                return toolingType.Substring(0, avionicsPrefix.Length + 1);
+
+            if (!IsTankTooling(toolingType)) return toolingType;
+
+            // Single-bucket categories (no HP variants in the data).
+            if (toolingType == "ServiceModule" || toolingType.StartsWith("SM-")) return TankServiceModule;
+            if (toolingType == "TankShielded") return TankShieldedKey;
+            if (toolingType == "Cryogenic" || toolingType == "BalloonCryo") return TankCryogenic;
+
+            bool hp = toolingType.EndsWith("-HP");
+            if (toolingType.StartsWith("Tank-Iso-"))                          return hp ? TankIsogridHP  : TankIsogrid;
+            if (toolingType.StartsWith("Tank-Balloon-") || toolingType == "Balloon")
+                                                                              return hp ? TankBalloonHP  : TankBalloon;
+            if (toolingType == "Fuselage")                                    return hp ? TankFuselageHP : TankFuselage;
+            if (toolingType.StartsWith("Tank-Sep-"))                          return hp ? TankConventionalHP : TankConventional;
+            return TankOther;  // legacy RF types we don't know how to place: Default, ElectricPropulsion, etc.
+        }
+
+
+        // RF TANK_DEFINITION names that RP-1 patches (see GameData/RP-1/ProcCosts.cfg), plus the RP-1
+        // tank tooling families. Anything not in this set is treated as non-tank and passes through —
+        // matters when grouping the Conventional fallback so we don't sweep ProcAvionics /
+        // PayloadFairing / Structural / Battery / CrewTube etc. into it.
+        // NOTE: "Structural" is intentionally *not* in this list — it's the toolingType assigned to
+        // proceduralStructural / proceduralNoseCone / ROT-ModularCargoBay (and the legacy RF Structural
+        // tank type). It passes through to get its own button so structural-skin tooling is searchable
+        // without picking material first, the same way the tank categories work.
+        private static bool IsTankTooling(string toolingType)
+        {
+            if (toolingType.StartsWith("Tank-") || toolingType.StartsWith("SM-")) return true;
+            switch (toolingType)
+            {
+                case "Default":
+                case "Cryogenic":
+                case "Fuselage":
+                case "ServiceModule":
+                case "Balloon":
+                case "BalloonCryo":
+                case "ElectricPropulsion":
+                case "TankShielded":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         public void RenderTypeTab()
         {
             GUILayout.BeginHorizontal();
@@ -191,10 +306,16 @@ namespace RP0
 
             Parameter[] parameters = Parameters.GetParametersForToolingType(_currentToolingType);
             DisplayTypeHeadings(parameters);
-            _toolingTypesScroll = GUILayout.BeginScrollView(_toolingTypesScroll, GUILayout.Width(360), GUILayout.Height(300));
+            // Match the Untooled Parts list width above (3*80 + 312 + scrollbar padding) so the
+            // tooling rows have room for the subcategory-prefixed badges ("Modular Booster Tank - Al").
+            _toolingTypesScroll = GUILayout.BeginScrollView(_toolingTypesScroll, GUILayout.Width(572), GUILayout.Height(300));
             try
             {
-                var entries = ToolingDatabase.toolings[_currentToolingType];
+                // For grouped types (e.g. "Avionics-N") merge entries across all underlying tech-level keys.
+                // For pass-through types _currentUnderlyingTypes contains the single matching DB key.
+                var entries = _currentUnderlyingTypes != null
+                    ? ToolingDatabase.GetMergedEntries(_currentUnderlyingTypes)
+                    : ToolingDatabase.toolings[_currentToolingType];
                 var values = new float[parameters.Length];
                 DisplayRows(entries, 0, values, parameters);
             }
@@ -367,7 +488,7 @@ namespace RP0
             }
         }
 
-        private void DisplayRow(float[] values, Parameter[] parameters)
+        private void DisplayRow(float[] values, Parameter[] parameters, ToolingEntry leaf)
         {
             string toolingMargin = GetToolingMargin(values[0], parameters[0].Unit);
             GUILayout.BeginHorizontal();
@@ -378,23 +499,59 @@ namespace RP0
                 toolingMargin = GetToolingMargin(values[i], parameters[i].Unit);
                 GUILayout.Label(new GUIContent($"{values[i]:F3} {parameters[i].Unit}", toolingMargin), HighLogic.Skin.label, GUILayout.Width(80));
             }
+            if (leaf?.Sources != null && leaf.Sources.Count > 0)
+            {
+                var materials = leaf.Sources
+                    .OrderBy(ExtractTrailingInt)
+                    .ThenBy(MaterialLabel)
+                    .Select(MaterialLabel);
+                GUILayout.Label($"  [{string.Join(", ", materials)}]", HighLogic.Skin.label);
+            }
             GUILayout.EndHorizontal();
         }
 
         private void DisplayRows(List<ToolingEntry> entries, int parameterIndex, float[] values, Parameter[] parameters)
         {
             if (entries == null) return;
-            if (parameterIndex == parameters.Length)
-            {
-                DisplayRow(values, parameters);
-                return;
-            }
-
             foreach (var toolingEntry in entries)
             {
                 values[parameterIndex] = toolingEntry.Value;
-                DisplayRows(toolingEntry.Children, parameterIndex + 1, values, parameters);
+                if (parameterIndex + 1 == parameters.Length)
+                    DisplayRow(values, parameters, toolingEntry);
+                else
+                    DisplayRows(toolingEntry.Children, parameterIndex + 1, values, parameters);
             }
+        }
+
+        // Drops the construction segment from Tank-* keys since the bucket title already conveys
+        // it ("Conventional Tanks", "Isogrid Tanks", ...). SM-* keeps its numeral suffix. Other
+        // dashed keys (Avionics-N3) drop the prefix; bare names pass through.
+        //   "Tank-Sep-Al"      -> "Al"
+        //   "Tank-Iso-AlCu-HP" -> "AlCu"   (HP redundant -- button title says HP)
+        //   "SM-II"            -> "SM-II"  (bare numeral would be ambiguous)
+        //   "Avionics-N3"      -> "N3"
+        //   "Cryogenic"        -> "Cryogenic"
+        private static string MaterialLabel(string sourceType)
+        {
+            if (sourceType.StartsWith("Tank-"))
+            {
+                var rest = sourceType.Substring(5);
+                int dash = rest.IndexOf('-');
+                var material = dash >= 0 ? rest.Substring(dash + 1) : rest;
+                if (material.EndsWith("-HP")) material = material.Substring(0, material.Length - 3);
+                return material;
+            }
+            if (sourceType.StartsWith("SM-")) return sourceType;
+            int dashG = sourceType.IndexOf('-');
+            return dashG >= 0 ? sourceType.Substring(dashG + 1) : sourceType;
+        }
+
+        // Pulls the trailing integer off a key so "Avionics-N3" sorts before "Avionics-N10".
+        private static int ExtractTrailingInt(string s)
+        {
+            int i = s.Length;
+            while (i > 0 && char.IsDigit(s[i - 1])) i--;
+            return i < s.Length && int.TryParse(s.Substring(i), out int n) ? n : 0;
         }
     }
 }

--- a/Source/RP0/UI/ToolingGUI.cs
+++ b/Source/RP0/UI/ToolingGUI.cs
@@ -50,14 +50,13 @@ namespace RP0
 
         // Category keys for tank groupings. Prefix "Tank-" is reused so GetParametersForToolingType
         // routes them to the diameter/length parameter set the same way bare "Tank-*" DB keys would.
-        // Conventional / Isogrid / Balloon / Fuselage each have a non-HP and an HP variant; ServiceModule
+        // Conventional / Isogrid / Fuselage each have a non-HP and an HP variant; Balloon, ServiceModule
         // and Shielded have no HP. HP buttons only appear when at least one underlying type matched.
         private const string TankConventional   = "Tank-Conventional";
         private const string TankConventionalHP = "Tank-ConventionalHP";
         private const string TankIsogrid        = "Tank-Isogrid";
         private const string TankIsogridHP      = "Tank-IsogridHP";
         private const string TankBalloon        = "Tank-Balloon";
-        private const string TankBalloonHP      = "Tank-BalloonHP";
         private const string TankFuselage       = "Tank-Fuselage";
         private const string TankFuselageHP     = "Tank-FuselageHP";
         private const string TankServiceModule  = "Tank-ServiceModule";
@@ -74,8 +73,7 @@ namespace RP0
             { TankConventionalHP, "Tank (HP Conventional)"     },
             { TankIsogrid,        "Tank (Non-HP Isogrid)"      },
             { TankIsogridHP,      "Tank (HP Isogrid)"          },
-            { TankBalloon,        "Tank (Non-HP Balloon)"      },
-            { TankBalloonHP,      "Tank (HP Balloon)"          },
+            { TankBalloon,        "Tank (Balloon)"             },
             { TankFuselage,       "Tank (Non-HP Fuselage)"     },
             { TankFuselageHP,     "Tank (HP Fuselage)"         },
             { TankServiceModule,  "Tank (Service Module)"      },
@@ -340,10 +338,10 @@ namespace RP0
             if (IsServiceModuleTank(toolingType)) return TankServiceModule;
             if (IsShieldedTank(toolingType))      return TankShieldedKey;
             if (IsCryoTank(toolingType))          return TankCryogenic;
+            if (IsBalloonTank(toolingType))       return TankBalloon;
 
             bool hp = toolingType.EndsWith("-HP");
             if (IsIsogridTank(toolingType))      return hp ? TankIsogridHP      : TankIsogrid;
-            if (IsBalloonTank(toolingType))      return hp ? TankBalloonHP      : TankBalloon;
             if (IsFuselageTank(toolingType))     return hp ? TankFuselageHP     : TankFuselage;
             if (IsConventionalTank(toolingType)) return hp ? TankConventionalHP : TankConventional;
             return TankOther;  // legacy RF types we don't know how to place: Default, ElectricPropulsion, etc.

--- a/Source/RP0/UI/ToolingPartResizer.cs
+++ b/Source/RP0/UI/ToolingPartResizer.cs
@@ -44,73 +44,127 @@ namespace RP0
         /// <summary>
         /// Picks an RF tank type to apply when refitting, or null when none of the row's materials
         /// can be applied to this part. Prefers the part's current type if it's already one of the
-        /// row's materials (no switch needed); otherwise the first material the part actually
-        /// advertises as available (per ModuleFuelTanks.typesAvailable). Never falls back to a
-        /// material the part can't accept -- forcing a tech-locked or incompatible type would leave
-        /// the tank in an invalid state. The caller disables Refit and explains why when this is null.
+        /// row's materials (no switch needed); otherwise the first material the part can switch to
+        /// right now -- one it lists in typesAvailable whose RF type-upgrade is either absent or
+        /// already purchased. Never returns a tech-locked material (one whose upgrade isn't bought):
+        /// that mirrors ModuleFuelTanks.Validate and avoids leaving the tank in a locked state. The
+        /// caller disables Refit and explains why when this is null.
         /// </summary>
         public static string PickRfType(Part p, IEnumerable<string> sources)
         {
             if (p == null || sources == null) return null;
             ModuleFuelTanks rf = p.Modules.GetModule<ModuleFuelTanks>();
+            if (rf == null) return null;
             IList<string> srcList = sources as IList<string> ?? sources.ToList();
             if (srcList.Count == 0) return null;
-            if (rf?.type != null)
+            if (rf.type != null)
             {
                 foreach (string s in srcList) if (string.Equals(s, rf.type, StringComparison.Ordinal)) return rf.type;
             }
-            // Only switch to a material the part advertises as available. If we can't read the
-            // available list, or none of the row's materials are in it, refuse rather than guess.
-            string[] available = (rf?.typesAvailable as IEnumerable<string>)?.ToArray();
-            if (available != null)
+            // typesAvailable is a List<TankDefinition>; it can include locked types (preview mode),
+            // so test each candidate's upgrade state rather than trusting membership alone.
+            List<TankDefinition> available = rf.typesAvailable;
+            if (available == null) return null;
+            foreach (string s in srcList)
             {
-                foreach (string s in srcList)
-                    if (Array.IndexOf(available, s) >= 0) return s;
+                TankDefinition def = available.FirstOrDefault(t => string.Equals(t.name, s, StringComparison.Ordinal));
+                if (def != null && IsTypeUnlocked(rf, def.name)) return s;
             }
             return null;
         }
 
+        // True when the part can switch to this tank type without buying anything: either the type
+        // carries no RF type-upgrade, or that upgrade is already purchased.
+        private static bool IsTypeUnlocked(ModuleFuelTanks rf, string typeName)
+        {
+            PartUpgradeHandler.Upgrade up = ModuleFuelTanks.GetUpgradeForType(rf, typeName);
+            return up == null || PartUpgradeManager.Handler.IsUnlocked(up.name);
+        }
+
         /// <summary>
-        /// Writes (diameter, length) to the part, optionally switching its RF tank type first.
-        /// Posts a screen message describing the outcome; failures are logged and surfaced, not thrown.
+        /// Writes (diameter, length) to the part and all its symmetry counterparts, optionally
+        /// switching their RF tank type first. Dimension changes go through the procedural module's
+        /// own field-changed handler -- the same path the PAW sliders use -- which rebuilds geometry,
+        /// repositions attach nodes and attached parts, and already walks the symmetry group itself,
+        /// so it's fired once on the master. Posts a single screen message; failures are logged and
+        /// surfaced, not thrown. If the shape can't be refit (e.g. a truss), the reason is posted and
+        /// no success message is shown.
         /// </summary>
         public static void Resize(Part p, float diameter, float length, string targetRfType = null)
         {
             if (p == null) { Msg("No part PAW open."); return; }
             try
             {
-                bool typeChanged = false;
-                if (!string.IsNullOrEmpty(targetRfType))
-                {
-                    ModuleFuelTanks rf = p.Modules.GetModule<ModuleFuelTanks>();
-                    if (rf != null && !string.Equals(rf.type, targetRfType, StringComparison.Ordinal))
-                    {
-                        ApplyRfTankType(rf, targetRfType);
-                        typeChanged = true;
-                    }
-                }
-                Apply(p, diameter, length);
+                // RF tank type isn't a slider-driven dimension and our reflection write doesn't mirror
+                // across symmetry, so switch it on the master and every counterpart explicitly.
+                bool typeChanged = ApplyRfTypeToGroup(p, targetRfType);
+
+                if (!ApplyGeometry(p, diameter, length))
+                    return;   // shape couldn't be refit -- ApplyGeometry already said why
+
+                GameEvents.onEditorShipModified.Fire(EditorLogic.fetch?.ship);
+
+                // The open PAW caches its slider text; our programmatic field writes don't invalidate
+                // it, so the displayed value goes stale even though the underlying value is correct
+                // (increment/decrement operate on the new value). Force the part's PAW to rebuild its
+                // field displays, the same way ProceduralParts does after a shape change.
+                MonoUtilities.RefreshPartContextWindow(p);
+
+                int count = 1 + CountCounterparts(p);
+                string scope = count > 1 ? $" (x{count})" : "";
                 Msg(typeChanged
-                    ? $"Refit {p.partInfo?.title} to {targetRfType} at d={diameter:F3}m, L={length:F3}m"
-                    : $"Resized {p.partInfo?.title} to d={diameter:F3}m, L={length:F3}m");
+                    ? $"Refit {p.partInfo?.title} to {targetRfType} at d={diameter:F3}m, L={length:F3}m{scope}"
+                    : $"Resized {p.partInfo?.title} to d={diameter:F3}m, L={length:F3}m{scope}");
             }
             catch (Exception ex) { Debug.LogError("[RP0 Tooling] resize failed: " + ex); Msg("Resize failed: " + ex.Message); }
         }
 
-        /// <summary>Dispatches the dimension write to whichever procedural module the part carries.</summary>
-        private static void Apply(Part p, float diameter, float length)
+        private static int CountCounterparts(Part p)
+        {
+            List<Part> cp = p.symmetryCounterparts;
+            if (cp == null) return 0;
+            int n = 0;
+            for (int i = 0; i < cp.Count; i++) if (cp[i] != null && cp[i] != p) n++;
+            return n;
+        }
+
+        /// <summary>
+        /// Switches the RF tank type on the part and each symmetry counterpart. Returns whether the
+        /// master part's type actually changed (drives the success-message wording).
+        /// </summary>
+        private static bool ApplyRfTypeToGroup(Part p, string targetRfType)
+        {
+            if (string.IsNullOrEmpty(targetRfType)) return false;
+            bool masterChanged = ApplyRfTypeToPart(p, targetRfType);
+            List<Part> counterparts = p.symmetryCounterparts;
+            if (counterparts != null)
+                for (int i = 0; i < counterparts.Count; i++)
+                {
+                    Part c = counterparts[i];
+                    if (c != null && c != p) ApplyRfTypeToPart(c, targetRfType);
+                }
+            return masterChanged;
+        }
+
+        private static bool ApplyRfTypeToPart(Part p, string targetRfType)
+        {
+            ModuleFuelTanks rf = p.Modules.GetModule<ModuleFuelTanks>();
+            if (rf == null || string.Equals(rf.type, targetRfType, StringComparison.Ordinal)) return false;
+            ApplyRfTankType(rf, targetRfType);
+            return true;
+        }
+
+        /// <summary>
+        /// Dispatches the dimension write to whichever procedural module the part carries. Returns
+        /// false when the part has no ROTank/ProceduralPart to drive or the shape isn't refittable.
+        /// </summary>
+        private static bool ApplyGeometry(Part p, float diameter, float length)
         {
             PartModule roTank = p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == "ModuleROTank");
-            if (roTank != null)
-            {
-                ApplyRoTank(roTank, diameter, length);
-            }
-            else
-            {
-                PartModule procPart = p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == "ProceduralPart");
-                if (procPart != null) ApplyProcShape(p, procPart, diameter, length);
-            }
-            GameEvents.onEditorShipModified.Fire(EditorLogic.fetch?.ship);
+            if (roTank != null) { ApplyRoTank(p, roTank, diameter, length); return true; }
+            PartModule procPart = p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == "ProceduralPart");
+            if (procPart != null) return ApplyProcShape(p, procPart, diameter, length);
+            return false;
         }
 
         /// <summary>Sets the RF tank type field (via reflection) and nudges RF to re-resolve it.</summary>
@@ -131,43 +185,65 @@ namespace RP0
         }
 
         /// <summary>
-        /// ROTanks geometry is driven by two editable knobs: currentDiameter (cross-section) and
-        /// currentVScale (vertical stretch). totalTankLength / largestDiameter are computed outputs.
-        /// ROT meshes scale uniformly with diameter, so a fixed vScale gives a length proportional
-        /// to diameter: totalTankLength = aspect * currentDiameter * currentVScale. We measure aspect
-        /// from the current state BEFORE mutating anything and invert it to find the vScale that
-        /// yields the target length at the target diameter.
+        /// ROTanks expose currentDiameter for the cross-section, and drive length two different ways:
+        /// in lengthWidth mode the editable knob is currentLength (currentVScale is hidden), otherwise
+        /// it's currentVScale. totalTankLength is a computed output. We set the diameter first (so the
+        /// tank rebuilds and totalTankLength reflects the new diameter), then drive whichever length
+        /// control is active to hit the target totalTankLength. All writes go through the field-changed
+        /// handlers, which reposition attachments and walk the symmetry group.
         /// </summary>
-        private static void ApplyRoTank(PartModule roTank, float diameter, float length)
+        private static void ApplyRoTank(Part p, PartModule roTank, float diameter, float length)
         {
-            float curD        = GetFloat(roTank, "currentDiameter");
-            float curVScale   = GetFloat(roTank, "currentVScale");
-            float curTotalLen = GetFloat(roTank, "totalTankLength");
-            float aspect = (curD > 0f && curVScale > 0f && curTotalLen > 0f)
-                ? curTotalLen / (curD * curVScale)
-                : 1f;
-            float newVScale = (aspect > 0f && diameter > 0f) ? length / (aspect * diameter) : 1f;
+            ChangeDimension(p, roTank, "currentDiameter", diameter);
 
-            SetField(roTank, "currentDiameter", diameter);
-            SetField(roTank, "largestDiameter", diameter);
-            SetField(roTank, "currentVScale", newVScale);
-            SetField(roTank, "totalTankLength", length);
+            if (GetBool(roTank, "lengthWidth"))
+            {
+                // totalTankLength = currentLength + a fixed offset (end caps minus dome) that doesn't
+                // depend on currentLength, so measure it at the new diameter and back-solve.
+                float offset = GetFloat(roTank, "totalTankLength") - GetFloat(roTank, "currentLength");
+                ChangeDimension(p, roTank, "currentLength", length - offset);
+            }
+            else
+            {
+                // Length is driven by currentVScale; totalTankLength scales ~linearly with it.
+                float totalLen = GetFloat(roTank, "totalTankLength");
+                float curVScale = GetFloat(roTank, "currentVScale");
+                if (totalLen > 0f && curVScale > 0f)
+                    ChangeDimension(p, roTank, "currentVScale", curVScale * length / totalLen);
+            }
         }
 
-        /// <summary>Writes diameter/length onto the active ProceduralPart shape and forces a rebuild.</summary>
-        private static void ApplyProcShape(Part p, PartModule procPart, float diameter, float length)
+        /// <summary>
+        /// Writes diameter/length onto the active ProceduralPart shape. The target fields mirror
+        /// ModuleToolingPTank.GetDimensions so we set exactly what tooling reads back: "length", and
+        /// the diameter field for this shape class -- "diameter" for plain shapes, "outerDiameter"
+        /// for hollow ones, and top/bottom (set equal) for cones so the tooled diameter (max of the
+        /// two) lands on the requested value. Truss shapes use an unrelated realLength/rodDiameter
+        /// model and are skipped.
+        /// </summary>
+        private static bool ApplyProcShape(Part p, PartModule procPart, float diameter, float length)
         {
             string shapeName = (string)procPart.Fields["shapeName"]?.GetValue(procPart);
+            if (string.IsNullOrEmpty(shapeName)) return false;
+            if (shapeName.Contains("Truss")) { Msg($"Refit doesn't support {shapeName} shapes."); return false; }
+
             PartModule shape = ShapeForName(p, shapeName);
-            if (shape == null) return;
-            SetField(shape, "length", length);
-            SetField(shape, "diameter", diameter);
-            SetField(shape, "topDiameter", diameter);
-            SetField(shape, "bottomDiameter", diameter);
-            // ProceduralShape rebuilds via Update() polling old vs current; calling UpdateShape()
-            // nudges it now instead of waiting for next frame.
-            TryInvoke(shape, "UpdateShape", new object[] { true });
-            TryInvoke(procPart, "UpdateShape", new object[] { true });
+            if (shape == null) return false;
+
+            bool isCone = shapeName.Contains("Cone");
+            bool isHollow = shapeName.Contains("Hollow");
+
+            ChangeDimension(p, shape, "length", length);
+            if (isCone)
+            {
+                ChangeDimension(p, shape, isHollow ? "topOuterDiameter" : "topDiameter", diameter);
+                ChangeDimension(p, shape, isHollow ? "bottomOuterDiameter" : "bottomDiameter", diameter);
+            }
+            else
+            {
+                ChangeDimension(p, shape, isHollow ? "outerDiameter" : "diameter", diameter);
+            }
+            return true;
         }
 
         /// <summary>Resolves the ProceduralShape* PartModule that matches the part's current shape name.</summary>
@@ -189,24 +265,47 @@ namespace RP0
         }
 
         /// <summary>
-        /// BaseField.SetValue writes the underlying field, but some KSP versions don't fire the
-        /// UI_Control.onFieldChanged callback that shape modules listen on; fire it explicitly with
-        /// the prior value so the shape rebuilds even when there's no PAW interaction.
+        /// Drives one editable dimension field the way a PAW slider does: writes the value on the
+        /// master module, mirrors it onto the same module on every symmetry counterpart (so their
+        /// geometry rebuilds to the new size), then fires the master field's onFieldChanged once with
+        /// the prior value. That handler (ProceduralParts' OnShapeDimensionChanged, ROTank's
+        /// OnDiameterChanged, ...) rebuilds the mesh, repositions attach nodes, pushes attached parts,
+        /// and already walks the symmetry group -- so it must NOT be invoked per counterpart, or
+        /// attachments get translated multiple times and parts drift.
         /// </summary>
-        private static void SetField(PartModule m, string name, float value)
+        private static void ChangeDimension(Part masterPart, PartModule masterModule, string fieldName, float value)
         {
-            BaseField f = m.Fields[name];
-            if (f == null) return;
-            object before = null;
-            try { before = f.GetValue(m); }
-            catch (Exception ex) { Debug.LogWarning($"[RP0 Tooling] SetField could not read '{name}' on {m.moduleName}: {ex.Message}"); }
-            try
+            BaseField mf = masterModule.Fields[fieldName];
+            if (mf == null) return;
+            object oldValue;
+            try { oldValue = mf.GetValue(masterModule); }
+            catch (Exception ex)
             {
-                f.SetValue(value, m);
-                try { f.uiControlEditor?.onFieldChanged?.Invoke(f, before); }
-                catch (Exception ex) { Debug.LogWarning($"[RP0 Tooling] SetField onFieldChanged callback for '{name}' on {m.moduleName} threw: {ex.Message}"); }
+                Debug.LogWarning($"[RP0 Tooling] ChangeDimension could not read '{fieldName}' on {masterModule.moduleName}: {ex.Message}");
+                return;
             }
-            catch (Exception ex) { Debug.LogWarning($"[RP0 Tooling] SetField could not write '{name}' on {m.moduleName}: {ex.Message}"); }
+
+            SetFieldValue(masterModule, mf, value);
+
+            List<Part> counterparts = masterPart.symmetryCounterparts;
+            if (counterparts != null)
+                for (int i = 0; i < counterparts.Count; i++)
+                {
+                    Part c = counterparts[i];
+                    if (c == null || c == masterPart) continue;
+                    PartModule cm = c.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == masterModule.moduleName);
+                    BaseField cf = cm?.Fields[fieldName];
+                    if (cf != null) SetFieldValue(cm, cf, value);
+                }
+
+            try { mf.uiControlEditor?.onFieldChanged?.Invoke(mf, oldValue); }
+            catch (Exception ex) { Debug.LogWarning($"[RP0 Tooling] onFieldChanged for '{fieldName}' on {masterModule.moduleName} threw: {ex.Message}"); }
+        }
+
+        private static void SetFieldValue(PartModule m, BaseField f, float value)
+        {
+            try { f.SetValue(value, m); }
+            catch (Exception ex) { Debug.LogWarning($"[RP0 Tooling] could not write '{f.name}' on {m.moduleName}: {ex.Message}"); }
         }
 
         /// <summary>Reads a float-valued BaseField via reflection, returning 0 if it's absent or unreadable.</summary>
@@ -223,6 +322,21 @@ namespace RP0
             {
                 Debug.LogWarning($"[RP0 Tooling] GetFloat could not read '{name}' on {m.moduleName}: {ex.Message}");
                 return 0f;
+            }
+        }
+
+        /// <summary>Reads a bool-valued BaseField via reflection, returning false if absent or unreadable.</summary>
+        private static bool GetBool(PartModule m, string name)
+        {
+            try
+            {
+                BaseField f = m.Fields[name];
+                return f != null && f.GetValue(m) is bool b && b;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[RP0 Tooling] GetBool could not read '{name}' on {m.moduleName}: {ex.Message}");
+                return false;
             }
         }
 

--- a/Source/RP0/UI/ToolingPartResizer.cs
+++ b/Source/RP0/UI/ToolingPartResizer.cs
@@ -15,16 +15,18 @@ namespace RP0
     // tool just snaps its dims to a tooled value.
     internal static class ToolingPartResizer
     {
-        // Resolves the part whose PAW is currently visible. Returns null when nothing's open, or
-        // when multiple PAWs are up (ambiguous which one the player means).
+        /// <summary>
+        /// Resolves the part whose PAW is currently visible. Returns null when nothing's open, or
+        /// when multiple PAWs are up (ambiguous which one the player means).
+        /// </summary>
         public static Part PawTarget()
         {
-            var windows = UIPartActionController.Instance?.windows;
+            List<UIPartActionWindow> windows = UIPartActionController.Instance?.windows;
             if (windows == null) return null;
             Part candidate = null;
             for (int i = 0; i < windows.Count; i++)
             {
-                var w = windows[i];
+                UIPartActionWindow w = windows[i];
                 if (w == null || w.part == null) continue;
                 if (candidate != null) return null;        // 2+ PAWs -> ambiguous
                 candidate = w.part;
@@ -32,38 +34,46 @@ namespace RP0
             return candidate;
         }
 
-        // Returns the part's current RF tank type if it has a ModuleFuelTanks, else null.
+        /// <summary>Returns the part's current RF tank type if it has a ModuleFuelTanks, else null.</summary>
         public static string CurrentTankType(Part p)
         {
             if (p == null) return null;
             return p.Modules.GetModule<ModuleFuelTanks>()?.type;
         }
 
-        // Picks an RF tank type to apply when refitting: prefer the part's current type if it's
-        // already in the row's source list (no change needed), otherwise the first source in the
-        // list that the part can actually accept (per ModuleFuelTanks.typesAvailable), and finally
-        // just the first source if we can't see the available list.
+        /// <summary>
+        /// Picks an RF tank type to apply when refitting, or null when none of the row's materials
+        /// can be applied to this part. Prefers the part's current type if it's already one of the
+        /// row's materials (no switch needed); otherwise the first material the part actually
+        /// advertises as available (per ModuleFuelTanks.typesAvailable). Never falls back to a
+        /// material the part can't accept -- forcing a tech-locked or incompatible type would leave
+        /// the tank in an invalid state. The caller disables Refit and explains why when this is null.
+        /// </summary>
         public static string PickRfType(Part p, IEnumerable<string> sources)
         {
             if (p == null || sources == null) return null;
-            var rf = p.Modules.GetModule<ModuleFuelTanks>();
-            var srcList = sources as IList<string> ?? sources.ToList();
+            ModuleFuelTanks rf = p.Modules.GetModule<ModuleFuelTanks>();
+            IList<string> srcList = sources as IList<string> ?? sources.ToList();
             if (srcList.Count == 0) return null;
             if (rf?.type != null)
             {
-                foreach (var s in srcList) if (string.Equals(s, rf.type, StringComparison.Ordinal)) return rf.type;
+                foreach (string s in srcList) if (string.Equals(s, rf.type, StringComparison.Ordinal)) return rf.type;
             }
-            // Try to honour the part's typesAvailable so we don't pick a material that won't apply.
-            string[] available = null;
-            try { available = (rf?.typesAvailable as IEnumerable<string>)?.ToArray(); } catch { }
-            if (available != null && available.Length > 0)
+            // Only switch to a material the part advertises as available. If we can't read the
+            // available list, or none of the row's materials are in it, refuse rather than guess.
+            string[] available = (rf?.typesAvailable as IEnumerable<string>)?.ToArray();
+            if (available != null)
             {
-                foreach (var s in srcList)
+                foreach (string s in srcList)
                     if (Array.IndexOf(available, s) >= 0) return s;
             }
-            return srcList[0];
+            return null;
         }
 
+        /// <summary>
+        /// Writes (diameter, length) to the part, optionally switching its RF tank type first.
+        /// Posts a screen message describing the outcome; failures are logged and surfaced, not thrown.
+        /// </summary>
         public static void Resize(Part p, float diameter, float length, string targetRfType = null)
         {
             if (p == null) { Msg("No part PAW open."); return; }
@@ -72,7 +82,7 @@ namespace RP0
                 bool typeChanged = false;
                 if (!string.IsNullOrEmpty(targetRfType))
                 {
-                    var rf = p.Modules.GetModule<ModuleFuelTanks>();
+                    ModuleFuelTanks rf = p.Modules.GetModule<ModuleFuelTanks>();
                     if (rf != null && !string.Equals(rf.type, targetRfType, StringComparison.Ordinal))
                     {
                         ApplyRfTankType(rf, targetRfType);
@@ -87,28 +97,30 @@ namespace RP0
             catch (Exception ex) { Debug.LogError("[RP0 Tooling] resize failed: " + ex); Msg("Resize failed: " + ex.Message); }
         }
 
-        static void Apply(Part p, float diameter, float length)
+        /// <summary>Dispatches the dimension write to whichever procedural module the part carries.</summary>
+        private static void Apply(Part p, float diameter, float length)
         {
-            var roTank = p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == "ModuleROTank");
+            PartModule roTank = p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == "ModuleROTank");
             if (roTank != null)
             {
                 ApplyRoTank(roTank, diameter, length);
             }
             else
             {
-                var procPart = p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == "ProceduralPart");
+                PartModule procPart = p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == "ProceduralPart");
                 if (procPart != null) ApplyProcShape(p, procPart, diameter, length);
             }
             GameEvents.onEditorShipModified.Fire(EditorLogic.fetch?.ship);
         }
 
-        static void ApplyRfTankType(ModuleFuelTanks rfTank, string rfType)
+        /// <summary>Sets the RF tank type field (via reflection) and nudges RF to re-resolve it.</summary>
+        private static void ApplyRfTankType(ModuleFuelTanks rfTank, string rfType)
         {
-            var typeField = typeof(ModuleFuelTanks).GetField("type", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            FieldInfo typeField = typeof(ModuleFuelTanks).GetField("type", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             if (typeField != null) typeField.SetValue(rfTank, rfType);
             else
             {
-                var typeProp = typeof(ModuleFuelTanks).GetProperty("type", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                PropertyInfo typeProp = typeof(ModuleFuelTanks).GetProperty("type", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
                 typeProp?.SetValue(rfTank, rfType, null);
             }
             if (!TryInvoke(rfTank, "UpdateTankType", new object[] { false }) &&
@@ -118,14 +130,15 @@ namespace RP0
             }
         }
 
-        // ROTanks geometry is driven by two editable knobs: currentDiameter (cross-section) and
-        // currentVScale (vertical stretch). totalTankLength / largestDiameter are computed outputs.
-        // ROT meshes scale uniformly with diameter, so a fixed vScale gives a length proportional
-        // to diameter:
-        //   totalTankLength = aspect × currentDiameter × currentVScale
-        // We measure aspect from the current state BEFORE mutating anything and invert it to find
-        // the vScale that yields the target length at the target diameter.
-        static void ApplyRoTank(PartModule roTank, float diameter, float length)
+        /// <summary>
+        /// ROTanks geometry is driven by two editable knobs: currentDiameter (cross-section) and
+        /// currentVScale (vertical stretch). totalTankLength / largestDiameter are computed outputs.
+        /// ROT meshes scale uniformly with diameter, so a fixed vScale gives a length proportional
+        /// to diameter: totalTankLength = aspect * currentDiameter * currentVScale. We measure aspect
+        /// from the current state BEFORE mutating anything and invert it to find the vScale that
+        /// yields the target length at the target diameter.
+        /// </summary>
+        private static void ApplyRoTank(PartModule roTank, float diameter, float length)
         {
             float curD        = GetFloat(roTank, "currentDiameter");
             float curVScale   = GetFloat(roTank, "currentVScale");
@@ -141,10 +154,11 @@ namespace RP0
             SetField(roTank, "totalTankLength", length);
         }
 
-        static void ApplyProcShape(Part p, PartModule procPart, float diameter, float length)
+        /// <summary>Writes diameter/length onto the active ProceduralPart shape and forces a rebuild.</summary>
+        private static void ApplyProcShape(Part p, PartModule procPart, float diameter, float length)
         {
-            var shapeName = (string)procPart.Fields["shapeName"]?.GetValue(procPart);
-            var shape = ShapeForName(p, shapeName);
+            string shapeName = (string)procPart.Fields["shapeName"]?.GetValue(procPart);
+            PartModule shape = ShapeForName(p, shapeName);
             if (shape == null) return;
             SetField(shape, "length", length);
             SetField(shape, "diameter", diameter);
@@ -156,7 +170,8 @@ namespace RP0
             TryInvoke(procPart, "UpdateShape", new object[] { true });
         }
 
-        static PartModule ShapeForName(Part p, string shapeName)
+        /// <summary>Resolves the ProceduralShape* PartModule that matches the part's current shape name.</summary>
+        private static PartModule ShapeForName(Part p, string shapeName)
         {
             string moduleName = shapeName switch
             {
@@ -173,45 +188,63 @@ namespace RP0
             return p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == moduleName);
         }
 
-        // BaseField.SetValue writes the underlying field, but some KSP versions don't fire the
-        // UI_Control.onFieldChanged callback that shape modules listen on; fire it explicitly with
-        // the prior value so the shape rebuilds even when there's no PAW interaction.
-        static void SetField(PartModule m, string name, float value)
+        /// <summary>
+        /// BaseField.SetValue writes the underlying field, but some KSP versions don't fire the
+        /// UI_Control.onFieldChanged callback that shape modules listen on; fire it explicitly with
+        /// the prior value so the shape rebuilds even when there's no PAW interaction.
+        /// </summary>
+        private static void SetField(PartModule m, string name, float value)
         {
-            var f = m.Fields[name];
+            BaseField f = m.Fields[name];
             if (f == null) return;
-            object before = null; try { before = f.GetValue(m); } catch { }
+            object before = null;
+            try { before = f.GetValue(m); }
+            catch (Exception ex) { Debug.LogWarning($"[RP0 Tooling] SetField could not read '{name}' on {m.moduleName}: {ex.Message}"); }
             try
             {
                 f.SetValue(value, m);
-                try { f.uiControlEditor?.onFieldChanged?.Invoke(f, before); } catch { }
+                try { f.uiControlEditor?.onFieldChanged?.Invoke(f, before); }
+                catch (Exception ex) { Debug.LogWarning($"[RP0 Tooling] SetField onFieldChanged callback for '{name}' on {m.moduleName} threw: {ex.Message}"); }
             }
-            catch { }
+            catch (Exception ex) { Debug.LogWarning($"[RP0 Tooling] SetField could not write '{name}' on {m.moduleName}: {ex.Message}"); }
         }
 
-        static float GetFloat(PartModule m, string name)
+        /// <summary>Reads a float-valued BaseField via reflection, returning 0 if it's absent or unreadable.</summary>
+        private static float GetFloat(PartModule m, string name)
         {
             try
             {
-                var f = m.Fields[name];
+                BaseField f = m.Fields[name];
                 if (f == null) return 0f;
-                var v = f.GetValue(m);
+                object v = f.GetValue(m);
                 return v is float fv ? fv : Convert.ToSingle(v);
             }
-            catch { return 0f; }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[RP0 Tooling] GetFloat could not read '{name}' on {m.moduleName}: {ex.Message}");
+                return 0f;
+            }
         }
 
-        static bool TryInvoke(object o, string method, object[] args)
+        /// <summary>
+        /// Invokes a method by name + argument count via reflection. Returns false (and logs) when
+        /// the method is missing or the call throws, so callers can fall back to an alternate API.
+        /// </summary>
+        private static bool TryInvoke(object o, string method, object[] args)
         {
             int argCount = args?.Length ?? 0;
-            var mi = o.GetType()
+            MethodInfo mi = o.GetType()
                 .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                 .FirstOrDefault(m => m.Name == method && m.GetParameters().Length == argCount);
             if (mi == null) return false;
             try { mi.Invoke(o, args); return true; }
-            catch { return false; }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[RP0 Tooling] {method}({argCount} args) on {o.GetType().Name} threw: {ex.Message}");
+                return false;
+            }
         }
 
-        static void Msg(string s) => ScreenMessages.PostScreenMessage(new ScreenMessage(s, 4f, ScreenMessageStyle.UPPER_CENTER));
+        private static void Msg(string s) => ScreenMessages.PostScreenMessage(new ScreenMessage(s, 4f, ScreenMessageStyle.UPPER_CENTER));
     }
 }

--- a/Source/RP0/UI/ToolingPartResizer.cs
+++ b/Source/RP0/UI/ToolingPartResizer.cs
@@ -160,9 +160,9 @@ namespace RP0
         /// </summary>
         private static bool ApplyGeometry(Part p, float diameter, float length)
         {
-            PartModule roTank = p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == "ModuleROTank");
+            PartModule roTank = p.Modules.GetModule("ModuleROTank");
             if (roTank != null) { ApplyRoTank(p, roTank, diameter, length); return true; }
-            PartModule procPart = p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == "ProceduralPart");
+            PartModule procPart = p.Modules.GetModule("ProceduralPart");
             if (procPart != null) return ApplyProcShape(p, procPart, diameter, length);
             return false;
         }
@@ -261,7 +261,7 @@ namespace RP0
                 "Truss"                  => "ProceduralShapeHollowTruss",
                 _                        => "ProceduralShapeCylinder",
             };
-            return p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == moduleName);
+            return p.Modules.GetModule(moduleName);
         }
 
         /// <summary>
@@ -293,7 +293,7 @@ namespace RP0
                 {
                     Part c = counterparts[i];
                     if (c == null || c == masterPart) continue;
-                    PartModule cm = c.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == masterModule.moduleName);
+                    PartModule cm = c.Modules.GetModule(masterModule.moduleName);
                     BaseField cf = cm?.Fields[fieldName];
                     if (cf != null) SetFieldValue(cm, cf, value);
                 }

--- a/Source/RP0/UI/ToolingPartResizer.cs
+++ b/Source/RP0/UI/ToolingPartResizer.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+using RealFuels.Tanks;
+
+namespace RP0
+{
+    // "Resize" button on each tooled (diameter, length) row in ToolingGUI.DisplayRow: writes the
+    // dimensions to whatever part has its PAW open right now, *if* that part's RF tank type is one
+    // of the materials this row is tooled for. We don't try to spawn a new part — pre-RP-1 changes,
+    // ModuleToolingPTank emits the same ToolingType regardless of part class, so the DB has no way
+    // to tell us which part class an entry belongs to. The user picks the part in the editor; this
+    // tool just snaps its dims to a tooled value.
+    internal static class ToolingPartResizer
+    {
+        // Resolves the part whose PAW is currently visible. Returns null when nothing's open, or
+        // when multiple PAWs are up (ambiguous which one the player means).
+        public static Part PawTarget()
+        {
+            var windows = UIPartActionController.Instance?.windows;
+            if (windows == null) return null;
+            Part candidate = null;
+            for (int i = 0; i < windows.Count; i++)
+            {
+                var w = windows[i];
+                if (w == null || w.part == null) continue;
+                if (candidate != null) return null;        // 2+ PAWs -> ambiguous
+                candidate = w.part;
+            }
+            return candidate;
+        }
+
+        // Returns the part's current RF tank type if it has a ModuleFuelTanks, else null.
+        public static string CurrentTankType(Part p)
+        {
+            if (p == null) return null;
+            return p.Modules.GetModule<ModuleFuelTanks>()?.type;
+        }
+
+        // Picks an RF tank type to apply when refitting: prefer the part's current type if it's
+        // already in the row's source list (no change needed), otherwise the first source in the
+        // list that the part can actually accept (per ModuleFuelTanks.typesAvailable), and finally
+        // just the first source if we can't see the available list.
+        public static string PickRfType(Part p, IEnumerable<string> sources)
+        {
+            if (p == null || sources == null) return null;
+            var rf = p.Modules.GetModule<ModuleFuelTanks>();
+            var srcList = sources as IList<string> ?? sources.ToList();
+            if (srcList.Count == 0) return null;
+            if (rf?.type != null)
+            {
+                foreach (var s in srcList) if (string.Equals(s, rf.type, StringComparison.Ordinal)) return rf.type;
+            }
+            // Try to honour the part's typesAvailable so we don't pick a material that won't apply.
+            string[] available = null;
+            try { available = (rf?.typesAvailable as IEnumerable<string>)?.ToArray(); } catch { }
+            if (available != null && available.Length > 0)
+            {
+                foreach (var s in srcList)
+                    if (Array.IndexOf(available, s) >= 0) return s;
+            }
+            return srcList[0];
+        }
+
+        public static void Resize(Part p, float diameter, float length, string targetRfType = null)
+        {
+            if (p == null) { Msg("No part PAW open."); return; }
+            try
+            {
+                bool typeChanged = false;
+                if (!string.IsNullOrEmpty(targetRfType))
+                {
+                    var rf = p.Modules.GetModule<ModuleFuelTanks>();
+                    if (rf != null && !string.Equals(rf.type, targetRfType, StringComparison.Ordinal))
+                    {
+                        ApplyRfTankType(rf, targetRfType);
+                        typeChanged = true;
+                    }
+                }
+                Apply(p, diameter, length);
+                Msg(typeChanged
+                    ? $"Refit {p.partInfo?.title} to {targetRfType} at d={diameter:F3}m, L={length:F3}m"
+                    : $"Resized {p.partInfo?.title} to d={diameter:F3}m, L={length:F3}m");
+            }
+            catch (Exception ex) { Debug.LogError("[RP0 Tooling] resize failed: " + ex); Msg("Resize failed: " + ex.Message); }
+        }
+
+        static void Apply(Part p, float diameter, float length)
+        {
+            var roTank = p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == "ModuleROTank");
+            if (roTank != null)
+            {
+                ApplyRoTank(roTank, diameter, length);
+            }
+            else
+            {
+                var procPart = p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == "ProceduralPart");
+                if (procPart != null) ApplyProcShape(p, procPart, diameter, length);
+            }
+            GameEvents.onEditorShipModified.Fire(EditorLogic.fetch?.ship);
+        }
+
+        static void ApplyRfTankType(ModuleFuelTanks rfTank, string rfType)
+        {
+            var typeField = typeof(ModuleFuelTanks).GetField("type", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (typeField != null) typeField.SetValue(rfTank, rfType);
+            else
+            {
+                var typeProp = typeof(ModuleFuelTanks).GetProperty("type", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                typeProp?.SetValue(rfTank, rfType, null);
+            }
+            if (!TryInvoke(rfTank, "UpdateTankType", new object[] { false }) &&
+                !TryInvoke(rfTank, "UpdateTankType", null))
+            {
+                TryInvoke(rfTank, "ChangeTankType", new object[] { rfType });
+            }
+        }
+
+        // ROTanks geometry is driven by two editable knobs: currentDiameter (cross-section) and
+        // currentVScale (vertical stretch). totalTankLength / largestDiameter are computed outputs.
+        // ROT meshes scale uniformly with diameter, so a fixed vScale gives a length proportional
+        // to diameter:
+        //   totalTankLength = aspect × currentDiameter × currentVScale
+        // We measure aspect from the current state BEFORE mutating anything and invert it to find
+        // the vScale that yields the target length at the target diameter.
+        static void ApplyRoTank(PartModule roTank, float diameter, float length)
+        {
+            float curD        = GetFloat(roTank, "currentDiameter");
+            float curVScale   = GetFloat(roTank, "currentVScale");
+            float curTotalLen = GetFloat(roTank, "totalTankLength");
+            float aspect = (curD > 0f && curVScale > 0f && curTotalLen > 0f)
+                ? curTotalLen / (curD * curVScale)
+                : 1f;
+            float newVScale = (aspect > 0f && diameter > 0f) ? length / (aspect * diameter) : 1f;
+
+            SetField(roTank, "currentDiameter", diameter);
+            SetField(roTank, "largestDiameter", diameter);
+            SetField(roTank, "currentVScale", newVScale);
+            SetField(roTank, "totalTankLength", length);
+        }
+
+        static void ApplyProcShape(Part p, PartModule procPart, float diameter, float length)
+        {
+            var shapeName = (string)procPart.Fields["shapeName"]?.GetValue(procPart);
+            var shape = ShapeForName(p, shapeName);
+            if (shape == null) return;
+            SetField(shape, "length", length);
+            SetField(shape, "diameter", diameter);
+            SetField(shape, "topDiameter", diameter);
+            SetField(shape, "bottomDiameter", diameter);
+            // ProceduralShape rebuilds via Update() polling old vs current; calling UpdateShape()
+            // nudges it now instead of waiting for next frame.
+            TryInvoke(shape, "UpdateShape", new object[] { true });
+            TryInvoke(procPart, "UpdateShape", new object[] { true });
+        }
+
+        static PartModule ShapeForName(Part p, string shapeName)
+        {
+            string moduleName = shapeName switch
+            {
+                "Smooth Cone"            => "ProceduralShapeBezierCone",
+                "Cone"                   => "ProceduralShapeCone",
+                "Fillet Cylinder"        => "ProceduralShapePill",
+                "Polygon"                => "ProceduralShapePolygon",
+                "Hollow Cylinder"        => "ProceduralShapeHollowCylinder",
+                "Hollow Cone"            => "ProceduralShapeHollowCone",
+                "Hollow Fillet Cylinder" => "ProceduralShapeHollowPill",
+                "Truss"                  => "ProceduralShapeHollowTruss",
+                _                        => "ProceduralShapeCylinder",
+            };
+            return p.Modules.Cast<PartModule>().FirstOrDefault(m => m.moduleName == moduleName);
+        }
+
+        // BaseField.SetValue writes the underlying field, but some KSP versions don't fire the
+        // UI_Control.onFieldChanged callback that shape modules listen on; fire it explicitly with
+        // the prior value so the shape rebuilds even when there's no PAW interaction.
+        static void SetField(PartModule m, string name, float value)
+        {
+            var f = m.Fields[name];
+            if (f == null) return;
+            object before = null; try { before = f.GetValue(m); } catch { }
+            try
+            {
+                f.SetValue(value, m);
+                try { f.uiControlEditor?.onFieldChanged?.Invoke(f, before); } catch { }
+            }
+            catch { }
+        }
+
+        static float GetFloat(PartModule m, string name)
+        {
+            try
+            {
+                var f = m.Fields[name];
+                if (f == null) return 0f;
+                var v = f.GetValue(m);
+                return v is float fv ? fv : Convert.ToSingle(v);
+            }
+            catch { return 0f; }
+        }
+
+        static bool TryInvoke(object o, string method, object[] args)
+        {
+            int argCount = args?.Length ?? 0;
+            var mi = o.GetType()
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .FirstOrDefault(m => m.Name == method && m.GetParameters().Length == argCount);
+            if (mi == null) return false;
+            try { mi.Invoke(o, args); return true; }
+            catch { return false; }
+        }
+
+        static void Msg(string s) => ScreenMessages.PostScreenMessage(new ScreenMessage(s, 4f, ScreenMessageStyle.UPPER_CENTER));
+    }
+}


### PR DESCRIPTION
## Summary

Two-commit change to the Toolings tab in the editor:


1. **Group tank tooling types into category buttons** keyed by construction (Conventional / Isogrid / Balloon / Fuselage / Service Module / Shielded / Cryogenic / Other) and pressure class (HP variants get their own button where they exist). Buttons sorted alphabetically by title. Each leaf row tags the underlying material(s) supplied it. Lets a player search for an existing tooled diameter for a tank type without picking material first. `ProceduralAvionicsWindow` now also shows the avionics tooling abbreviation ("N3") next to the config name so it cross-references the grouped `Avionics-N` entries.

Before:
<img width="445" height="391" alt="Screenshot 2026-06-03 170800" src="https://github.com/user-attachments/assets/c2a159ea-41a3-4dd9-a7d0-3ac48f498089" />

After:
<img width="582" height="567" alt="Screenshot 2026-06-05 161536" src="https://github.com/user-attachments/assets/d23ae05a-9033-494d-8e96-e31b93f4c75e" />

<img width="366" height="414" alt="Screenshot 2026-06-05 162333" src="https://github.com/user-attachments/assets/da6394d0-80eb-4e4b-9ade-909fdc1e899c" />


2. **Refit button on each tooled (d, L) row** that writes the dims to whichever part has its PAW open in the editor, switching the part's RF tank type when the row only supplies materials the part isn't currently on. Disabled when the PAW target's tank type belongs to a different bucket than the one on screen -- refit only crosses materials within the same construction family. When the user opens a PAW on a tank, the viewer auto-switches to that tank's bucket (from the main bucket list or from inside another bucket page). Manual bucket picks suppress the auto-switch until the PAW target changes.
<img width="579" height="450" alt="Screenshot 2026-06-07 222638" src="https://github.com/user-attachments/assets/4d1f45f4-b8c2-4823-b26a-84c750aa8d5c" />


## Test plan

- [x] Tooling tab in editor -- categories render in alphabetical order, HP variants appear as separate buttons where data exists.
- [x] Open a PAW on each tank class (Conventional/Isogrid/Balloon/Fuselage/ServiceModule/Cryogenic) -- viewer jumps to the matching bucket from both the main list and from inside another bucket.
- [x] In a bucket, click Refit on a row -- part resizes to (d, L), and RF tank type switches if the row's materials don't include the current type.
- [x] PAW open on a tank in a non-matching bucket -- Refit greys out with the "switch to its bucket" tooltip.
- [x] No PAW open -- Refit greys out with "Open a part's PAW" tooltip.
- [x] Avionics-N bucket -- ProceduralAvionicsWindow shows the N-level abbreviation next to the config name.