### PR TITLE
Update and harmonize tags on SSPX parts

### DIFF
--- a/GameData/RP-1/Tree/TREE-Parts.cfg
+++ b/GameData/RP-1/Tree/TREE-Parts.cfg
@@ -32866,6 +32866,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-adapter-1875-0625-1]:FOR[xxxRP0]
 {
@@ -32890,6 +32893,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-adapter-25-1875-1]:FOR[xxxRP0]
 {
@@ -32898,6 +32904,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-adapter-25-375-1]:FOR[xxxRP0]
 {
@@ -32906,6 +32915,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-adapter-25-375-2]:FOR[xxxRP0]
 {
@@ -32922,6 +32934,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-adapter-375-5-2]:FOR[xxxRP0]
 {
@@ -33038,6 +33053,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-attach-25-1]:FOR[xxxRP0]
 {
@@ -33046,6 +33064,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-attach-375-1]:FOR[xxxRP0]
 {
@@ -33054,6 +33075,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-cargo-125-1]:FOR[xxxRP0]
 {
@@ -33570,6 +33594,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-hub-1875-1]:FOR[xxxRP0]
 {
@@ -33578,6 +33605,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-hub-25-1]:FOR[xxxRP0]
 {
@@ -33586,6 +33616,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-inflatable-centrifuge-125-1]:FOR[xxxRP0]
 {
@@ -33781,6 +33814,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-125-2]:FOR[xxxRP0]
 {
@@ -33789,6 +33825,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-125-3]:FOR[xxxRP0]
 {
@@ -33797,6 +33836,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-1875-1]:FOR[xxxRP0]
 {
@@ -33805,6 +33847,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-1875-2]:FOR[xxxRP0]
 {
@@ -33813,6 +33858,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-1875-3]:FOR[xxxRP0]
 {
@@ -33821,6 +33869,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-1875-angled-1]:FOR[xxxRP0]
 {
@@ -33829,6 +33880,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-25-1]:FOR[xxxRP0]
 {
@@ -33837,6 +33891,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-25-2]:FOR[xxxRP0]
 {
@@ -33845,6 +33902,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-25-3]:FOR[xxxRP0]
 {
@@ -33853,6 +33913,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-375-1]:FOR[xxxRP0]
 {
@@ -33861,6 +33924,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-375-2]:FOR[xxxRP0]
 {
@@ -33869,6 +33935,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-tube-375-3]:FOR[xxxRP0]
 {
@@ -33877,6 +33946,9 @@
     %entryCost = 0
     RP0conf = true
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
+
+    %MODULE[ModuleTagList] { tag = HumanRated }
+
 }
 @PART[sspx-utility-125-1]:FOR[xxxRP0]
 {

--- a/GameData/RP-1/Tree/TREE-Parts.cfg
+++ b/GameData/RP-1/Tree/TREE-Parts.cfg
@@ -32996,6 +32996,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-airlock-25-1]:FOR[xxxRP0]
@@ -33007,6 +33008,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-aquaculture-375-1]:FOR[xxxRP0]
@@ -33018,6 +33020,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-attach-125-1]:FOR[xxxRP0]
@@ -33197,6 +33200,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-core-1875-1]:FOR[xxxRP0]
@@ -33208,6 +33212,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-core-25-1]:FOR[xxxRP0]
@@ -33219,6 +33224,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-core-375-1]:FOR[xxxRP0]
@@ -33230,6 +33236,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-core-5-1]:FOR[xxxRP0]
@@ -33241,6 +33248,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-cupola-125-1]:FOR[xxxRP0]
@@ -33252,6 +33260,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-cupola-1875-1]:FOR[xxxRP0]
@@ -33263,6 +33272,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-cupola-375-1]:FOR[xxxRP0]
@@ -33274,6 +33284,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-cupola-greenhouse-125-1]:FOR[xxxRP0]
@@ -33285,6 +33296,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-cupola-telescope-125-1]:FOR[xxxRP0]
@@ -33296,6 +33308,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-docking-125-1]:FOR[xxxRP0]
@@ -33315,6 +33328,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-dome-cupola-5-1]:FOR[xxxRP0]
@@ -33326,6 +33340,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-dome-greenhouse-5-1]:FOR[xxxRP0]
@@ -33337,6 +33352,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-dome-habitation-5-1]:FOR[xxxRP0]
@@ -33348,6 +33364,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-expandable-centrifuge-375-1]:FOR[xxxRP0]
@@ -33359,6 +33376,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-expandable-centrifuge-375-2]:FOR[xxxRP0]
@@ -33370,6 +33388,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-expandable-centrifuge-5-1]:FOR[xxxRP0]
@@ -33381,6 +33400,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-extendable-tube-125-1]:FOR[xxxRP0]
@@ -33408,6 +33428,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-greenhouse-375-1]:FOR[xxxRP0]
@@ -33419,6 +33440,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-greenhouse-5-1]:FOR[xxxRP0]
@@ -33430,6 +33452,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-habitation-125-1]:FOR[xxxRP0]
@@ -33441,6 +33464,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-habitation-1875-1]:FOR[xxxRP0]
@@ -33452,6 +33476,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-habitation-1875-2]:FOR[xxxRP0]
@@ -33463,6 +33488,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-habitation-25-1]:FOR[xxxRP0]
@@ -33474,6 +33500,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-habitation-375-1]:FOR[xxxRP0]
@@ -33485,6 +33512,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-habitation-375-2]:FOR[xxxRP0]
@@ -33496,6 +33524,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-habitation-375-3]:FOR[xxxRP0]
@@ -33507,6 +33536,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-habitation-5-1]:FOR[xxxRP0]
@@ -33518,6 +33548,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-habitation-5-2]:FOR[xxxRP0]
@@ -33529,6 +33560,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-hub-125-1]:FOR[xxxRP0]
@@ -33564,6 +33596,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-inflatable-centrifuge-125-2]:FOR[xxxRP0]
@@ -33575,6 +33608,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-inflatable-centrifuge-25-1]:FOR[xxxRP0]
@@ -33586,6 +33620,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-inflatable-hab-125-1]:FOR[xxxRP0]
@@ -33597,6 +33632,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-inflatable-hab-125-2]:FOR[xxxRP0]
@@ -33608,6 +33644,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-inflatable-hab-125-3]:FOR[xxxRP0]
@@ -33619,6 +33656,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-inflatable-hab-25-1]:FOR[xxxRP0]
@@ -33630,6 +33668,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-inflatable-hab-25-2]:FOR[xxxRP0]
@@ -33641,6 +33680,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-lab-375-1]:FOR[xxxRP0]
@@ -33652,6 +33692,8 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = Instruments }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-lab-5-1]:FOR[xxxRP0]
@@ -33663,6 +33705,8 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = Instruments }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-lab-pallet-1]:FOR[xxxRP0]
@@ -33690,6 +33734,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-logistics-5-2]:FOR[xxxRP0]
@@ -33701,6 +33746,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-observation-25-1]:FOR[xxxRP0]
@@ -33712,6 +33758,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-science-1875-1]:FOR[xxxRP0]
@@ -33723,6 +33770,8 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = Instruments }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-tube-125-1]:FOR[xxxRP0]
@@ -33838,6 +33887,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[sspx-utility-1875-1]:FOR[xxxRP0]
@@ -33849,6 +33899,7 @@
     @description ^=:$: <b><color=green>From Station Parts Expansion Redux mod</color></b>
 
     %MODULE[ModuleTagList] { tag = HumanRated }
