### PR TITLE
Improve display of leader unlocks on contracts with a minimum count

### DIFF
--- a/Source/RP0/Harmony/Contract.cs
+++ b/Source/RP0/Harmony/Contract.cs
@@ -68,9 +68,12 @@ namespace RP0.Harmony
                     value += $"\n{KSP.Localization.Localizer.Format("#rp0_ContractRewards_GainApplicants", applicants)}";
             }
 
-            var leaderTitles = LeaderUtils.GetLeadersUnlockedByContract(_contract)
+            var leaderTitles = LeaderUtils.GetLeadersUnlockedByContract(_contract, _contract.ContractState != Contract.State.Completed)
                 .Where(s => !_isReward || !s.IsUnlocked())
                 .Select(s => s.title);
+            // TODO: for contracts with multiple completions where only one triggers a strategy unlock, if the user looks in the archive window while on that completion count,
+            // all of the past contracts of that type will show the strategy unlocks. not sure of a great way around this.
+            // additionally, once the user has more completions than the contract requires to unlock the strategy, the strategy will no longer be shown in the archive window.
             string leaderString = string.Join("\n", leaderTitles);
             if (!string.IsNullOrEmpty(leaderString))
                 value += "\n" + KSP.Localization.Localizer.Format(_isReward ? "#rp0_Leaders_LeadersUnlocked" : "#rp0_Leaders_UnlocksLeader") + leaderString;

--- a/Source/RP0/Leaders/LeaderUtils.cs
+++ b/Source/RP0/Leaders/LeaderUtils.cs
@@ -53,7 +53,8 @@ namespace RP0.Leaders
                             s.RequirementsBlock.ChildBlocks.Count == 0 &&
                             s.RequirementsBlock.Reqs.Any(r => !r.IsInverted &&
                                                               r is Requirements.ContractRequirement cr &&
-                                                              cr.ContractName == cc.contractType.name));
+                                                              cr.ContractName == cc.contractType.name &&
+                                                              cr.IsAlmostMet));
         }
 
         public static IEnumerable<StrategyConfigRP0> GetLeadersUnlockedByProgram(string programName)

--- a/Source/RP0/Leaders/LeaderUtils.cs
+++ b/Source/RP0/Leaders/LeaderUtils.cs
@@ -44,7 +44,7 @@ namespace RP0.Leaders
                                                               cr.TechName == techID));
         }
 
-        public static IEnumerable<StrategyConfigRP0> GetLeadersUnlockedByContract(ConfiguredContract cc)
+        public static IEnumerable<StrategyConfigRP0> GetLeadersUnlockedByContract(ConfiguredContract cc, bool unlockNextCompletion)
         {
             return GetAllLeaderStrategies()
                 .Where(s => s.RequirementsBlock != null &&
@@ -54,7 +54,7 @@ namespace RP0.Leaders
                             s.RequirementsBlock.Reqs.Any(r => !r.IsInverted &&
                                                               r is Requirements.ContractRequirement cr &&
                                                               cr.ContractName == cc.contractType.name &&
-                                                              cr.IsAlmostMet));
+                                                              (unlockNextCompletion ? cr.IsAlmostMet : cr.IsStrictlyMet)));
         }
 
         public static IEnumerable<StrategyConfigRP0> GetLeadersUnlockedByProgram(string programName)

--- a/Source/RP0/Requirements/Requirements.cs
+++ b/Source/RP0/Requirements/Requirements.cs
@@ -31,62 +31,26 @@ namespace RP0.Requirements
 
         public uint? MinCount { get; set; }
 
-        public override bool IsMet
-        {
-            get
-            {
-                bool isMet;
-                if (MinCount.HasValue && MinCount > 1)
-                {
-                    int c = ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) ? list.Count : 0;
-                    isMet = c >= MinCount;
-                }
-                else
-                {
-                    isMet = ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) && list.Count > 0;
-                }
+        private bool HasMinCount => MinCount.HasValue && MinCount > 1;
 
-                return IsInverted ? !isMet : isMet;
-            }
-        }
+        private int CompletedCount => ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) ? list.Count : 0;
 
-        public bool IsStrictlyMet
-        {
-            get
-            {
-                bool isStrictlyMet;
-                if (MinCount.HasValue && MinCount > 1)
-                {
-                    int c = ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) ? list.Count : 0;
-                    isStrictlyMet = c == MinCount;
-                }
-                else
-                {
-                    isStrictlyMet = ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) && list.Count > 0;
-                }
+        private bool ApplyInversion(bool met) => IsInverted ? !met : met;
 
-                return IsInverted ? !isStrictlyMet : isStrictlyMet;
-            }
-        }
+        /// <summary>
+        /// Has been met
+        /// </summary>
+        public override bool IsMet => ApplyInversion(HasMinCount ? CompletedCount >= MinCount : CompletedCount > 0);
 
