### PR TITLE
[Staff GUI] Fix time estimates

### DIFF
--- a/Source/RP0/UI/KCT/GUI_Personnel.cs
+++ b/Source/RP0/UI/KCT/GUI_Personnel.cs
@@ -122,7 +122,7 @@ namespace RP0
 
             GUILayout.BeginHorizontal();
             GUILayout.Label("Assigned:");
-            
+
             string assignStr = GetAssignText(true, currentLC, out int assignAmt);
             string unassignStr = GetAssignText(false, currentLC, out int unassignAmt);
 
@@ -201,13 +201,7 @@ namespace RP0
                 if (engCap != currentLC.MaxEngineers)
                     GUILayout.Label($"(max of {engCap} eng.)");
 
-                int delta = assignDelta;
-                if (engCap < currentLC.Engineers + assignDelta)
-                    delta = engCap - currentLC.Engineers;
-                double buildRate = KCTUtilities.GetBuildRate(0, b.Type, currentLC, b.humanRated, delta)
-                    * efficiency * stratMult;
-                double bpLeft = b.buildPoints - b.progress;
-                GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(bpLeft / buildRate, "PersonnelVessel"), GetLabelRightAlignStyle());
+                GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(b.GetTimeLeft(), "PersonnelVessel"), GetLabelRightAlignStyle());
             }
             else
             {
@@ -216,7 +210,7 @@ namespace RP0
                 {
                     int engCap = lcp.IsCapped ? currentLC.MaxEngineersFor(lcp.mass, lcp.vesselBP, lcp.isHumanRated) : int.MaxValue;
                     GUILayout.Label($"Current Project: {lcp.Name} {(lcp.AssociatedVP == null ? string.Empty : lcp.AssociatedVP.shipName)}");
-                    
+
                     int delta = assignDelta;
                     if (engCap < currentLC.Engineers + assignDelta)
                         delta = engCap - currentLC.Engineers;
@@ -277,7 +271,7 @@ namespace RP0
             }
             GUILayout.EndHorizontal();
 
-            
+
             GUILayout.BeginHorizontal();
             const string researcherEfficTooltip = "Researching new Electronics Research nodes and gathering more science will increase this";
             GUILayout.Label(new GUIContent("Efficiency:", researcherEfficTooltip));
@@ -289,9 +283,7 @@ namespace RP0
             {
                 ResearchProject t = SpaceCenterManagement.Instance.TechList[0];
                 GUILayout.Label($"Current Research: {t.techName}");
-                double techRate = Formula.GetResearchRate(t.scienceCost, 0, delta) * efficiency * t.YearBasedRateMult;
-                double timeLeft = (t.scienceCost - t.progress) / techRate;
-                GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(timeLeft, "PersonnelTech"), GetLabelRightAlignStyle());
+                GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(t.TimeLeft, "PersonnelTech"), GetLabelRightAlignStyle());
             }
             else
             {


### PR DESCRIPTION
As reported by [Krex on discord](https://discord.com/channels/319857228905447436/620690446540341261/1516287211106996315), the staffing GUI and space center management GUI show different time estimates to next project completion. This occurs both for engineers (the time to next vessel completion for each LC disagree), and to a lesser extent, for researchers. In both case, the SCM GUI has the correct value, and the staffing values change gradually over time.

In my save I saw the discrepancy for engineers but not for researchers:
<img width="954" height="359" alt="Screenshot_20260616_210448" src="https://github.com/user-attachments/assets/f8620bba-8f4f-482f-9732-3715b051c6b4" />

The issue is that in both case, the staff GUI uses different function for time estimates:
- For engineers, it uses a flat `remaining_BP / build_rate`, which fails to account for LC efficiency gain
- For scientists, it uses `Formula.GetResearchRate`, while SCM uses `ResearchProject.BuildRate`. The latter calls `Formula.GetResearchRate` but adds three multipliers: `YearBasedRateMult`, `CurrencyUtils.Rate(TransactionReasonsRP0.RateResearch)` and `Leaders.LeaderUtils.GetResearchRateEffect(nodeType, techID)`

This PR modifies the staff GUI so that it reports the same numbers as the space center management, as I doubt the differing displays was intended behavior.