### PR TITLE
Show warnings in Editor GUI when the vessel cannot be integrated

### DIFF
--- a/Source/RP0/SpaceCenter/Projects/VesselProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/VesselProject.cs
@@ -804,6 +804,8 @@ namespace RP0
             if (ShipSize.sqrMagnitude > 0)
                 return ShipSize;
 
+            if (ShipNodeCompressed.Node is null) // true when first loading VAB
+                return Vector3.zero;
             ShipTemplate template = new ShipTemplate();
             template.LoadShip(ShipNodeCompressed.Node);
             ShipSize = template.GetShipSize();

--- a/Source/RP0/SpaceCenter/Projects/VesselProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/VesselProject.cs
@@ -118,13 +118,13 @@ namespace RP0
         private double _leaderEffect = -1d;
         public double LeaderEffect => _leaderEffect < 0 ? UpdateLeaderEffect() : _leaderEffect;
         private double _modifiedEC = -1d;
-        public double ModifiedEC 
-        { 
+        public double ModifiedEC
+        {
             get
             {
                 if (_modifiedEC < 0) UpdateLeaderEffect();
                 return _modifiedEC;
-            } 
+            }
         }
 
         internal ShipConstruct _ship;
@@ -575,7 +575,7 @@ namespace RP0
                     lc.SwitchLaunchPad(launchSiteIndex);
 
                 LCLaunchPad pad = lc.ActiveLPInstance;
-                
+
                 launchSiteName = pad.launchSiteName;
             }
 
@@ -587,7 +587,7 @@ namespace RP0
             }));
         }
 
-        public bool ResourcesOK(LCData stats, List<string> failedReasons = null)
+        public bool ResourcesOK(LCData stats, List<string> failedReasons = null, bool shortReasons = false)
         {
             bool pass = true;
             LCResourceType ignoreType = stats.lcType == LaunchComplexType.Hangar ? LCResourceType.HangarIgnore : LCResourceType.PadIgnore;
@@ -609,11 +609,14 @@ namespace RP0
                     return false;
 
                 pass = false;
-                failedReasons.Add($"Insufficient {kvp.Key} at LC: {kvp.Value:N0} required, {lcAmount:N0} available. Modify {(stats.lcType == LaunchComplexType.Pad ? "LC" : "the Hangar")}.");
+                failedReasons.Add(shortReasons
+                    ? $"Insufficient {kvp.Key} (needs {kvp.Value:N0}, has {lcAmount:N0})"
+                    : $"Insufficient {kvp.Key} at LC: {kvp.Value:N0} required, {lcAmount:N0} available. Modify {(stats.lcType == LaunchComplexType.Pad ? "LC" : "the Hangar")}.");
             }
 
             return pass;
         }
+
 
         public bool MeetsFacilityRequirements(List<string> failedReasons)
         {
@@ -631,7 +634,9 @@ namespace RP0
             return MeetsFacilityRequirements(selectedLC.Stats, failedReasons);
         }
 
-        public bool MeetsFacilityRequirements(LCData stats, List<string> failedReasons)
+        // shortReasons toggles shorter error messages for display in the narrow
+        // editor GUI
+        public bool MeetsFacilityRequirements(LCData stats, List<string> failedReasons, bool shortReasons = false)
         {
             if (!KSPUtils.CurrentGameIsCareer())
                 return true;
@@ -642,16 +647,20 @@ namespace RP0
                 if (failedReasons == null)
                     return false;
 
-                failedReasons.Add($"Mass limit exceeded, currently at {totalMass:N} tons, max {stats.massMax:N}");
+                failedReasons.Add(shortReasons
+                    ? $"Too heavy for LC ({totalMass:N})"
+                    : $"Mass limit exceeded, currently at {totalMass:N} tons, max {stats.massMax:N}");
             }
             if (totalMass < stats.MassMin)
             {
                 if (failedReasons == null)
                     return false;
 
-                failedReasons.Add($"Mass minimum exceeded, currently at {totalMass:N} tons, min {stats.MassMin:N}");
+                failedReasons.Add(shortReasons
+                    ? $"Too light for LC ({totalMass:N})"
+                    : $"Mass minimum exceeded, currently at {totalMass:N} tons, min {stats.MassMin:N}");
             }
-            if (!ResourcesOK(stats, failedReasons) && failedReasons == null)
+            if (!ResourcesOK(stats, failedReasons, shortReasons) && failedReasons == null)
                 return false;
 
             // Facility doesn't matter here.