-        public bool IsAlmostMet
-        {
-            get
-            {
-                bool isAlmostMet;
-                if (MinCount.HasValue && MinCount > 1)
-                {
-                    int c = ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) ? list.Count : 0;
-                    isAlmostMet = c == MinCount - 1;
-                }
-                else
-                {
-                    isAlmostMet = false;
-                }
+        /// <summary>
+        /// Has been met on exactly this completion
+        /// </summary>
+        public bool IsStrictlyMet => ApplyInversion(HasMinCount ? CompletedCount == MinCount : CompletedCount > 0);
 
-                return IsInverted ? !isAlmostMet : isAlmostMet;
-            }
-        }
+        /// <summary>
+        /// Will be met on the next completion
+        /// </summary>
+        public bool IsAlmostMet => ApplyInversion(HasMinCount ? CompletedCount == MinCount - 1 : CompletedCount == 0);
 
         public ContractRequirement()
         {

--- a/Source/RP0/Requirements/Requirements.cs
+++ b/Source/RP0/Requirements/Requirements.cs
@@ -50,6 +50,25 @@ namespace RP0.Requirements
             }
         }
 
+        public bool IsAlmostMet
+        {
+            get
+            {
+                bool isAlmostMet;
+                if (MinCount.HasValue && MinCount > 1)
+                {
+                    int c = ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) ? list.Count : 0;
+                    isAlmostMet = c == MinCount - 1;
+                }
+                else
+                {
+                    isAlmostMet = ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) && list.Count > 0;
+                }
+
+                return IsInverted ? !isAlmostMet : isAlmostMet;
+            }
+        }
+
         public ContractRequirement()
         {
         }

--- a/Source/RP0/Requirements/Requirements.cs
+++ b/Source/RP0/Requirements/Requirements.cs
@@ -62,7 +62,7 @@ namespace RP0.Requirements
                 }
                 else
                 {
-                    isAlmostMet = ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) && list.Count > 0;
+                    isAlmostMet = false;
                 }
 
                 return IsInverted ? !isAlmostMet : isAlmostMet;

--- a/Source/RP0/Requirements/Requirements.cs
+++ b/Source/RP0/Requirements/Requirements.cs
@@ -39,7 +39,7 @@ namespace RP0.Requirements
                 if (MinCount.HasValue && MinCount > 1)
                 {
                     int c = ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) ? list.Count : 0;
-                    isMet =  c >= MinCount;
+                    isMet = c >= MinCount;
                 }
                 else
                 {

--- a/Source/RP0/Requirements/Requirements.cs
+++ b/Source/RP0/Requirements/Requirements.cs
@@ -50,6 +50,25 @@ namespace RP0.Requirements
             }
         }
 
+        public bool IsStrictlyMet
+        {
+            get
+            {
+                bool isStrictlyMet;
+                if (MinCount.HasValue && MinCount > 1)
+                {
+                    int c = ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) ? list.Count : 0;
+                    isStrictlyMet = c == MinCount;
+                }
+                else
+                {
+                    isStrictlyMet = ConfiguredContract.CompletedContractsByName.TryGetValue(ContractName, out var list) && list.Count > 0;
+                }
+
+                return IsInverted ? !isStrictlyMet : isStrictlyMet;
+            }
+        }
+
         public bool IsAlmostMet
         {
             get

--- a/Source/RP0/Singletons/LeaderNotifications.cs
+++ b/Source/RP0/Singletons/LeaderNotifications.cs
@@ -62,7 +62,7 @@ namespace RP0.Singletons
         {
             if (data is ConfiguredContract cc)
             {
-                var leadersUnlockedByThis = LeaderUtils.GetLeadersUnlockedByContract(cc);
+                var leadersUnlockedByThis = LeaderUtils.GetLeadersUnlockedByContract(cc, false);
                 AddNewLeadersUnlockedMessage(leadersUnlockedByThis);
             }
         }


### PR DESCRIPTION
Fix https://github.com/KSP-RO/RP-1/issues/2304

The text to show which leaders will be unlocked by a contract will only be shown if you are one before meeting the minCount completions of that contract to unlock the leader

Example (flight directors are unlocked when completing the 25km contract):

<img width="838" height="1115" alt="image" src="https://github.com/user-attachments/assets/24499c5c-a0d2-41cd-a825-6fe3fa398d59" />
<img width="847" height="1068" alt="image" src="https://github.com/user-attachments/assets/27dc03b3-5dce-4d6b-b2c6-fc55fe9dc3e7" />
<img width="839" height="1121" alt="image" src="https://github.com/user-attachments/assets/cac86315-2994-4d99-a1ab-b39a34fd069e" />
<img width="846" height="1105" alt="image" src="https://github.com/user-attachments/assets/52cbc390-bfa0-42fa-9593-90515e07f0c9" />
