### PR TITLE
Fix an NRE when force completing a contract

### DIFF
--- a/Source/CC_RP0/RP1ContractTracker.cs
+++ b/Source/CC_RP0/RP1ContractTracker.cs
@@ -69,7 +69,7 @@ namespace ContractConfigurator.RP0
                 {
                     foreach (VesselParameterGroup vpg in activeContract.GetChildren().Where(x => x is VesselParameterGroup))
                     {
-                        if (vpg.TrackedVessel.GetKCTVesselId() == trackedVessel.GetKCTVesselId())
+                        if (vpg.TrackedVessel?.GetKCTVesselId() == trackedVessel.GetKCTVesselId())
                             CheckVPG(vpg);
                     }
                 }


### PR DESCRIPTION
Fixes the following issue:

When I force-complete the Karman Line contract via the Active Contracts tab in the debug menu (notably, does not happen with the First Launch contract) while on the launchpad, I get some errors from RP-1

<img width="1521" height="855" alt="Image" src="https://github.com/user-attachments/assets/c1b880ce-8223-43d5-9755-4fa8b825380a" />

```
[LOG 15:39:20.947] Awarding 6 reputation to player for contract completion
[LOG 15:39:20.948] Contract (First Launch): Congratulations! Your space program is off to a great start. Now it is time for some rocket science as you need to continue to go higher, faster, and farther.

<b><color=#8BED8B>Completion Rewards:</color></b> 
<color=#E0D503><sprite="CurrencySpriteAsset" name="Reputation" tint=1> 6   </color>


[LOG 15:39:21.665] Awarding 12 reputation to player for contract completion
[LOG 15:39:21.666] Contract (Karman Line): Congratulations! You've reached space!

<b><color=#8BED8B>Completion Rewards:</color></b> 
<color=#E0D503><sprite="CurrencySpriteAsset" name="Reputation" tint=1> 12   </color>
Gain 10 Applicants!


[ERR 15:39:21.666] Exception handling event Contract.Completed in class RP1ContractTracker:System.NullReferenceException: Object reference not set to an instance of an object
  at RP0.KCTUtilities.GetKCTVesselData (Vessel v) [0x00000] in <23b02108a1db413dbf81d6d388eff77e>:0 
  at RP0.KCTUtilities.GetKCTVesselId (Vessel v) [0x00000] in <23b02108a1db413dbf81d6d388eff77e>:0 
  at ContractConfigurator.RP0.RP1ContractTracker.CheckClosedVPGs (ContractConfigurator.ConfiguredContract cc, Vessel trackedVessel) [0x0005c] in <28370b1888304dfc8fdfb13def22be38>:0 
  at ContractConfigurator.RP0.RP1ContractTracker.OnContractCompleted (Contracts.Contract c) [0x0008f] in <28370b1888304dfc8fdfb13def22be38>:0 
  at EventData`1[T].Fire (T data) [0x000b0] in <4b449f2841f84227adfaad3149c8fdba>:0 

[EXC 15:39:21.667] NullReferenceException: Object reference not set to an instance of an object
	RP0.KCTUtilities.GetKCTVesselData (Vessel v) (at <23b02108a1db413dbf81d6d388eff77e>:0)
	RP0.KCTUtilities.GetKCTVesselId (Vessel v) (at <23b02108a1db413dbf81d6d388eff77e>:0)
	ContractConfigurator.RP0.RP1ContractTracker.CheckClosedVPGs (ContractConfigurator.ConfiguredContract cc, Vessel trackedVessel) (at <28370b1888304dfc8fdfb13def22be38>:0)
	ContractConfigurator.RP0.RP1ContractTracker.OnContractCompleted (Contracts.Contract c) (at <28370b1888304dfc8fdfb13def22be38>:0)
	EventData`1[T].Fire (T data) (at <4b449f2841f84227adfaad3149c8fdba>:0)
	UnityEngine.DebugLogHandler:LogException(Exception, Object)
	ModuleManager.UnityLogHandle.InterceptLogHandler:LogException(Exception, Object)
	UnityEngine.Debug:LogException(Exception)
	EventData`1:Fire(Contract)
	Contracts.Contract:SetState(State)
	Contracts.Contract:Complete()
	KSP.UI.Screens.DebugToolbar.Screens.Contract.ScreenContractExistingItem:OnLeftButtonClicked()
	UnityEngine.EventSystems.EventSystem:Update()
```