@@ -669,7 +678,9 @@ namespace RP0
                 if (failedReasons == null)
                     return false;
 
-                failedReasons.Add("Vessel is human-rated but launch complex is not");
+                failedReasons.Add(shortReasons
+                    ? "LC is not human-rated"
+                    : "Vessel is human-rated but launch complex is not");
             }
 
             if (HasClamps() && stats.lcType == LaunchComplexType.Hangar)
@@ -677,7 +688,8 @@ namespace RP0
                 if (failedReasons == null)
                     return false;
 
-                failedReasons.Add("Has launch clamps/GSE but is launching from runway");
+                failedReasons.Add(shortReasons ? "Launch clamps/GSE in hangar"
+                    :"Has launch clamps/GSE but is launching from runway");
             }
 
             return failedReasons == null || failedReasons.Count == 0;
@@ -795,7 +807,7 @@ namespace RP0
             template.LoadShip(ShipNodeCompressed.Node);
             ShipSize = template.GetShipSize();
             ShipNodeCompressed.CompressAndRelease();
-            
+
             return ShipSize;
         }
 
@@ -888,7 +900,7 @@ namespace RP0
 
             if (removed)
                 RP0Debug.Log("Sucessfully removed vessel from LC.");
-            else 
+            else
                 RP0Debug.Log("Still couldn't remove ship!");
 
             return removed;
@@ -1043,7 +1055,7 @@ namespace RP0
 
             humanRated = state.HumanRated;
         }
-        
+
         // A little silly, but made to mirror ShipConstruction.GetPartCostsAndMass
         private static void GetPartCostsAndMass(Part p, out float dryCost, out float fuelCost, out float dryMass, out float fuelMass, Dictionary<string, double> resources)
         {
@@ -1124,7 +1136,7 @@ namespace RP0
                 amt += kvp.Value;
                 state.ResourceAmounts[kvp.Key] = amt;
             }
-            
+
             double effectiveCost = partMultiplier * moduleMultiplier * cost;
 
             if (partRef.FindModuleImplementing<ModuleEngines>() != null)

--- a/Source/RP0/SpaceCenter/Projects/VesselProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/VesselProject.cs
@@ -610,7 +610,7 @@ namespace RP0
 
                 pass = false;
                 failedReasons.Add(shortReasons
-                    ? $"Insufficient {kvp.Key} (needs {kvp.Value:N0}, has {lcAmount:N0})"
+                    ? $"Insufficient {kvp.Key} ({kvp.Value:N0} > {lcAmount:N0})"
                     : $"Insufficient {kvp.Key} at LC: {kvp.Value:N0} required, {lcAmount:N0} available. Modify {(stats.lcType == LaunchComplexType.Pad ? "LC" : "the Hangar")}.");
             }
 
@@ -648,7 +648,7 @@ namespace RP0
                     return false;
 
                 failedReasons.Add(shortReasons
-                    ? $"Too heavy for LC ({totalMass:N})"
+                    ? $"Too heavy for LC ({totalMass:N0})"
                     : $"Mass limit exceeded, currently at {totalMass:N} tons, max {stats.massMax:N}");
             }
             if (totalMass < stats.MassMin)
@@ -657,11 +657,9 @@ namespace RP0
                     return false;
 
                 failedReasons.Add(shortReasons
-                    ? $"Too light for LC ({totalMass:N})"
+                    ? $"Too light for LC ({totalMass:N0})"
                     : $"Mass minimum exceeded, currently at {totalMass:N} tons, min {stats.MassMin:N}");
             }
-            if (!ResourcesOK(stats, failedReasons, shortReasons) && failedReasons == null)
-                return false;
 
             // Facility doesn't matter here.
             Vector3 size = GetShipSize();
@@ -691,6 +689,9 @@ namespace RP0
                 failedReasons.Add(shortReasons ? "Launch clamps/GSE in hangar"
                     :"Has launch clamps/GSE but is launching from runway");
             }
+
+            if (!ResourcesOK(stats, failedReasons, shortReasons) && failedReasons == null)
+                return false;
 
             return failedReasons == null || failedReasons.Count == 0;
         }

