### PR TITLE
Extend the subsidy curve into the early 1990s

### DIFF
--- a/GameData/RP-1/SpaceCenterSettings.cfg
+++ b/GameData/RP-1/SpaceCenterSettings.cfg
@@ -66,7 +66,11 @@ SPACECENTERSETTINGS
 		key = 13 450000
 		key = 14 500000
 		key = 15 550000
-		key = 16 600000 // 1967 and beyond
+		key = 16 600000 //  1967
+		key = 20 700000 //  1971
+		key = 25 800000 //  1976
+		key = 30 900000 //  1981
+		key = 40 1000000 // 1991 and beyond
 	}
 	RushSalaryMult = 2
 	EngineerIdleSalaryMult = 0.25


### PR DESCRIPTION
The subsidy curve hasn't been touched since P&LC first came out, and the maximum subsidy currently caps out at the rather arbitrary number of 1.2 million in the rather arbitrary year of 1967. WIth all the new proposed programs to extend the late game of RP-1, it's worth reconsidering the subsidy curve for the later game, especially around the preparation for Marsboots. This changes the curve to go up to a maximum of 1.4 million by 1971, rising slowly to 1.8 million by 1981, around the time that players following a historical trajectory for their Moonboots/Early Stations will likely be undertaking (or about to undertake) MarsBoots, and very slowly rising thereafter to cap out at 2 million by 1991. This both helps fund post-Moonboots projects with a bigger scope (like Modular Stations, Lunar Habitation, Marsboots, AsteroidBoots, etc.), and gives a reason to keep your rep up high in the late game if you want to take full advantage of the larger subsidy.

Because all of these numbers are fairly arbitrary, especially for anything post-Moonboots, I am very open to suggestions on how this curve should be adjusted, especially regarding better accommodating MarsBoots.