+    %MODULE[ModuleTagList] { tag = NoResourceCostMult }
 
 }
 @PART[stackBiCoupler_v2]:FOR[xxxRP0]

--- a/Source/Tech Tree/Parts Browser/data/Station_Parts_Expansion_Redux.json
+++ b/Source/Tech Tree/Parts Browser/data/Station_Parts_Expansion_Redux.json
@@ -66,7 +66,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations415m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-adapter-1875-0625-1",
@@ -132,7 +134,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations305m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-adapter-25-1875-1",
@@ -154,7 +158,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations415m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-adapter-25-375-1",
@@ -177,7 +183,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations6225m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-adapter-25-375-2",
@@ -222,7 +230,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations6225m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-adapter-375-5-2",
@@ -526,7 +536,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations305m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-attach-25-1",
@@ -549,7 +561,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations415m, 3000",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-attach-375-1",
@@ -572,7 +586,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations6225m, 4000",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-cargo-125-1",
@@ -1790,7 +1806,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations305m, 5000",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-hub-1875-1",
@@ -1812,7 +1830,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations415m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-hub-25-1",
@@ -1835,7 +1855,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations415m, 7000",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-inflatable-centrifuge-125-1",
@@ -2257,7 +2279,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations305m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-125-2",
@@ -2280,7 +2304,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations305m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-125-3",
@@ -2303,7 +2329,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations305m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-1875-1",
@@ -2325,7 +2353,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations305m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-1875-2",
@@ -2347,7 +2377,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations305m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-1875-3",
@@ -2369,7 +2401,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations305m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-1875-angled-1",
@@ -2391,7 +2425,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations415m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-25-1",
@@ -2414,7 +2450,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations415m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-25-2",
@@ -2437,7 +2475,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations415m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-25-3",
@@ -2460,7 +2500,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations415m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-375-1",
@@ -2483,7 +2525,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations6225m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-375-2",
@@ -2506,7 +2550,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations6225m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-tube-375-3",
@@ -2529,7 +2575,9 @@
         "upgrade": false,
         "entry_cost_mods": "stations6225m",
         "identical_part_name": "",