--- a/Source/RP0/SpaceCenter/Projects/VesselProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/VesselProject.cs
@@ -610,7 +610,7 @@ namespace RP0
 
                 pass = false;
                 failedReasons.Add(shortReasons
-                    ? $"Insufficient {kvp.Key} ({kvp.Value:N0} > {lcAmount:N0})"
+                    ? $"{kvp.Key}: {kvp.Value:N0}/{lcAmount:N0}"
                     : $"Insufficient {kvp.Key} at LC: {kvp.Value:N0} required, {lcAmount:N0} available. Modify {(stats.lcType == LaunchComplexType.Pad ? "LC" : "the Hangar")}.");
             }
 

--- a/Source/RP0/SpaceCenter/Projects/VesselProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/VesselProject.cs
@@ -648,7 +648,7 @@ namespace RP0
                     return false;
 
                 failedReasons.Add(shortReasons
-                    ? $"Too heavy for LC ({totalMass:N0})"
+                    ? $"Too heavy for LC ({totalMass:N0}t)"
                     : $"Mass limit exceeded, currently at {totalMass:N} tons, max {stats.massMax:N}");
             }
             if (totalMass < stats.MassMin)
@@ -657,7 +657,7 @@ namespace RP0
                     return false;
 
                 failedReasons.Add(shortReasons
-                    ? $"Too light for LC ({totalMass:N0})"
+                    ? $"Too light for LC ({totalMass:N0}t)"
                     : $"Mass minimum exceeded, currently at {totalMass:N} tons, min {stats.MassMin:N}");
             }
 

--- a/Source/RP0/SpaceCenter/Projects/VesselProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/VesselProject.cs
@@ -118,13 +118,13 @@ namespace RP0
         private double _leaderEffect = -1d;
         public double LeaderEffect => _leaderEffect < 0 ? UpdateLeaderEffect() : _leaderEffect;
         private double _modifiedEC = -1d;
-        public double ModifiedEC
-        {
+        public double ModifiedEC 
+        { 
             get
             {
                 if (_modifiedEC < 0) UpdateLeaderEffect();
                 return _modifiedEC;
-            }
+            } 
         }
 
         internal ShipConstruct _ship;
@@ -575,7 +575,7 @@ namespace RP0
                     lc.SwitchLaunchPad(launchSiteIndex);
 
                 LCLaunchPad pad = lc.ActiveLPInstance;
-
+                
                 launchSiteName = pad.launchSiteName;
             }
 
@@ -616,7 +616,6 @@ namespace RP0
 
             return pass;
         }
-
 
         public bool MeetsFacilityRequirements(List<string> failedReasons)
         {
@@ -826,7 +825,7 @@ namespace RP0
             template.LoadShip(ShipNodeCompressed.Node);
             ShipSize = template.GetShipSize();
             ShipNodeCompressed.CompressAndRelease();
-
+            
             return ShipSize;
         }
 
@@ -919,7 +918,7 @@ namespace RP0
 
             if (removed)
                 RP0Debug.Log("Sucessfully removed vessel from LC.");
-            else
+            else 
                 RP0Debug.Log("Still couldn't remove ship!");
 
             return removed;
@@ -1074,7 +1073,7 @@ namespace RP0
 
             humanRated = state.HumanRated;
         }
-
+        
         // A little silly, but made to mirror ShipConstruction.GetPartCostsAndMass
         private static void GetPartCostsAndMass(Part p, out float dryCost, out float fuelCost, out float dryMass, out float fuelMass, Dictionary<string, double> resources)
         {
@@ -1155,7 +1154,7 @@ namespace RP0
                 amt += kvp.Value;
                 state.ResourceAmounts[kvp.Key] = amt;
             }
-
+            
             double effectiveCost = partMultiplier * moduleMultiplier * cost;
 
             if (partRef.FindModuleImplementing<ModuleEngines>() != null)

--- a/Source/RP0/SpaceCenter/Projects/VesselProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/VesselProject.cs
@@ -610,7 +610,7 @@ namespace RP0
 
                 pass = false;
                 failedReasons.Add(shortReasons
-                    ? $"{kvp.Key}: {kvp.Value:N0}/{lcAmount:N0}"
+                    ? $"{kvp.Key}: {kvp.Value:N0} / {lcAmount:N0}"
                     : $"Insufficient {kvp.Key} at LC: {kvp.Value:N0} required, {lcAmount:N0} available. Modify {(stats.lcType == LaunchComplexType.Pad ? "LC" : "the Hangar")}.");
             }
 

--- a/Source/RP0/SpaceCenter/Projects/VesselProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/VesselProject.cs
@@ -634,8 +634,24 @@ namespace RP0
             return MeetsFacilityRequirements(selectedLC.Stats, failedReasons);
         }
 
