### PR TITLE
Increase Avionics massLimit for Big Gemini Crew Module

### DIFF
--- a/GameData/RP-1/Avionics.cfg
+++ b/GameData/RP-1/Avionics.cfg
@@ -176,8 +176,19 @@
 	%SetupKOS = ApolloCM
 }
 
-// Big G, Soyuz DM
-@PART[FASAGeminiBigG|FASAGeminiBigGWhite|ROC-BigGeminiCabinBDB|SSTU-SC-A-DM|ok_sa|tg_sa|rn_zond_sa]:FOR[RP-0]
+// Big G
+@PART[FASAGeminiBigG|FASAGeminiBigGWhite|ROC-BigGeminiCabinBDB]:FOR[RP-0]
+{
+	%MODULE[ModuleAvionics]
+	{
+		%massLimit = 10.0
+		%interplanetary = False
+	}
+	%SetupKOS = Gemini
+}
+
+// Soyuz DM
+@PART[SSTU-SC-A-DM|ok_sa|tg_sa|rn_zond_sa]:FOR[RP-0]
 {
 	%MODULE[ModuleAvionics]
 	{


### PR DESCRIPTION
The full Big Gemini Spacecraft weighs over 6 tons. This allows the capsule to be controlled during reentry with some margin.