-        "module_tags": []
+        "module_tags": [
+            "HumanRated"
+        ]
     },
     {
         "name": "sspx-utility-125-1",

--- a/Source/Tech Tree/Parts Browser/data/Station_Parts_Expansion_Redux.json
+++ b/Source/Tech Tree/Parts Browser/data/Station_Parts_Expansion_Redux.json
@@ -428,7 +428,8 @@
         "entry_cost_mods": "stations305m, 5000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -453,7 +454,8 @@
         "entry_cost_mods": "stations415m, 7000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -477,7 +479,8 @@
         "entry_cost_mods": "stations6225m",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -984,7 +987,8 @@
         "entry_cost_mods": "stations305m, 10000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1008,7 +1012,8 @@
         "entry_cost_mods": "stations415m",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1033,7 +1038,8 @@
         "entry_cost_mods": "stations415m, 12000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1058,7 +1064,8 @@
         "entry_cost_mods": "stations6225m, 15000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1082,7 +1089,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1107,7 +1115,8 @@
         "entry_cost_mods": "stations305m, 5000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1131,7 +1140,8 @@
         "entry_cost_mods": "stations415m",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1156,7 +1166,8 @@
         "entry_cost_mods": "stations6225m, 9000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1180,7 +1191,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1204,7 +1216,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1251,7 +1264,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1275,7 +1289,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1299,7 +1314,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1323,7 +1339,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1347,7 +1364,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1371,7 +1389,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1395,7 +1414,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1465,7 +1485,8 @@
         "entry_cost_mods": "stations415m",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1489,7 +1510,8 @@
         "entry_cost_mods": "stations6225m",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1513,7 +1535,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1538,7 +1561,8 @@
         "entry_cost_mods": "stations305m, 5000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1562,7 +1586,8 @@
         "entry_cost_mods": "stations305m",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1586,7 +1611,8 @@
         "entry_cost_mods": "stations305m",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1611,7 +1637,8 @@
         "entry_cost_mods": "stations415m, 7000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1636,7 +1663,8 @@
         "entry_cost_mods": "stations6225m, 9000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1661,7 +1689,8 @@
         "entry_cost_mods": "stations6225m, 9000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1686,7 +1715,8 @@
         "entry_cost_mods": "stations6225m, 9000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1710,7 +1740,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1734,7 +1765,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1826,7 +1858,8 @@
         "entry_cost_mods": "inflatable",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1850,7 +1883,8 @@
         "entry_cost_mods": "inflatable",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1874,7 +1908,8 @@
         "entry_cost_mods": "inflatable",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1898,7 +1933,8 @@
         "entry_cost_mods": "inflatable",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1922,7 +1958,8 @@
         "entry_cost_mods": "inflatable",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1946,7 +1983,8 @@
         "entry_cost_mods": "inflatable",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1970,7 +2008,8 @@
         "entry_cost_mods": "inflatable",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -1994,7 +2033,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -2019,7 +2059,9 @@
         "entry_cost_mods": "stations6225m, 20000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "Instruments",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -2043,7 +2085,9 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "Instruments",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -2111,7 +2155,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -2135,7 +2180,8 @@
         "entry_cost_mods": "",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -2160,7 +2206,8 @@
         "entry_cost_mods": "stations415m, 7000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -2184,7 +2231,9 @@
         "entry_cost_mods": "stations415m",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "Instruments",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -2504,7 +2553,8 @@
         "entry_cost_mods": "stations305m, 5000",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     },
     {
@@ -2528,7 +2578,8 @@
         "entry_cost_mods": "stations305m",
         "identical_part_name": "",
         "module_tags": [
-            "HumanRated"
+            "HumanRated",
+            "NoResourceCostMult"
         ]
     }
 ]


### PR DESCRIPTION
This updates all of the human-rated SSPX parts to include the NoResourceCostMult to bring them in line with other non-SSPX station parts. I also added the Instruments tag to the science labs, again to bring them in line with existing parts.

That said, there's a number of SSPX parts that have habitat volume, but don't have the Human Rated tag. I'd also be willing to add that tag to all of those if that's something that the maintainers believe should be done.