-        // shortReasons toggles shorter error messages for display in the narrow
-        // editor GUI
+        /// <summary>
+        ///   Checks that this vessel can be integrated at the selected LC
+        /// </summary>
+        /// <param name="stats">The LC's stats used to verify compatibility</param>
+        /// <param name="failedReasons">
+        ///     An initially empty list or <c>null</c> - each unmet requirement will
+        ///     add a string error description to that list (it it isn't <c>null</c>)
+        /// </param>
+        /// <param name="shortReasons">When <c>true</c>, write shorter error messages
+        ///     in <paramref name="failedReasons"/>, used to display warning in
+        ///     the narrow KCT editor GUI. <c>false</c> by default, for warnings
+        ///     that appear in a popup window when attempting to build the vessel
+        /// </param>
+        /// <returns>
+        ///     <c>true</c> if the vessel can be integrated at the specified LC (in which
+        ///     case <paramref name="failedReasons"/> remains empty), <c>false</c>
+        ///     otherwise.
+        /// </returns>
         public bool MeetsFacilityRequirements(LCData stats, List<string> failedReasons, bool shortReasons = false)
         {
             if (!KSPUtils.CurrentGameIsCareer())

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -150,6 +150,11 @@ namespace RP0
             // show a warning with failure reasons.
             vesselFailedChecks.Clear();
             if (!SpaceCenterManagement.Instance.EditorVessel.MeetsFacilityRequirements(SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Stats, vesselFailedChecks, true)) {
+                int count = vesselFailedChecks.Count;
+                if (count > 5) {
+                    vesselFailedChecks.RemoveRange(4, count - 4);
+                    vesselFailedChecks.Add($" + {count-4} errors");
+                }
                 GUILayout.Label("Warning: cannot integrate at this LC:\n- " + String.Join("\n- ", vesselFailedChecks), _yellowText);
             }
 

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -336,7 +336,7 @@ namespace RP0
             KCTUtilities.GetShipEditProgress(editedVessel, out double newProgressBP, out double originalCompletionPercent, out double newCompletionPercent);
             GUILayout.Label($"Original: {Math.Max(0, originalCompletionPercent):P2}");
             GUILayout.Label($"Edited: {newCompletionPercent:P2}");
-
+            
             double rateWithCurEngis = KCTUtilities.GetBuildRate(editedVessel.LC, SpaceCenterManagement.Instance.EditorVessel.mass, SpaceCenterManagement.Instance.EditorVessel.buildPoints, SpaceCenterManagement.Instance.EditorVessel.humanRated, 0)
                 * effic * editedVessel.LC.StrategyRateMultiplier;
 
@@ -360,7 +360,7 @@ namespace RP0
                         ? buildPoints / (bR * bpLeaderEffect)
                         : editedVessel.CalculateTimeLeftForBuildRate(buildPoints, bR / effic, startingEff, out rolloutEff))
                     : double.NaN;
-                GUILayout.Label(new GUIContent($"Remaining: {RP0DTUtils.GetFormattedTime(buildTime, 0, false)}",
+                GUILayout.Label(new GUIContent($"Remaining: {RP0DTUtils.GetFormattedTime(buildTime, 0, false)}", 
                     idx == -1 ? "Time left takes efficiency increase into account based on assuming vessel will be placed at head of integration list" :
                     "Time left takes efficiency increase into account based on vessel's current place in the integration list"));
 

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using UniLinq;
 using UnityEngine;
 using ROUtils;
@@ -20,6 +21,7 @@ namespace RP0
         private static readonly GUIContent _gcNewLC = new GUIContent("New LC", "Build a new launch complex to support this vessel, with a margin of 10% to vessel mass and size upgrades.");
         private static readonly GUIContent _gcNoHangar = new GUIContent("Hangar Unavailable", "The Hangar is currently being modified.");
         private static readonly GUIContent _gcSwitchToHangar = new GUIContent("Switch to Hangar", "A Launch Complex is currently selected; this will switch to the Hangar, needed for planes.");
+        private static List<string> vesselFailedChecks = new List<string>();
 
         public static void DrawEditorGUI(int windowID)
         {
@@ -144,10 +146,11 @@ namespace RP0
                 GUILayout.Label(techLabel);
             }
 
-            if (SpaceCenterManagement.Instance.EditorVessel.humanRated && !SpaceCenterManagement.Instance.ActiveSC.ActiveLC.IsHumanRated)
-            {
-                GUILayout.Label("WARNING: Cannot integrate vessel!");
-                GUILayout.Label("Select a human-rated Launch Complex.");
+            // Check that the vessel can be built at the current LC. If it can't
+            // show a warning with failure reasons.
+            vesselFailedChecks.Clear();
+            if (!SpaceCenterManagement.Instance.EditorVessel.MeetsFacilityRequirements(SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Stats, vesselFailedChecks, true)) {
+                GUILayout.Label("Warning: cannot integrate at this LC:" + String.Join("\n- ", vesselFailedChecks), _yellowText);
             }
 
             GUILayout.BeginHorizontal();
@@ -326,7 +329,7 @@ namespace RP0
             KCTUtilities.GetShipEditProgress(editedVessel, out double newProgressBP, out double originalCompletionPercent, out double newCompletionPercent);
             GUILayout.Label($"Original: {Math.Max(0, originalCompletionPercent):P2}");
             GUILayout.Label($"Edited: {newCompletionPercent:P2}");
-            
+
             double rateWithCurEngis = KCTUtilities.GetBuildRate(editedVessel.LC, SpaceCenterManagement.Instance.EditorVessel.mass, SpaceCenterManagement.Instance.EditorVessel.buildPoints, SpaceCenterManagement.Instance.EditorVessel.humanRated, 0)
                 * effic * editedVessel.LC.StrategyRateMultiplier;
 
@@ -350,7 +353,7 @@ namespace RP0
                         ? buildPoints / (bR * bpLeaderEffect)
                         : editedVessel.CalculateTimeLeftForBuildRate(buildPoints, bR / effic, startingEff, out rolloutEff))
                     : double.NaN;
-                GUILayout.Label(new GUIContent($"Remaining: {RP0DTUtils.GetFormattedTime(buildTime, 0, false)}", 
+                GUILayout.Label(new GUIContent($"Remaining: {RP0DTUtils.GetFormattedTime(buildTime, 0, false)}",
                     idx == -1 ? "Time left takes efficiency increase into account based on assuming vessel will be placed at head of integration list" :
                     "Time left takes efficiency increase into account based on vessel's current place in the integration list"));
 

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -149,7 +149,12 @@ namespace RP0
             // Check that the vessel can be built at the current LC. If it can't
             // show a warning with failure reasons.
             vesselFailedChecks.Clear();
-            if (!SpaceCenterManagement.Instance.EditorVessel.MeetsFacilityRequirements(SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Stats, vesselFailedChecks, true))
+            bool isHangar = EditorDriver.editorFacility == EditorFacility.SPH;
+            if (isHangar != (activeLC.LCType == LaunchComplexType.Hangar))
+            {
+                GUILayout.Label("Warning: wrong LC type, switch to " + (isHangar ? "hangar" : "a rocket LC"), _yellowText);
+            }
+            else if (!SpaceCenterManagement.Instance.EditorVessel.MeetsFacilityRequirements(SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Stats, vesselFailedChecks, true))
             {
                 int count = vesselFailedChecks.Count;
                 if (count > 5)

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -155,7 +155,9 @@ namespace RP0
                     vesselFailedChecks.RemoveRange(4, count - 4);
                     vesselFailedChecks.Add($" + {count-4} errors");
                 }
-                GUILayout.Label("Warning: cannot integrate at this LC:\n- " + String.Join("\n- ", vesselFailedChecks), _yellowText);
+                GUILayout.Label("Warning: cannot integrate at this LC:\n- "
+                    + String.Join("\n- ", vesselFailedChecks)
+                    + "\nModify LC or select another LC", _yellowText);
             }
 
             GUILayout.BeginHorizontal();

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -155,7 +155,7 @@ namespace RP0
                 if (count > 5)
                 {
                     vesselFailedChecks.RemoveRange(4, count - 4);
-                    vesselFailedChecks.Add($" + {count-4} errors");
+                    vesselFailedChecks.Add($"... and {count - 4} more errors");
                 }
                 GUILayout.Label("Warning: cannot integrate at this LC:\n- "
                     + String.Join("\n- ", vesselFailedChecks)

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -149,22 +149,28 @@ namespace RP0
             // Check that the vessel can be built at the current LC. If it can't
             // show a warning with failure reasons.
             vesselFailedChecks.Clear();
-            bool isHangar = EditorDriver.editorFacility == EditorFacility.SPH;
-            if (isHangar != (activeLC.LCType == LaunchComplexType.Hangar))
+            if (EditorLogic.fetch.ship.Parts.Count > 0)
             {
-                GUILayout.Label("Warning: wrong LC type, switch to " + (isHangar ? "hangar" : "a rocket LC"), _yellowText);
-            }
-            else if (!SpaceCenterManagement.Instance.EditorVessel.MeetsFacilityRequirements(SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Stats, vesselFailedChecks, true))
-            {
-                int count = vesselFailedChecks.Count;
-                if (count > 5)
+                bool isHangar = EditorDriver.editorFacility == EditorFacility.SPH;
+                if (isHangar != (SpaceCenterManagement.Instance.ActiveSC.ActiveLC.LCType == LaunchComplexType.Hangar))
                 {
-                    vesselFailedChecks.RemoveRange(4, count - 4);
-                    vesselFailedChecks.Add($"... and {count - 4} more errors");
+                    GUILayout.Label("Warning: wrong LC type, switch to " + (isHangar ? "hangar" : "a rocket LC"), _yellowText);
                 }
-                GUILayout.Label("Warning: cannot integrate at this LC:\n- "
-                    + String.Join("\n- ", vesselFailedChecks)
-                    + "\nModify LC or select another LC", _yellowText);
+                else if (!SpaceCenterManagement.Instance.EditorVessel.MeetsFacilityRequirements(SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Stats, vesselFailedChecks, true))
+                {
+                    int count = vesselFailedChecks.Count;
+                    if (count > 5)
+                    {
+                        vesselFailedChecks.RemoveRange(4, count - 4);
+                        vesselFailedChecks.Add($"... and {count - 4} more errors");
+                    }
+                    GUILayout.Label($"Warning: cannot integrate at "
+                        + (isHangar ? "Hangar" : "this LC")
+                        + ":\n- "
+                        + String.Join("\n- ", vesselFailedChecks)
+                        + (isHangar ? "\nModify Hangar" : "\nModify LC or select another LC"),
+                        _yellowText);
+                }
             }
 
             GUILayout.BeginHorizontal();

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -149,9 +149,11 @@ namespace RP0
             // Check that the vessel can be built at the current LC. If it can't
             // show a warning with failure reasons.
             vesselFailedChecks.Clear();
-            if (!SpaceCenterManagement.Instance.EditorVessel.MeetsFacilityRequirements(SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Stats, vesselFailedChecks, true)) {
+            if (!SpaceCenterManagement.Instance.EditorVessel.MeetsFacilityRequirements(SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Stats, vesselFailedChecks, true))
+            {
                 int count = vesselFailedChecks.Count;
-                if (count > 5) {
+                if (count > 5)
+                {
                     vesselFailedChecks.RemoveRange(4, count - 4);
                     vesselFailedChecks.Add($" + {count-4} errors");
                 }

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -150,7 +150,7 @@ namespace RP0
             // show a warning with failure reasons.
             vesselFailedChecks.Clear();
             if (!SpaceCenterManagement.Instance.EditorVessel.MeetsFacilityRequirements(SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Stats, vesselFailedChecks, true)) {
-                GUILayout.Label("Warning: cannot integrate at this LC:" + String.Join("\n- ", vesselFailedChecks), _yellowText);
+                GUILayout.Label("Warning: cannot integrate at this LC:\n- " + String.Join("\n- ", vesselFailedChecks), _yellowText);
             }
 
             GUILayout.BeginHorizontal();


### PR DESCRIPTION
The editor KCT GUI had a single warning for human-rated vessels in non human-rated LC. This PR expands that to all vessel checks (mass limits, size limits, resources, clamp in hangar), and makes the label yellow. To avoid issues with long resource lists, the warnings list is cut after 5 elements:
<img width="292" height="508" alt="image" src="https://github.com/user-attachments/assets/a55c8cf2-f82f-48d5-8a84-8d7e76df5f62" /><img width="292" height="508" alt="image" src="https://github.com/user-attachments/assets/b5f39b56-b48d-44f1-9947-3dd1188e1224" />

I've spliced into the VesselProject.MeetsFacilityRequirements to avoid recoding the checks. However, since the GUI is quite narrow, I wanted shorter error messages to avoid line breaks. So I added an extra shortReasons parameter, which returns alternate strings.

Full disclaimer: while I have fairly extensive programming experience, this is my first time with C#. Let me know if what I'm missing some good coding practices.