### PR TITLE
Add SustainedCruise contract parameter (range-based endurance)

### DIFF
--- a/Source/CC_RP0/CC_RP0.csproj
+++ b/Source/CC_RP0/CC_RP0.csproj
@@ -106,6 +106,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Parameter\RP1ReturnHome.cs" />
     <Compile Include="ParameterFactory\RP1ReturnHomeFactory.cs" />
+    <Compile Include="Parameter\SustainedCruiseVesselParam.cs" />
+    <Compile Include="ParameterFactory\SustainedCruiseFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RP0\RP0.csproj">

--- a/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
+++ b/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
@@ -5,31 +5,31 @@ using UnityEngine;
 namespace ContractConfigurator.RP0
 {
     /// <summary>
-    /// A single sustained-cruise test. The active vessel must hold ALL of these SIMULTANEOUSLY and
-    /// continuously for holdSeconds:
+    /// Instantaneous cruise-endurance test: met while the active vessel simultaneously satisfies ALL of:
     ///   * surface speed within [minSpeed, maxSpeed]
     ///   * vertical speed within [minVerticalSpeed, maxVerticalSpeed]
     ///   * projected range >= requiredRange
     ///
     /// Endurance is measured as RANGE rather than time, so flying faster and/or more efficiently (e.g.
-    /// higher, where jets burn less for the same speed) is rewarded. Any violation resets the continuous
-    /// hold timer, so the conditions can't be satisfied separately ("cheesed") -- they must all be true at
-    /// once for the whole period.
+    /// higher, where jets burn less for the same speed) is rewarded. Range is computed for EVERY mass-bearing
+    /// propellant the vessel is actively burning (jets run on all sorts of resources here -- kerosene,
+    /// hydrogen, methane, nitrous, water injection, enriched uranium), and the reported range is the MINIMUM
+    /// across them, i.e. whichever fuel runs out first. Each fuel's burn rate is averaged over a rolling
+    /// rateWindowSeconds, and samples are only taken while at cruise speed so the rate is representative.
+    /// Massless resources (ElectricCharge, IntakeAir) are ignored.
     ///
-    /// Range is computed for EVERY mass-bearing propellant the vessel is actively burning (jets run on all
-    /// sorts of resources here -- kerosene, hydrogen, methane, nitrous, water injection, enriched uranium),
-    /// and the reported range is the MINIMUM across them, i.e. whichever fuel runs out first. Each fuel's
-    /// burn rate is averaged over a rolling rateWindowSeconds, and samples are only taken while at cruise
-    /// speed so the rate is representative. Massless resources (ElectricCharge, IntakeAir) are ignored.
+    /// This parameter is a plain instantaneous check. To require the condition be held for a time -- and to
+    /// get a countdown display -- pair it with a stock Duration parameter placed as a LATER sibling, and set
+    /// disableOnStateChange = false here so its state toggles as the vessel enters/leaves the band (Duration
+    /// times only while its preceding siblings are Complete, and resets when one stops).
     ///
-    /// Config: requiredRange m (req), holdSeconds (def 300), minSpeed/maxSpeed m/s,
-    /// minVerticalSpeed/maxVerticalSpeed m/s, rateWindowSeconds (def 30), updateFrequency (def 0.5).
-    /// Enable CC verbose logging to see the per-tick speed/VS/range/held values.
+    /// Config: requiredRange m (req), minSpeed/maxSpeed m/s, minVerticalSpeed/maxVerticalSpeed m/s,
+    /// rateWindowSeconds (def 30), updateFrequency (def 0.5). Enable CC verbose logging to see the per-tick
+    /// speed/VS/range/met values.
     /// </summary>
     public class SustainedCruise : VesselParameter
     {
         protected double requiredRange { get; set; }
-        protected double holdSeconds { get; set; }
         protected double minSpeed { get; set; }
         protected double maxSpeed { get; set; }
         protected double minVerticalSpeed { get; set; }
@@ -37,7 +37,6 @@ namespace ContractConfigurator.RP0
         protected double rateWindowSeconds { get; set; }
         protected float updateFrequency { get; set; }
 
-        internal const double DEFAULT_HOLD = 300.0;
         internal const double DEFAULT_RATE_WINDOW = 30.0;
         internal const float DEFAULT_UPDATE_FREQUENCY = 0.5f;
         private const double MIN_RATE = 1e-4;   // below this the craft isn't really burning this resource
@@ -46,7 +45,7 @@ namespace ContractConfigurator.RP0
         private double lastCheckTime = double.NegativeInfinity;
         private int lastPartCount = -1;
         private uint lastVesselPersistentId;
-        private double heldTime = 0.0;   // continuous time all conditions have held
+        private bool met = false;   // whether all conditions were satisfied as of the last sample
         // Rolling per-tick samples for the burn-rate average: sampleTimes[k] holds the time of tick k, and
         // sampleAmounts[k] maps resource id -> total amount on the vessel at that tick.
         private readonly List<double> sampleTimes = new List<double>();
@@ -55,13 +54,12 @@ namespace ContractConfigurator.RP0
 
         public SustainedCruise() : base(null) { }
 
-        public SustainedCruise(string title, double requiredRange, double holdSeconds,
+        public SustainedCruise(string title, double requiredRange,
                                double minSpeed, double maxSpeed, double minVerticalSpeed, double maxVerticalSpeed,
                                double rateWindowSeconds, float updateFrequency)
             : base(title)
         {
             this.requiredRange = requiredRange;
-            this.holdSeconds = holdSeconds;
             this.minSpeed = minSpeed;
             this.maxSpeed = maxSpeed;
             this.minVerticalSpeed = minVerticalSpeed;
@@ -75,7 +73,6 @@ namespace ContractConfigurator.RP0
         {
             base.OnParameterSave(node);
             node.AddValue("requiredRange", requiredRange);
-            node.AddValue("holdSeconds", holdSeconds);
             node.AddValue("minSpeed", minSpeed);
             node.AddValue("maxSpeed", maxSpeed);
             node.AddValue("minVerticalSpeed", minVerticalSpeed);
@@ -88,7 +85,6 @@ namespace ContractConfigurator.RP0
         {
             base.OnParameterLoad(node);
             requiredRange = ConfigNodeUtil.ParseValue<double>(node, "requiredRange");
-            holdSeconds = ConfigNodeUtil.ParseValue<double>(node, "holdSeconds", DEFAULT_HOLD);
             minSpeed = ConfigNodeUtil.ParseValue<double>(node, "minSpeed", 0.0);
             maxSpeed = ConfigNodeUtil.ParseValue<double>(node, "maxSpeed", double.MaxValue);
             minVerticalSpeed = ConfigNodeUtil.ParseValue<double>(node, "minVerticalSpeed", double.MinValue);
@@ -100,16 +96,14 @@ namespace ContractConfigurator.RP0
         protected override string GetParameterTitle()
         {
             double km = requiredRange / 1000.0;
-            double hold = holdSeconds / 60.0;
             string band = maxSpeed >= double.MaxValue * 0.5 ? $">= {minSpeed:0} m/s" : $"{minSpeed:0}-{maxSpeed:0} m/s";
-            return $"Sustain cruise for {hold:0} min: range >= {km:0} km, speed {band}";
+            return $"Cruise: range >= {km:0} km, speed {band}";
         }
 
         private void ResetAll()
         {
             sampleTimes.Clear();
             sampleAmounts.Clear();
-            heldTime = 0.0;
         }
 
         // Smallest projected range (m) across every mass-bearing resource the craft is actively burning,
@@ -206,7 +200,6 @@ namespace ContractConfigurator.RP0
                 lastVesselPersistentId = v.persistentId;
                 lastPartCount = v.parts.Count;
                 ResetAll();
-                dt = 0.0;
             }
             lastCheckTime = now;
 
@@ -214,11 +207,12 @@ namespace ContractConfigurator.RP0
             double vs = v.verticalSpeed;
             bool speedOk = speed >= minSpeed && speed <= maxSpeed;
 
-            // Out of the cruise speed band: rate isn't representative and the hold is broken. Drop the
-            // window + timer so endurance can't be "proven" by slowing down.
+            // Out of the cruise speed band: rate isn't representative. Drop the window so the burn rate has
+            // to rebuild before range can be proven again, and mark the condition unmet.
             if (!speedOk)
             {
                 ResetAll();
+                met = false;
                 LogState(speed, vs, false, false, false, 0.0, null);
                 CheckVessel(v);
                 return;
@@ -235,9 +229,7 @@ namespace ContractConfigurator.RP0
             bool rateReady = TryMinRange(v, speed, out double range, out PartResourceDefinition limiter);
             bool vsOk = vs >= minVerticalSpeed && vs <= maxVerticalSpeed;
             bool rangeOk = rateReady && range >= requiredRange;
-
-            if (vsOk && rangeOk) heldTime += dt;   // speedOk already true here
-            else heldTime = 0.0;
+            met = vsOk && rangeOk;   // speedOk already true here
 
             LogState(speed, vs, speedOk, vsOk, rangeOk, range, limiter);
             CheckVessel(v);
@@ -245,15 +237,15 @@ namespace ContractConfigurator.RP0
 
         private void LogState(double speed, double vs, bool speedOk, bool vsOk, bool rangeOk, double range, PartResourceDefinition limiter)
         {
-            LoggingUtil.LogVerbose(this, "SustainedCruise spd={0:0}({1}) vs={2:0.0}({3}) range={4:0}/{5:0}km({6}) limiter={7} held={8:0}/{9:0}s",
+            LoggingUtil.LogVerbose(this, "SustainedCruise spd={0:0}({1}) vs={2:0.0}({3}) range={4:0}/{5:0}km({6}) limiter={7} -> {8}",
                 speed, speedOk ? "ok" : "X", vs, vsOk ? "ok" : "X",
                 range / 1000.0, requiredRange / 1000.0, rangeOk ? "ok" : "X",
-                limiter != null ? limiter.name : "-", heldTime, holdSeconds);
+                limiter != null ? limiter.name : "-", met ? "IN" : "out");
         }
 
         protected override bool VesselMeetsCondition(Vessel vessel)
         {
-            return vessel == FlightGlobals.ActiveVessel && heldTime >= holdSeconds;
+            return vessel == FlightGlobals.ActiveVessel && met;
         }
     }
 }

--- a/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
+++ b/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
@@ -46,6 +46,7 @@ namespace ContractConfigurator.RP0
         private int lastPartCount = -1;
         private uint lastVesselPersistentId;
         private bool met = false;   // whether all conditions were satisfied as of the last sample
+        private double curRange = 0.0;   // most recent projected range (m), shown live in the contract title
         // Rolling per-tick samples for the burn-rate average: sampleTimes[k] holds the time of tick k, and
         // sampleAmounts[k] maps resource id -> total amount on the vessel at that tick.
         private readonly List<double> sampleTimes = new List<double>();
@@ -66,7 +67,7 @@ namespace ContractConfigurator.RP0
             this.maxVerticalSpeed = maxVerticalSpeed;
             this.rateWindowSeconds = rateWindowSeconds;
             this.updateFrequency = updateFrequency;
-            this.title = GetParameterTitle();
+            // Leave title unset so GetTitle() falls back to GetParameterTitle() each redraw (live range).
         }
 
         protected override void OnParameterSave(ConfigNode node)
@@ -95,9 +96,11 @@ namespace ContractConfigurator.RP0
 
         protected override string GetParameterTitle()
         {
-            double km = requiredRange / 1000.0;
+            double reqKm = requiredRange / 1000.0;
             string band = maxSpeed >= double.MaxValue * 0.5 ? $">= {minSpeed:0} m/s" : $"{minSpeed:0}-{maxSpeed:0} m/s";
-            return $"Cruise: range >= {km:0} km, speed {band}";
+            if (FlightGlobals.ActiveVessel == null)
+                return $"Cruise: range >= {reqKm:0} km, speed {band}";
+            return $"Cruise: range {curRange / 1000.0:0} / {reqKm:0} km, speed {band}";
         }
 
         private void ResetAll()
@@ -213,8 +216,10 @@ namespace ContractConfigurator.RP0
             {
                 ResetAll();
                 met = false;
+                curRange = 0.0;
                 LogState(speed, vs, false, false, false, 0.0, null);
                 CheckVessel(v);
+                GetTitle();   // refresh the contracts app with the live range
                 return;
             }
 
@@ -230,9 +235,11 @@ namespace ContractConfigurator.RP0
             bool vsOk = vs >= minVerticalSpeed && vs <= maxVerticalSpeed;
             bool rangeOk = rateReady && range >= requiredRange;
             met = vsOk && rangeOk;   // speedOk already true here
+            curRange = rateReady ? range : 0.0;
 
             LogState(speed, vs, speedOk, vsOk, rangeOk, range, limiter);
             CheckVessel(v);
+            GetTitle();   // refresh the contracts app with the live range
         }
 
         private void LogState(double speed, double vs, bool speedOk, bool vsOk, bool rangeOk, double range, PartResourceDefinition limiter)

--- a/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
+++ b/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
@@ -1,0 +1,227 @@
+using System.Collections.Generic;
+using ContractConfigurator.Parameters;
+using UnityEngine;
+
+namespace ContractConfigurator.RP0
+{
+    /// <summary>
+    /// A single sustained-cruise test. The active vessel must hold ALL of these SIMULTANEOUSLY and
+    /// continuously for holdSeconds:
+    ///   * surface speed within [minSpeed, maxSpeed]
+    ///   * vertical speed within [minVerticalSpeed, maxVerticalSpeed]
+    ///   * projected range >= requiredRange, where range = speed * (fuel / averageBurnRate)
+    ///
+    /// Endurance is measured as RANGE rather than time, so flying faster and/or more efficiently (e.g.
+    /// higher, where jets burn less for the same speed) is rewarded. Any violation resets the continuous
+    /// hold timer, so the conditions can't be satisfied separately ("cheesed") -- they must all be true at
+    /// once for the whole period. Burn rate is averaged over a rolling rateWindowSeconds, and samples are
+    /// only taken while at cruise speed so the rate is representative.
+    ///
+    /// Config: resource (req), requiredRange m (req), holdSeconds (def 300), minSpeed/maxSpeed m/s,
+    /// minVerticalSpeed/maxVerticalSpeed m/s, rateWindowSeconds (def 30), updateFrequency (def 0.5),
+    /// debug (def false; set true to log the per-tick speed/VS/range/held values).
+    /// </summary>
+    public class SustainedCruise : VesselParameter
+    {
+        protected PartResourceDefinition resource { get; set; }
+        protected double requiredRange { get; set; }
+        protected double holdSeconds { get; set; }
+        protected double minSpeed { get; set; }
+        protected double maxSpeed { get; set; }
+        protected double minVerticalSpeed { get; set; }
+        protected double maxVerticalSpeed { get; set; }
+        protected double rateWindowSeconds { get; set; }
+        protected float updateFrequency { get; set; }
+        protected bool debug { get; set; }
+
+        internal const double DEFAULT_HOLD = 300.0;
+        internal const double DEFAULT_RATE_WINDOW = 30.0;
+        internal const float DEFAULT_UPDATE_FREQUENCY = 0.5f;
+        private const double MIN_RATE = 1e-4;   // below this the craft isn't really burning fuel
+
+        private float lastUpdate = 0f;
+        private double lastCheckTime = double.NegativeInfinity;
+        private int lastPartCount = -1;
+        private uint lastVesselPersistentId;
+        private float lastDebugLog = 0f;
+        private double heldTime = 0.0;   // continuous time all conditions have held
+        // Rolling (time, amount) samples for the burn-rate average.
+        private readonly List<double> sampleTimes = new List<double>();
+        private readonly List<double> sampleAmounts = new List<double>();
+
+        public SustainedCruise() : base(null) { }
+
+        public SustainedCruise(string title, PartResourceDefinition resource, double requiredRange, double holdSeconds,
+                               double minSpeed, double maxSpeed, double minVerticalSpeed, double maxVerticalSpeed,
+                               double rateWindowSeconds, float updateFrequency, bool debug)
+            : base(title)
+        {
+            this.resource = resource;
+            this.requiredRange = requiredRange;
+            this.holdSeconds = holdSeconds;
+            this.minSpeed = minSpeed;
+            this.maxSpeed = maxSpeed;
+            this.minVerticalSpeed = minVerticalSpeed;
+            this.maxVerticalSpeed = maxVerticalSpeed;
+            this.rateWindowSeconds = rateWindowSeconds;
+            this.updateFrequency = updateFrequency;
+            this.debug = debug;
+            this.title = GetParameterTitle();
+        }
+
+        protected override void OnParameterSave(ConfigNode node)
+        {
+            base.OnParameterSave(node);
+            node.AddValue("resource", resource.name);
+            node.AddValue("requiredRange", requiredRange);
+            node.AddValue("holdSeconds", holdSeconds);
+            node.AddValue("minSpeed", minSpeed);
+            node.AddValue("maxSpeed", maxSpeed);
+            node.AddValue("minVerticalSpeed", minVerticalSpeed);
+            node.AddValue("maxVerticalSpeed", maxVerticalSpeed);
+            node.AddValue("rateWindowSeconds", rateWindowSeconds);
+            node.AddValue("updateFrequency", updateFrequency);
+            node.AddValue("debug", debug);
+        }
+
+        protected override void OnParameterLoad(ConfigNode node)
+        {
+            base.OnParameterLoad(node);
+            resource = PartResourceLibrary.Instance.GetDefinition(ConfigNodeUtil.ParseValue<string>(node, "resource"));
+            requiredRange = ConfigNodeUtil.ParseValue<double>(node, "requiredRange");
+            holdSeconds = ConfigNodeUtil.ParseValue<double>(node, "holdSeconds", DEFAULT_HOLD);
+            minSpeed = ConfigNodeUtil.ParseValue<double>(node, "minSpeed", 0.0);
+            maxSpeed = ConfigNodeUtil.ParseValue<double>(node, "maxSpeed", double.MaxValue);
+            minVerticalSpeed = ConfigNodeUtil.ParseValue<double>(node, "minVerticalSpeed", double.MinValue);
+            maxVerticalSpeed = ConfigNodeUtil.ParseValue<double>(node, "maxVerticalSpeed", double.MaxValue);
+            rateWindowSeconds = ConfigNodeUtil.ParseValue<double>(node, "rateWindowSeconds", DEFAULT_RATE_WINDOW);
+            updateFrequency = ConfigNodeUtil.ParseValue<float>(node, "updateFrequency", DEFAULT_UPDATE_FREQUENCY);
+            // bool collides with CC's (node, key, allowExpression) overload, so read it manually.
+            debug = false;
+            if (node.HasValue("debug") && bool.TryParse(node.GetValue("debug"), out bool db)) debug = db;
+        }
+
+        protected override string GetParameterTitle()
+        {
+            double km = requiredRange / 1000.0;
+            double hold = holdSeconds / 60.0;
+            string band = maxSpeed >= double.MaxValue * 0.5 ? $">= {minSpeed:0} m/s" : $"{minSpeed:0}-{maxSpeed:0} m/s";
+            return $"Sustain cruise for {hold:0} min: range >= {km:0} km, speed {band}";
+        }
+
+        private void ResetAll()
+        {
+            sampleTimes.Clear();
+            sampleAmounts.Clear();
+            heldTime = 0.0;
+        }
+
+        // Average burn rate (units/s) and current fuel over the rolling window; false until the window is
+        // filled with a contiguous run and the craft is actually burning fuel.
+        private bool TryRate(out double rate, out double current)
+        {
+            rate = 0.0; current = 0.0;
+            int n = sampleTimes.Count;
+            if (n < 2) return false;
+            double span = sampleTimes[n - 1] - sampleTimes[0];
+            current = sampleAmounts[n - 1];
+            if (span < rateWindowSeconds * 0.9) return false;
+            rate = (sampleAmounts[0] - sampleAmounts[n - 1]) / span;
+            return rate >= MIN_RATE;
+        }
+
+        // Still-air range the craft could cover from now. Uses the Breguet range equation, which accounts
+        // for the craft getting lighter as fuel burns (burn rate falls with weight in level cruise, so
+        // real range exceeds a naive fuel/rate*speed extrapolation):
+        //     range = speed * (M / massRate) * ln(M / Mempty)
+        // with M = current total mass and Mempty = mass once this resource is exhausted. Reduces to the
+        // linear form at small fuel fractions; falls back to it if mass/density data is unavailable.
+        private double ProjectedRange(Vessel v, double speed, double currentUnits, double rateUnits)
+        {
+            double dens = resource.density;                 // tonnes per unit
+            double M = v.totalMass;                          // current total mass (t)
+            double mFuel = currentUnits * dens;              // remaining mass of this resource (t)
+            double mEmpty = M - mFuel;                       // mass when it runs out (t)
+            double massRate = rateUnits * dens;              // burn rate (t/s)
+            if (dens > 0.0 && massRate > 0.0 && mFuel > 1e-6 && mEmpty > 1e-3)
+                return speed * (M / massRate) * System.Math.Log(M / mEmpty);
+            return speed * (currentUnits / rateUnits);       // linear fallback
+        }
+
+        protected override void OnUpdate()
+        {
+            base.OnUpdate();
+            Vessel v = FlightGlobals.ActiveVessel;
+            if (v == null) return;
+            if (Time.fixedTime - lastUpdate < updateFrequency) return;
+            lastUpdate = Time.fixedTime;
+
+            double now = Time.fixedTime;
+            double dt = now - lastCheckTime;
+            bool gap = dt > updateFrequency * 4.0 || dt < 0;   // pause / warp / first tick
+            if (v.persistentId != lastVesselPersistentId || v.parts.Count != lastPartCount || gap)
+            {
+                lastVesselPersistentId = v.persistentId;
+                lastPartCount = v.parts.Count;
+                ResetAll();
+                dt = 0.0;
+            }
+            lastCheckTime = now;
+
+            double speed = v.srfSpeed;
+            double vs = v.verticalSpeed;
+            bool speedOk = speed >= minSpeed && speed <= maxSpeed;
+
+            // Out of the cruise speed band: rate isn't representative and the hold is broken. Drop the
+            // window + timer so endurance can't be "proven" by slowing down.
+            if (!speedOk)
+            {
+                sampleTimes.Clear();
+                sampleAmounts.Clear();
+                heldTime = 0.0;
+                DebugLog(speed, vs, false, false, false, 0.0, 0.0, 0.0);
+                CheckVessel(v);
+                return;
+            }
+
+            double amount = 0.0;
+            for (int i = 0; i < v.parts.Count; i++)
+            {
+                PartResource pr = v.parts[i].Resources.Get(resource.id);
+                if (pr != null) amount += pr.amount;
+            }
+            sampleTimes.Add(now);
+            sampleAmounts.Add(amount);
+            while (sampleTimes.Count > 2 && now - sampleTimes[1] >= rateWindowSeconds)
+            {
+                sampleTimes.RemoveAt(0);
+                sampleAmounts.RemoveAt(0);
+            }
+
+            bool rateReady = TryRate(out double rate, out double current);
+            double range = rateReady ? ProjectedRange(v, speed, current, rate) : 0.0;
+            bool vsOk = vs >= minVerticalSpeed && vs <= maxVerticalSpeed;
+            bool rangeOk = rateReady && range >= requiredRange;
+
+            if (vsOk && rangeOk) heldTime += dt;   // speedOk already true here
+            else heldTime = 0.0;
+
+            DebugLog(speed, vs, speedOk, vsOk, rangeOk, range, rate, current);
+            CheckVessel(v);
+        }
+
+        private void DebugLog(double speed, double vs, bool speedOk, bool vsOk, bool rangeOk, double range, double rate, double current)
+        {
+            if (!debug || Time.fixedTime - lastDebugLog < 2.0f) return;
+            lastDebugLog = Time.fixedTime;
+            UnityEngine.Debug.Log($"[SustainedCruise] spd={speed:0}({(speedOk ? "ok" : "X")}) vs={vs:0.0}({(vsOk ? "ok" : "X")}) " +
+                $"{resource.name}={current:0} rate={rate:0.###}/s range={range / 1000.0:0}/{requiredRange / 1000.0:0}km({(rangeOk ? "ok" : "X")}) " +
+                $"held={heldTime:0}/{holdSeconds:0}s");
+        }
+
+        protected override bool VesselMeetsCondition(Vessel vessel)
+        {
+            return vessel == FlightGlobals.ActiveVessel && heldTime >= holdSeconds;
+        }
+    }
+}

--- a/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
+++ b/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
@@ -15,8 +15,10 @@ namespace ContractConfigurator.RP0
     /// propellant the vessel is actively burning (jets run on all sorts of resources here -- kerosene,
     /// hydrogen, methane, nitrous, water injection, enriched uranium), and the reported range is the MINIMUM
     /// across them, i.e. whichever fuel runs out first. Each fuel's burn rate is averaged over a rolling
-    /// rateWindowSeconds, and samples are only taken while at cruise speed so the rate is representative.
-    /// Massless resources (ElectricCharge, IntakeAir) are ignored.
+    /// rateWindowSeconds. Sampling runs continuously (even outside the speed band) so the projected range
+    /// can be shown while climbing to / accelerating into cruise; the rolling average simply converges to
+    /// the cruise burn rate within one window once speed settles. Massless resources (ElectricCharge,
+    /// IntakeAir) are ignored.
     ///
     /// This parameter is a plain instantaneous check. To require the condition be held for a time -- and to
     /// get a countdown display -- pair it with a stock Duration parameter placed as a LATER sibling, and set
@@ -208,21 +210,11 @@ namespace ContractConfigurator.RP0
 
             double speed = v.srfSpeed;
             double vs = v.verticalSpeed;
-            bool speedOk = speed >= minSpeed && speed <= maxSpeed;
 
-            // Out of the cruise speed band: rate isn't representative. Drop the window so the burn rate has
-            // to rebuild before range can be proven again, and mark the condition unmet.
-            if (!speedOk)
-            {
-                ResetAll();
-                met = false;
-                curRange = 0.0;
-                LogState(speed, vs, false, false, false, 0.0, null);
-                CheckVessel(v);
-                GetTitle();   // refresh the contracts app with the live range
-                return;
-            }
-
+            // Sample and project range every tick regardless of speed, so the estimate is shown even while
+            // outside the cruise band (climbing / accelerating in). The rolling rate converges to the cruise
+            // value within one window; met still requires speedOk each tick, so the Duration hold only
+            // accrues in-band and can't be "proven" out of band.
             sampleTimes.Add(now);
             sampleAmounts.Add(SampleResources(v));
             while (sampleTimes.Count > 2 && now - sampleTimes[1] >= rateWindowSeconds)
@@ -232,10 +224,12 @@ namespace ContractConfigurator.RP0
             }
 
             bool rateReady = TryMinRange(v, speed, out double range, out PartResourceDefinition limiter);
+            curRange = rateReady ? range : 0.0;
+
+            bool speedOk = speed >= minSpeed && speed <= maxSpeed;
             bool vsOk = vs >= minVerticalSpeed && vs <= maxVerticalSpeed;
             bool rangeOk = rateReady && range >= requiredRange;
-            met = vsOk && rangeOk;   // speedOk already true here
-            curRange = rateReady ? range : 0.0;
+            met = speedOk && vsOk && rangeOk;
 
             LogState(speed, vs, speedOk, vsOk, rangeOk, range, limiter);
             CheckVessel(v);

--- a/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
+++ b/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
@@ -9,21 +9,25 @@ namespace ContractConfigurator.RP0
     /// continuously for holdSeconds:
     ///   * surface speed within [minSpeed, maxSpeed]
     ///   * vertical speed within [minVerticalSpeed, maxVerticalSpeed]
-    ///   * projected range >= requiredRange, where range = speed * (fuel / averageBurnRate)
+    ///   * projected range >= requiredRange
     ///
     /// Endurance is measured as RANGE rather than time, so flying faster and/or more efficiently (e.g.
     /// higher, where jets burn less for the same speed) is rewarded. Any violation resets the continuous
     /// hold timer, so the conditions can't be satisfied separately ("cheesed") -- they must all be true at
-    /// once for the whole period. Burn rate is averaged over a rolling rateWindowSeconds, and samples are
-    /// only taken while at cruise speed so the rate is representative.
+    /// once for the whole period.
     ///
-    /// Config: resource (req), requiredRange m (req), holdSeconds (def 300), minSpeed/maxSpeed m/s,
-    /// minVerticalSpeed/maxVerticalSpeed m/s, rateWindowSeconds (def 30), updateFrequency (def 0.5),
-    /// debug (def false; set true to log the per-tick speed/VS/range/held values).
+    /// Range is computed for EVERY mass-bearing propellant the vessel is actively burning (jets run on all
+    /// sorts of resources here -- kerosene, hydrogen, methane, nitrous, water injection, enriched uranium),
+    /// and the reported range is the MINIMUM across them, i.e. whichever fuel runs out first. Each fuel's
+    /// burn rate is averaged over a rolling rateWindowSeconds, and samples are only taken while at cruise
+    /// speed so the rate is representative. Massless resources (ElectricCharge, IntakeAir) are ignored.
+    ///
+    /// Config: requiredRange m (req), holdSeconds (def 300), minSpeed/maxSpeed m/s,
+    /// minVerticalSpeed/maxVerticalSpeed m/s, rateWindowSeconds (def 30), updateFrequency (def 0.5).
+    /// Enable CC verbose logging to see the per-tick speed/VS/range/held values.
     /// </summary>
     public class SustainedCruise : VesselParameter
     {
-        protected PartResourceDefinition resource { get; set; }
         protected double requiredRange { get; set; }
         protected double holdSeconds { get; set; }
         protected double minSpeed { get; set; }
@@ -32,31 +36,30 @@ namespace ContractConfigurator.RP0
         protected double maxVerticalSpeed { get; set; }
         protected double rateWindowSeconds { get; set; }
         protected float updateFrequency { get; set; }
-        protected bool debug { get; set; }
 
         internal const double DEFAULT_HOLD = 300.0;
         internal const double DEFAULT_RATE_WINDOW = 30.0;
         internal const float DEFAULT_UPDATE_FREQUENCY = 0.5f;
-        private const double MIN_RATE = 1e-4;   // below this the craft isn't really burning fuel
+        private const double MIN_RATE = 1e-4;   // below this the craft isn't really burning this resource
 
         private float lastUpdate = 0f;
         private double lastCheckTime = double.NegativeInfinity;
         private int lastPartCount = -1;
         private uint lastVesselPersistentId;
-        private float lastDebugLog = 0f;
         private double heldTime = 0.0;   // continuous time all conditions have held
-        // Rolling (time, amount) samples for the burn-rate average.
+        // Rolling per-tick samples for the burn-rate average: sampleTimes[k] holds the time of tick k, and
+        // sampleAmounts[k] maps resource id -> total amount on the vessel at that tick.
         private readonly List<double> sampleTimes = new List<double>();
-        private readonly List<double> sampleAmounts = new List<double>();
+        private readonly List<Dictionary<int, double>> sampleAmounts = new List<Dictionary<int, double>>();
+        private readonly HashSet<int> massBearingIds = new HashSet<int>();
 
         public SustainedCruise() : base(null) { }
 
-        public SustainedCruise(string title, PartResourceDefinition resource, double requiredRange, double holdSeconds,
+        public SustainedCruise(string title, double requiredRange, double holdSeconds,
                                double minSpeed, double maxSpeed, double minVerticalSpeed, double maxVerticalSpeed,
-                               double rateWindowSeconds, float updateFrequency, bool debug)
+                               double rateWindowSeconds, float updateFrequency)
             : base(title)
         {
-            this.resource = resource;
             this.requiredRange = requiredRange;
             this.holdSeconds = holdSeconds;
             this.minSpeed = minSpeed;
@@ -65,14 +68,12 @@ namespace ContractConfigurator.RP0
             this.maxVerticalSpeed = maxVerticalSpeed;
             this.rateWindowSeconds = rateWindowSeconds;
             this.updateFrequency = updateFrequency;
-            this.debug = debug;
             this.title = GetParameterTitle();
         }
 
         protected override void OnParameterSave(ConfigNode node)
         {
             base.OnParameterSave(node);
-            node.AddValue("resource", resource.name);
             node.AddValue("requiredRange", requiredRange);
             node.AddValue("holdSeconds", holdSeconds);
             node.AddValue("minSpeed", minSpeed);
@@ -81,13 +82,11 @@ namespace ContractConfigurator.RP0
             node.AddValue("maxVerticalSpeed", maxVerticalSpeed);
             node.AddValue("rateWindowSeconds", rateWindowSeconds);
             node.AddValue("updateFrequency", updateFrequency);
-            node.AddValue("debug", debug);
         }
 
         protected override void OnParameterLoad(ConfigNode node)
         {
             base.OnParameterLoad(node);
-            resource = PartResourceLibrary.Instance.GetDefinition(ConfigNodeUtil.ParseValue<string>(node, "resource"));
             requiredRange = ConfigNodeUtil.ParseValue<double>(node, "requiredRange");
             holdSeconds = ConfigNodeUtil.ParseValue<double>(node, "holdSeconds", DEFAULT_HOLD);
             minSpeed = ConfigNodeUtil.ParseValue<double>(node, "minSpeed", 0.0);
@@ -96,9 +95,6 @@ namespace ContractConfigurator.RP0
             maxVerticalSpeed = ConfigNodeUtil.ParseValue<double>(node, "maxVerticalSpeed", double.MaxValue);
             rateWindowSeconds = ConfigNodeUtil.ParseValue<double>(node, "rateWindowSeconds", DEFAULT_RATE_WINDOW);
             updateFrequency = ConfigNodeUtil.ParseValue<float>(node, "updateFrequency", DEFAULT_UPDATE_FREQUENCY);
-            // bool collides with CC's (node, key, allowExpression) overload, so read it manually.
-            debug = false;
-            if (node.HasValue("debug") && bool.TryParse(node.GetValue("debug"), out bool db)) debug = db;
         }
 
         protected override string GetParameterTitle()
@@ -116,29 +112,51 @@ namespace ContractConfigurator.RP0
             heldTime = 0.0;
         }
 
-        // Average burn rate (units/s) and current fuel over the rolling window; false until the window is
-        // filled with a contiguous run and the craft is actually burning fuel.
-        private bool TryRate(out double rate, out double current)
+        // Smallest projected range (m) across every mass-bearing resource the craft is actively burning,
+        // i.e. whichever fuel is the endurance limiter. False until the window is filled with a contiguous
+        // run and at least one resource is actually being consumed. limitingResource names the limiter.
+        private bool TryMinRange(Vessel v, double speed, out double minRange, out PartResourceDefinition limitingResource)
         {
-            rate = 0.0; current = 0.0;
+            minRange = 0.0;
+            limitingResource = null;
             int n = sampleTimes.Count;
             if (n < 2) return false;
             double span = sampleTimes[n - 1] - sampleTimes[0];
-            current = sampleAmounts[n - 1];
             if (span < rateWindowSeconds * 0.9) return false;
-            rate = (sampleAmounts[0] - sampleAmounts[n - 1]) / span;
-            return rate >= MIN_RATE;
+
+            Dictionary<int, double> oldest = sampleAmounts[0];
+            Dictionary<int, double> newest = sampleAmounts[n - 1];
+            bool any = false;
+            double best = double.MaxValue;
+            foreach (KeyValuePair<int, double> kv in newest)
+            {
+                // Only rank resources present for the whole window, else a tank coming online mid-window
+                // reads as an impossibly high burn rate.
+                if (!oldest.TryGetValue(kv.Key, out double old)) continue;
+                double rate = (old - kv.Value) / span;
+                if (rate < MIN_RATE) continue;   // not really burning this one
+                PartResourceDefinition def = PartResourceLibrary.Instance.GetDefinition(kv.Key);
+                double range = ProjectedRange(v, speed, kv.Value, rate, def != null ? def.density : 0.0);
+                if (range < best)
+                {
+                    best = range;
+                    limitingResource = def;
+                }
+                any = true;
+            }
+            if (!any) return false;
+            minRange = best;
+            return true;
         }
 
-        // Still-air range the craft could cover from now. Uses the Breguet range equation, which accounts
-        // for the craft getting lighter as fuel burns (burn rate falls with weight in level cruise, so
-        // real range exceeds a naive fuel/rate*speed extrapolation):
+        // Still-air range the craft could cover from now on a single resource. Uses the Breguet range
+        // equation, which accounts for the craft getting lighter as fuel burns (burn rate falls with weight
+        // in level cruise, so real range exceeds a naive fuel/rate*speed extrapolation):
         //     range = speed * (M / massRate) * ln(M / Mempty)
         // with M = current total mass and Mempty = mass once this resource is exhausted. Reduces to the
         // linear form at small fuel fractions; falls back to it if mass/density data is unavailable.
-        private double ProjectedRange(Vessel v, double speed, double currentUnits, double rateUnits)
+        private double ProjectedRange(Vessel v, double speed, double currentUnits, double rateUnits, double dens)
         {
-            double dens = resource.density;                 // tonnes per unit
             double M = v.totalMass;                          // current total mass (t)
             double mFuel = currentUnits * dens;              // remaining mass of this resource (t)
             double mEmpty = M - mFuel;                       // mass when it runs out (t)
@@ -146,6 +164,30 @@ namespace ContractConfigurator.RP0
             if (dens > 0.0 && massRate > 0.0 && mFuel > 1e-6 && mEmpty > 1e-3)
                 return speed * (M / massRate) * System.Math.Log(M / mEmpty);
             return speed * (currentUnits / rateUnits);       // linear fallback
+        }
+
+        // Snapshot of every mass-bearing resource's vessel-wide total, keyed by resource id. Massless
+        // resources (ElectricCharge, IntakeAir) are skipped so they can't masquerade as a fuel.
+        private Dictionary<int, double> SampleResources(Vessel v)
+        {
+            massBearingIds.Clear();
+            for (int i = 0; i < v.parts.Count; i++)
+            {
+                PartResourceList prl = v.parts[i].Resources;
+                for (int j = 0; j < prl.Count; j++)
+                {
+                    PartResource pr = prl[j];
+                    if (pr.info.density > 0.0) massBearingIds.Add(pr.info.id);
+                }
+            }
+
+            var snapshot = new Dictionary<int, double>(massBearingIds.Count);
+            foreach (int id in massBearingIds)
+            {
+                v.GetConnectedResourceTotals(id, out double amount, out double _);
+                snapshot[id] = amount;
+            }
+            return snapshot;
         }
 
         protected override void OnUpdate()
@@ -176,47 +218,37 @@ namespace ContractConfigurator.RP0
             // window + timer so endurance can't be "proven" by slowing down.
             if (!speedOk)
             {
-                sampleTimes.Clear();
-                sampleAmounts.Clear();
-                heldTime = 0.0;
-                DebugLog(speed, vs, false, false, false, 0.0, 0.0, 0.0);
+                ResetAll();
+                LogState(speed, vs, false, false, false, 0.0, null);
                 CheckVessel(v);
                 return;
             }
 
-            double amount = 0.0;
-            for (int i = 0; i < v.parts.Count; i++)
-            {
-                PartResource pr = v.parts[i].Resources.Get(resource.id);
-                if (pr != null) amount += pr.amount;
-            }
             sampleTimes.Add(now);
-            sampleAmounts.Add(amount);
+            sampleAmounts.Add(SampleResources(v));
             while (sampleTimes.Count > 2 && now - sampleTimes[1] >= rateWindowSeconds)
             {
                 sampleTimes.RemoveAt(0);
                 sampleAmounts.RemoveAt(0);
             }
 
-            bool rateReady = TryRate(out double rate, out double current);
-            double range = rateReady ? ProjectedRange(v, speed, current, rate) : 0.0;
+            bool rateReady = TryMinRange(v, speed, out double range, out PartResourceDefinition limiter);
             bool vsOk = vs >= minVerticalSpeed && vs <= maxVerticalSpeed;
             bool rangeOk = rateReady && range >= requiredRange;
 
             if (vsOk && rangeOk) heldTime += dt;   // speedOk already true here
             else heldTime = 0.0;
 
-            DebugLog(speed, vs, speedOk, vsOk, rangeOk, range, rate, current);
+            LogState(speed, vs, speedOk, vsOk, rangeOk, range, limiter);
             CheckVessel(v);
         }
 
-        private void DebugLog(double speed, double vs, bool speedOk, bool vsOk, bool rangeOk, double range, double rate, double current)
+        private void LogState(double speed, double vs, bool speedOk, bool vsOk, bool rangeOk, double range, PartResourceDefinition limiter)
         {
-            if (!debug || Time.fixedTime - lastDebugLog < 2.0f) return;
-            lastDebugLog = Time.fixedTime;
-            UnityEngine.Debug.Log($"[SustainedCruise] spd={speed:0}({(speedOk ? "ok" : "X")}) vs={vs:0.0}({(vsOk ? "ok" : "X")}) " +
-                $"{resource.name}={current:0} rate={rate:0.###}/s range={range / 1000.0:0}/{requiredRange / 1000.0:0}km({(rangeOk ? "ok" : "X")}) " +
-                $"held={heldTime:0}/{holdSeconds:0}s");
+            LoggingUtil.LogVerbose(this, "SustainedCruise spd={0:0}({1}) vs={2:0.0}({3}) range={4:0}/{5:0}km({6}) limiter={7} held={8:0}/{9:0}s",
+                speed, speedOk ? "ok" : "X", vs, vsOk ? "ok" : "X",
+                range / 1000.0, requiredRange / 1000.0, rangeOk ? "ok" : "X",
+                limiter != null ? limiter.name : "-", heldTime, holdSeconds);
         }
 
         protected override bool VesselMeetsCondition(Vessel vessel)

--- a/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
+++ b/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
@@ -5,37 +5,16 @@ using UnityEngine;
 namespace ContractConfigurator.RP0
 {
     /// <summary>
-    /// Instantaneous cruise-endurance test: met while the active vessel simultaneously satisfies ALL of:
-    ///   * surface speed within [minSpeed, maxSpeed]
-    ///   * vertical speed within [minVerticalSpeed, maxVerticalSpeed]
-    ///   * projected range >= requiredRange
+    /// Instantaneous cruise-endurance check: met while the active vessel is within the [minSpeed, maxSpeed]
+    /// and [minVerticalSpeed, maxVerticalSpeed] bands AND its projected still-air range >= requiredRange.
+    /// Endurance is measured as RANGE, not time, so faster / more efficient flight is rewarded. Range is
+    /// projected per fuel and the minimum reported; how fuels are tracked lives on GatherEnginePropellants,
+    /// the min-range logic on TryMinRange, and the Breguet math on ProjectedRange.
     ///
-    /// Endurance is measured as RANGE rather than time, so flying faster and/or more efficiently (e.g.
-    /// higher, where jets burn less for the same speed) is rewarded. The fuels to project are gathered from
-    /// the propellants of currently-working engines (jets run on all sorts here -- kerosene, hydrogen,
-    /// methane, nitrous, water injection, enriched uranium), and the set is ADDITIVE: once a mass-bearing
-    /// propellant has been burned by a running engine it stays tracked even after that engine is shut down or
-    /// staged away, so switching engines/fuels midflight (RAPIER mode, water injection) keeps a valid
-    /// projection on every fuel the craft has used. (Staging itself changes part count, which resets the
-    /// rolling rate window -- mass jumps discontinuously -- so the projection re-warms over one window; the
-    /// tracked fuel SET still persists across it.) The reported range is the MINIMUM across
-    /// the tracked fuels still being consumed -- a fuel whose burn rate falls below MIN_RATE (e.g. its engine
-    /// is now off) simply drops out of the ranking. Each fuel's burn rate is averaged over a rolling
-    /// rateWindowSeconds. Sampling runs continuously (even outside the speed band) so the projected range
-    /// can be shown while climbing to / accelerating into cruise; the rolling average simply converges to
-    /// the cruise burn rate within one window once speed settles. Massless propellants (ElectricCharge,
-    /// IntakeAir) are never tracked.
-    ///
-    /// This parameter is a plain instantaneous check. To require the condition be held for a time -- and to
-    /// get a countdown display -- pair it with a stock Duration parameter placed as a LATER sibling, and set
-    /// disableOnStateChange = false here so its state toggles as the vessel enters/leaves the band (Duration
-    /// times only while its preceding siblings are Complete, and resets when one stops).
-    ///
-    /// Config: requiredRange m (req), minSpeed/maxSpeed m/s, minVerticalSpeed/maxVerticalSpeed m/s,
-    /// rateWindowSeconds (def 30), updateFrequency (def 0.5). Set the CC log level for the SustainedCruise
-    /// type to DEBUG (or VERBOSE) via an ADD_LOGLEVEL_EXCEPTION to see the per-tick speed/VS/range/met and
-    /// Breguet-input breakdown lines. (LogDebug, not LogVerbose, so it survives the Release build --
-    /// LogVerbose is [Conditional("DEBUG")] and gets compiled out.)
+    /// Pair with a LATER stock Duration sibling (and set disableOnStateChange = false here) to require the
+    /// band be held for a time with a countdown. Config keys: requiredRange (req, m), minSpeed, maxSpeed,
+    /// minVerticalSpeed, maxVerticalSpeed (m/s; all but requiredRange/minSpeed optional), rateWindowSeconds
+    /// (def 30), updateFrequency (def 0.5).
     /// </summary>
     public class SustainedCruise : VesselParameter
     {
@@ -107,9 +86,9 @@ namespace ContractConfigurator.RP0
             base.OnParameterLoad(node);
             requiredRange = ConfigNodeUtil.ParseValue<double>(node, "requiredRange");
             minSpeed = ConfigNodeUtil.ParseValue<double>(node, "minSpeed", 0.0);
-            maxSpeed = node.HasValue("maxSpeed") ? ConfigNodeUtil.ParseValue<double>(node, "maxSpeed") : (double?)null;
-            minVerticalSpeed = node.HasValue("minVerticalSpeed") ? ConfigNodeUtil.ParseValue<double>(node, "minVerticalSpeed") : (double?)null;
-            maxVerticalSpeed = node.HasValue("maxVerticalSpeed") ? ConfigNodeUtil.ParseValue<double>(node, "maxVerticalSpeed") : (double?)null;
+            maxSpeed = ConfigNodeUtil.ParseValue(node, "maxSpeed", (double?)null);
+            minVerticalSpeed = ConfigNodeUtil.ParseValue(node, "minVerticalSpeed", (double?)null);
+            maxVerticalSpeed = ConfigNodeUtil.ParseValue(node, "maxVerticalSpeed", (double?)null);
             rateWindowSeconds = ConfigNodeUtil.ParseValue<double>(node, "rateWindowSeconds", DEFAULT_RATE_WINDOW);
             updateFrequency = ConfigNodeUtil.ParseValue<float>(node, "updateFrequency", DEFAULT_UPDATE_FREQUENCY);
         }
@@ -304,8 +283,14 @@ namespace ContractConfigurator.RP0
             bool rangeOk = rateReady && range >= requiredRange;
             met = speedOk && vsOk && rangeOk;
 
-            LogState(speed, vs, speedOk, vsOk, rangeOk, range, limiter);
-            if (rateReady && limiter != null) LogRangeBreakdown(v, speed, limiter, limAmount, limRate, range);
+            // Gate the debug dumps on the log level so the params arrays / double boxing don't run every tick
+            // in the normal Release case. Set the CC log level for this type to DEBUG via an
+            // ADD_LOGLEVEL_EXCEPTION to see them (LogDebug, not LogVerbose, so they survive Release).
+            if (LoggingUtil.GetLogLevel(GetType()) <= LoggingUtil.LogLevel.DEBUG)
+            {
+                LogState(speed, vs, speedOk, vsOk, rangeOk, range, limiter);
+                if (rateReady && limiter != null) LogRangeBreakdown(v, speed, limiter, limAmount, limRate, range);
+            }
             CheckVessel(v);
             GetTitle();   // refresh the contracts app with the live range
         }

--- a/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
+++ b/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
@@ -114,10 +114,13 @@ namespace ContractConfigurator.RP0
         // Smallest projected range (m) across every mass-bearing resource the craft is actively burning,
         // i.e. whichever fuel is the endurance limiter. False until the window is filled with a contiguous
         // run and at least one resource is actually being consumed. limitingResource names the limiter.
-        private bool TryMinRange(Vessel v, double speed, out double minRange, out PartResourceDefinition limitingResource)
+        private bool TryMinRange(Vessel v, double speed, out double minRange, out PartResourceDefinition limitingResource,
+                                 out double limAmount, out double limRate)
         {
             minRange = 0.0;
             limitingResource = null;
+            limAmount = 0.0;
+            limRate = 0.0;
             int n = sampleTimes.Count;
             if (n < 2) return false;
             double span = sampleTimes[n - 1] - sampleTimes[0];
@@ -140,6 +143,8 @@ namespace ContractConfigurator.RP0
                 {
                     best = range;
                     limitingResource = def;
+                    limAmount = kv.Value;
+                    limRate = rate;
                 }
                 any = true;
             }
@@ -223,7 +228,8 @@ namespace ContractConfigurator.RP0
                 sampleAmounts.RemoveAt(0);
             }
 
-            bool rateReady = TryMinRange(v, speed, out double range, out PartResourceDefinition limiter);
+            bool rateReady = TryMinRange(v, speed, out double range, out PartResourceDefinition limiter,
+                                         out double limAmount, out double limRate);
             curRange = rateReady ? range : 0.0;
 
             bool speedOk = speed >= minSpeed && speed <= maxSpeed;
@@ -232,8 +238,27 @@ namespace ContractConfigurator.RP0
             met = speedOk && vsOk && rangeOk;
 
             LogState(speed, vs, speedOk, vsOk, rangeOk, range, limiter);
+            if (rateReady && limiter != null) LogRangeBreakdown(v, speed, limiter, limAmount, limRate, range);
             CheckVessel(v);
             GetTitle();   // refresh the contracts app with the live range
+        }
+
+        // Per-term dump of the Breguet inputs, to diff against FAR's PerformanceEnvelopeCalculator:
+        // FAR range reduces to V*(M/mdot)*ln(M/Mempty), the same formula, so any mismatch is in these
+        // inputs. Compare mdot against FAR's FuelFlowKgPerS / the engine PAW, and M/fuel against FAR's
+        // MassKg / UsableFuelKg. Both the Breguet and linear (fuel/rate) ranges are shown.
+        private void LogRangeBreakdown(Vessel v, double speed, PartResourceDefinition limiter, double amount, double rate, double range)
+        {
+            double dens = limiter.density;
+            double M = v.totalMass;
+            double mFuel = amount * dens;
+            double mEmpty = M - mFuel;
+            double mdotKgS = rate * dens * 1000.0;
+            double lnTerm = mEmpty > 1e-3 ? System.Math.Log(M / mEmpty) : 0.0;
+            double linear = speed * (amount / rate);
+            LoggingUtil.LogVerbose(this, "SustainedCruise[range] {0} V={1:0.0}m/s M={2:0.000}t fuel={3:0.000}t empty={4:0.000}t " +
+                "mdot={5:0.####}kg/s ln={6:0.####} breguet={7:0}m linear={8:0}m",
+                limiter.name, speed, M, mFuel, mEmpty, mdotKgS, lnTerm, range, linear);
         }
 
         private void LogState(double speed, double vs, bool speedOk, bool vsOk, bool rangeOk, double range, PartResourceDefinition limiter)

--- a/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
+++ b/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
@@ -11,14 +11,20 @@ namespace ContractConfigurator.RP0
     ///   * projected range >= requiredRange
     ///
     /// Endurance is measured as RANGE rather than time, so flying faster and/or more efficiently (e.g.
-    /// higher, where jets burn less for the same speed) is rewarded. Range is computed for EVERY mass-bearing
-    /// propellant the vessel is actively burning (jets run on all sorts of resources here -- kerosene,
-    /// hydrogen, methane, nitrous, water injection, enriched uranium), and the reported range is the MINIMUM
-    /// across them, i.e. whichever fuel runs out first. Each fuel's burn rate is averaged over a rolling
+    /// higher, where jets burn less for the same speed) is rewarded. The fuels to project are gathered from
+    /// the propellants of currently-working engines (jets run on all sorts here -- kerosene, hydrogen,
+    /// methane, nitrous, water injection, enriched uranium), and the set is ADDITIVE: once a mass-bearing
+    /// propellant has been burned by a running engine it stays tracked even after that engine is shut down or
+    /// staged away, so switching engines/fuels midflight (RAPIER mode, water injection) keeps a valid
+    /// projection on every fuel the craft has used. (Staging itself changes part count, which resets the
+    /// rolling rate window -- mass jumps discontinuously -- so the projection re-warms over one window; the
+    /// tracked fuel SET still persists across it.) The reported range is the MINIMUM across
+    /// the tracked fuels still being consumed -- a fuel whose burn rate falls below MIN_RATE (e.g. its engine
+    /// is now off) simply drops out of the ranking. Each fuel's burn rate is averaged over a rolling
     /// rateWindowSeconds. Sampling runs continuously (even outside the speed band) so the projected range
     /// can be shown while climbing to / accelerating into cruise; the rolling average simply converges to
-    /// the cruise burn rate within one window once speed settles. Massless resources (ElectricCharge,
-    /// IntakeAir) are ignored.
+    /// the cruise burn rate within one window once speed settles. Massless propellants (ElectricCharge,
+    /// IntakeAir) are never tracked.
     ///
     /// This parameter is a plain instantaneous check. To require the condition be held for a time -- and to
     /// get a countdown display -- pair it with a stock Duration parameter placed as a LATER sibling, and set
@@ -35,15 +41,16 @@ namespace ContractConfigurator.RP0
     {
         protected double requiredRange { get; set; }
         protected double minSpeed { get; set; }
-        protected double maxSpeed { get; set; }
-        protected double minVerticalSpeed { get; set; }
-        protected double maxVerticalSpeed { get; set; }
+        protected double? maxSpeed { get; set; }            // null = no upper speed bound
+        protected double? minVerticalSpeed { get; set; }    // null = no lower VS bound
+        protected double? maxVerticalSpeed { get; set; }    // null = no upper VS bound
         protected double rateWindowSeconds { get; set; }
         protected float updateFrequency { get; set; }
 
         internal const double DEFAULT_RATE_WINDOW = 30.0;
         internal const float DEFAULT_UPDATE_FREQUENCY = 0.5f;
         private const double MIN_RATE = 1e-4;   // below this the craft isn't really burning this resource
+        private const double EMPTY_UNITS = 1e-6;   // at/below this a resource is spent, not a live limiter
 
         private float lastUpdate = 0f;
         private double lastCheckTime = double.NegativeInfinity;
@@ -55,12 +62,21 @@ namespace ContractConfigurator.RP0
         // sampleAmounts[k] maps resource id -> total amount on the vessel at that tick.
         private readonly List<double> sampleTimes = new List<double>();
         private readonly List<Dictionary<int, double>> sampleAmounts = new List<Dictionary<int, double>>();
-        private readonly HashSet<int> massBearingIds = new HashSet<int>();
+        // Mass-bearing propellants ever burned by a working engine. Additive: only cleared when the active
+        // vessel changes, never on engine shutdown/staging, so old fuels keep projecting (see class summary).
+        private readonly HashSet<int> trackedPropellantIds = new HashSet<int>();
+        // Engines on the vessel, cached and only rebuilt on part-count / vessel change so the per-tick
+        // propellant gather doesn't walk every part's module list. Entries can go null if a part is destroyed
+        // between rebuilds, so the gather null-checks them.
+        private readonly List<ModuleEngines> engineCache = new List<ModuleEngines>();
+        // Snapshot dictionaries are pooled and reused across the rolling window so steady-state sampling
+        // doesn't allocate a fresh Dictionary every tick.
+        private readonly Stack<Dictionary<int, double>> dictPool = new Stack<Dictionary<int, double>>();
 
         public SustainedCruise() : base(null) { }
 
         public SustainedCruise(string title, double requiredRange,
-                               double minSpeed, double maxSpeed, double minVerticalSpeed, double maxVerticalSpeed,
+                               double minSpeed, double? maxSpeed, double? minVerticalSpeed, double? maxVerticalSpeed,
                                double rateWindowSeconds, float updateFrequency)
             : base(title)
         {
@@ -79,9 +95,9 @@ namespace ContractConfigurator.RP0
             base.OnParameterSave(node);
             node.AddValue("requiredRange", requiredRange);
             node.AddValue("minSpeed", minSpeed);
-            node.AddValue("maxSpeed", maxSpeed);
-            node.AddValue("minVerticalSpeed", minVerticalSpeed);
-            node.AddValue("maxVerticalSpeed", maxVerticalSpeed);
+            if (maxSpeed.HasValue) node.AddValue("maxSpeed", maxSpeed.Value);
+            if (minVerticalSpeed.HasValue) node.AddValue("minVerticalSpeed", minVerticalSpeed.Value);
+            if (maxVerticalSpeed.HasValue) node.AddValue("maxVerticalSpeed", maxVerticalSpeed.Value);
             node.AddValue("rateWindowSeconds", rateWindowSeconds);
             node.AddValue("updateFrequency", updateFrequency);
         }
@@ -91,9 +107,9 @@ namespace ContractConfigurator.RP0
             base.OnParameterLoad(node);
             requiredRange = ConfigNodeUtil.ParseValue<double>(node, "requiredRange");
             minSpeed = ConfigNodeUtil.ParseValue<double>(node, "minSpeed", 0.0);
-            maxSpeed = ConfigNodeUtil.ParseValue<double>(node, "maxSpeed", double.MaxValue);
-            minVerticalSpeed = ConfigNodeUtil.ParseValue<double>(node, "minVerticalSpeed", double.MinValue);
-            maxVerticalSpeed = ConfigNodeUtil.ParseValue<double>(node, "maxVerticalSpeed", double.MaxValue);
+            maxSpeed = node.HasValue("maxSpeed") ? ConfigNodeUtil.ParseValue<double>(node, "maxSpeed") : (double?)null;
+            minVerticalSpeed = node.HasValue("minVerticalSpeed") ? ConfigNodeUtil.ParseValue<double>(node, "minVerticalSpeed") : (double?)null;
+            maxVerticalSpeed = node.HasValue("maxVerticalSpeed") ? ConfigNodeUtil.ParseValue<double>(node, "maxVerticalSpeed") : (double?)null;
             rateWindowSeconds = ConfigNodeUtil.ParseValue<double>(node, "rateWindowSeconds", DEFAULT_RATE_WINDOW);
             updateFrequency = ConfigNodeUtil.ParseValue<float>(node, "updateFrequency", DEFAULT_UPDATE_FREQUENCY);
         }
@@ -101,21 +117,35 @@ namespace ContractConfigurator.RP0
         protected override string GetParameterTitle()
         {
             double reqKm = requiredRange / 1000.0;
-            string band = maxSpeed >= double.MaxValue * 0.5 ? $">= {minSpeed:0} m/s" : $"{minSpeed:0}-{maxSpeed:0} m/s";
-            if (FlightGlobals.ActiveVessel == null)
-                return $"Cruise: range >= {reqKm:0} km, speed {band}";
-            return $"Cruise: range {curRange / 1000.0:0} / {reqKm:0} km, speed {band}";
+            string speedBand = maxSpeed.HasValue ? $"{minSpeed:N0}-{maxSpeed.Value:N0} m/s" : $">= {minSpeed:N0} m/s";
+            string rangePart = FlightGlobals.ActiveVessel == null
+                ? $"range >= {reqKm:N0} km"
+                : $"range {curRange / 1000.0:N0} / {reqKm:N0} km";
+            return $"Cruise: {rangePart}, speed {speedBand}{VerticalSpeedBand()}";
+        }
+
+        // "" when unconstrained, else e.g. ", VS 0-5 m/s" / ", VS >= -2 m/s" / ", VS <= 5 m/s". Included in the
+        // title so a player failing purely on vertical speed gets feedback rather than a silently-incomplete param.
+        private string VerticalSpeedBand()
+        {
+            if (!minVerticalSpeed.HasValue && !maxVerticalSpeed.HasValue) return "";
+            if (minVerticalSpeed.HasValue && maxVerticalSpeed.HasValue)
+                return $", VS {minVerticalSpeed.Value:N0}-{maxVerticalSpeed.Value:N0} m/s";
+            if (maxVerticalSpeed.HasValue)
+                return $", VS <= {maxVerticalSpeed.Value:N0} m/s";
+            return $", VS >= {minVerticalSpeed.Value:N0} m/s";
         }
 
         private void ResetAll()
         {
+            for (int i = 0; i < sampleAmounts.Count; i++) dictPool.Push(sampleAmounts[i]);
             sampleTimes.Clear();
             sampleAmounts.Clear();
         }
 
-        // Smallest projected range (m) across every mass-bearing resource the craft is actively burning,
-        // i.e. whichever fuel is the endurance limiter. False until the window is filled with a contiguous
-        // run and at least one resource is actually being consumed. limitingResource names the limiter.
+        // Smallest projected range (m) across the tracked propellants still being consumed, i.e. whichever
+        // fuel is the endurance limiter. False until the window is filled with a contiguous run and at least
+        // one tracked propellant is actually being consumed. limitingResource names the limiter.
         private bool TryMinRange(Vessel v, double speed, out double minRange, out PartResourceDefinition limitingResource,
                                  out double limAmount, out double limRate)
         {
@@ -137,6 +167,9 @@ namespace ContractConfigurator.RP0
                 // Only rank resources present for the whole window, else a tank coming online mid-window
                 // reads as an impossibly high burn rate.
                 if (!oldest.TryGetValue(kv.Key, out double old)) continue;
+                // A fuel that has drained to empty is spent, not a live limiter: skip it so it can't drag the
+                // min range to 0 for a window after it runs dry while the craft flies on another fuel.
+                if (kv.Value <= EMPTY_UNITS) continue;
                 double rate = (old - kv.Value) / span;
                 if (rate < MIN_RATE) continue;   // not really burning this one
                 PartResourceDefinition def = PartResourceLibrary.Instance.GetDefinition(kv.Key);
@@ -172,23 +205,47 @@ namespace ContractConfigurator.RP0
             return speed * (currentUnits / rateUnits);       // linear fallback
         }
 
-        // Snapshot of every mass-bearing resource's vessel-wide total, keyed by resource id. Massless
-        // resources (ElectricCharge, IntakeAir) are skipped so they can't masquerade as a fuel.
-        private Dictionary<int, double> SampleResources(Vessel v)
+        // Rebuild the engine cache. Called only on part-count / vessel change, so the per-tick gather below
+        // iterates a short cached list instead of every part's module list.
+        private void RebuildEngineCache(Vessel v)
         {
-            massBearingIds.Clear();
+            engineCache.Clear();
             for (int i = 0; i < v.parts.Count; i++)
             {
-                PartResourceList prl = v.parts[i].Resources;
-                for (int j = 0; j < prl.Count; j++)
+                PartModuleList modules = v.parts[i].Modules;
+                for (int m = 0; m < modules.Count; m++)
+                    if (modules[m] is ModuleEngines me) engineCache.Add(me);
+            }
+        }
+
+        // Add every mass-bearing propellant burned by a currently-working cached engine to the tracked set.
+        // Additive: a fuel is never removed once seen, so shutting an engine down or staging it away leaves its
+        // fuel tracked (its burn rate just falls to ~0 and it drops out of the range ranking). Massless
+        // propellants (IntakeAir, ElectricCharge) are skipped so they can't masquerade as the endurance limiter.
+        private void GatherEnginePropellants()
+        {
+            for (int i = 0; i < engineCache.Count; i++)
+            {
+                ModuleEngines me = engineCache[i];
+                if (me == null || !me.isOperational || me.currentThrottle <= 0f) continue;
+                List<Propellant> props = me.propellants;
+                for (int k = 0; k < props.Count; k++)
                 {
-                    PartResource pr = prl[j];
-                    if (pr.info.density > 0.0) massBearingIds.Add(pr.info.id);
+                    int id = props[k].id;
+                    if (trackedPropellantIds.Contains(id)) continue;   // already tracked -- skip the lookup
+                    PartResourceDefinition def = PartResourceLibrary.Instance.GetDefinition(id);
+                    if (def != null && def.density > 0.0) trackedPropellantIds.Add(id);
                 }
             }
+        }
 
-            var snapshot = new Dictionary<int, double>(massBearingIds.Count);
-            foreach (int id in massBearingIds)
+        // Vessel-wide total of each tracked propellant, keyed by resource id. Uses a pooled dictionary so
+        // steady-state sampling doesn't allocate; callers return the dict to dictPool once it ages out.
+        private Dictionary<int, double> SnapshotTracked(Vessel v)
+        {
+            Dictionary<int, double> snapshot = dictPool.Count > 0 ? dictPool.Pop() : new Dictionary<int, double>();
+            snapshot.Clear();
+            foreach (int id in trackedPropellantIds)
             {
                 v.GetConnectedResourceTotals(id, out double amount, out double _);
                 snapshot[id] = amount;
@@ -207,10 +264,15 @@ namespace ContractConfigurator.RP0
             double now = Time.fixedTime;
             double dt = now - lastCheckTime;
             bool gap = dt > updateFrequency * 4.0 || dt < 0;   // pause / warp / first tick
-            if (v.persistentId != lastVesselPersistentId || v.parts.Count != lastPartCount || gap)
+            bool vesselChanged = v.persistentId != lastVesselPersistentId;
+            if (vesselChanged || v.parts.Count != lastPartCount || gap)
             {
                 lastVesselPersistentId = v.persistentId;
                 lastPartCount = v.parts.Count;
+                // The tracked-fuel set is per-vessel and additive, so only a different vessel clears it; a
+                // part-count change (staging) or a warp/pause gap only invalidates the rolling rate window.
+                if (vesselChanged) trackedPropellantIds.Clear();
+                RebuildEngineCache(v);
                 ResetAll();
             }
             lastCheckTime = now;
@@ -222,10 +284,12 @@ namespace ContractConfigurator.RP0
             // outside the cruise band (climbing / accelerating in). The rolling rate converges to the cruise
             // value within one window; met still requires speedOk each tick, so the Duration hold only
             // accrues in-band and can't be "proven" out of band.
+            GatherEnginePropellants();
             sampleTimes.Add(now);
-            sampleAmounts.Add(SampleResources(v));
+            sampleAmounts.Add(SnapshotTracked(v));
             while (sampleTimes.Count > 2 && now - sampleTimes[1] >= rateWindowSeconds)
             {
+                dictPool.Push(sampleAmounts[0]);
                 sampleTimes.RemoveAt(0);
                 sampleAmounts.RemoveAt(0);
             }
@@ -234,8 +298,9 @@ namespace ContractConfigurator.RP0
                                          out double limAmount, out double limRate);
             curRange = rateReady ? range : 0.0;
 
-            bool speedOk = speed >= minSpeed && speed <= maxSpeed;
-            bool vsOk = vs >= minVerticalSpeed && vs <= maxVerticalSpeed;
+            bool speedOk = speed >= minSpeed && (!maxSpeed.HasValue || speed <= maxSpeed.Value);
+            bool vsOk = (!minVerticalSpeed.HasValue || vs >= minVerticalSpeed.Value)
+                     && (!maxVerticalSpeed.HasValue || vs <= maxVerticalSpeed.Value);
             bool rangeOk = rateReady && range >= requiredRange;
             met = speedOk && vsOk && rangeOk;
 

--- a/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
+++ b/Source/CC_RP0/Parameter/SustainedCruiseVesselParam.cs
@@ -26,8 +26,10 @@ namespace ContractConfigurator.RP0
     /// times only while its preceding siblings are Complete, and resets when one stops).
     ///
     /// Config: requiredRange m (req), minSpeed/maxSpeed m/s, minVerticalSpeed/maxVerticalSpeed m/s,
-    /// rateWindowSeconds (def 30), updateFrequency (def 0.5). Enable CC verbose logging to see the per-tick
-    /// speed/VS/range/met values.
+    /// rateWindowSeconds (def 30), updateFrequency (def 0.5). Set the CC log level for the SustainedCruise
+    /// type to DEBUG (or VERBOSE) via an ADD_LOGLEVEL_EXCEPTION to see the per-tick speed/VS/range/met and
+    /// Breguet-input breakdown lines. (LogDebug, not LogVerbose, so it survives the Release build --
+    /// LogVerbose is [Conditional("DEBUG")] and gets compiled out.)
     /// </summary>
     public class SustainedCruise : VesselParameter
     {
@@ -256,14 +258,14 @@ namespace ContractConfigurator.RP0
             double mdotKgS = rate * dens * 1000.0;
             double lnTerm = mEmpty > 1e-3 ? System.Math.Log(M / mEmpty) : 0.0;
             double linear = speed * (amount / rate);
-            LoggingUtil.LogVerbose(this, "SustainedCruise[range] {0} V={1:0.0}m/s M={2:0.000}t fuel={3:0.000}t empty={4:0.000}t " +
+            LoggingUtil.LogDebug(this, "SustainedCruise[range] {0} V={1:0.0}m/s M={2:0.000}t fuel={3:0.000}t empty={4:0.000}t " +
                 "mdot={5:0.####}kg/s ln={6:0.####} breguet={7:0}m linear={8:0}m",
                 limiter.name, speed, M, mFuel, mEmpty, mdotKgS, lnTerm, range, linear);
         }
 
         private void LogState(double speed, double vs, bool speedOk, bool vsOk, bool rangeOk, double range, PartResourceDefinition limiter)
         {
-            LoggingUtil.LogVerbose(this, "SustainedCruise spd={0:0}({1}) vs={2:0.0}({3}) range={4:0}/{5:0}km({6}) limiter={7} -> {8}",
+            LoggingUtil.LogDebug(this, "SustainedCruise spd={0:0}({1}) vs={2:0.0}({3}) range={4:0}/{5:0}km({6}) limiter={7} -> {8}",
                 speed, speedOk ? "ok" : "X", vs, vsOk ? "ok" : "X",
                 range / 1000.0, requiredRange / 1000.0, rangeOk ? "ok" : "X",
                 limiter != null ? limiter.name : "-", met ? "IN" : "out");

--- a/Source/CC_RP0/ParameterFactory/SustainedCruiseFactory.cs
+++ b/Source/CC_RP0/ParameterFactory/SustainedCruiseFactory.cs
@@ -5,7 +5,6 @@ namespace ContractConfigurator.RP0
     public class SustainedCruiseFactory : ParameterFactory
     {
         protected double requiredRange;
-        protected double holdSeconds;
         protected double minSpeed;
         protected double maxSpeed;
         protected double minVerticalSpeed;
@@ -18,7 +17,6 @@ namespace ContractConfigurator.RP0
             bool valid = base.Load(configNode);
 
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "requiredRange", x => requiredRange = x, this, 0.0, x => Validation.GT(x, 0.0));
-            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "holdSeconds", x => holdSeconds = x, this, SustainedCruise.DEFAULT_HOLD, x => Validation.GT(x, 0.0));
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "minSpeed", x => minSpeed = x, this, 0.0, x => Validation.GE(x, 0.0));
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "maxSpeed", x => maxSpeed = x, this, double.MaxValue);
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "minVerticalSpeed", x => minVerticalSpeed = x, this, double.MinValue);
@@ -31,7 +29,7 @@ namespace ContractConfigurator.RP0
 
         public override ContractParameter Generate(Contract contract)
         {
-            return new SustainedCruise(title, requiredRange, holdSeconds, minSpeed, maxSpeed,
+            return new SustainedCruise(title, requiredRange, minSpeed, maxSpeed,
                                        minVerticalSpeed, maxVerticalSpeed, rateWindowSeconds, updateFrequency);
         }
     }

--- a/Source/CC_RP0/ParameterFactory/SustainedCruiseFactory.cs
+++ b/Source/CC_RP0/ParameterFactory/SustainedCruiseFactory.cs
@@ -4,7 +4,6 @@ namespace ContractConfigurator.RP0
 {
     public class SustainedCruiseFactory : ParameterFactory
     {
-        protected PartResourceDefinition resource;
         protected double requiredRange;
         protected double holdSeconds;
         protected double minSpeed;
@@ -13,13 +12,11 @@ namespace ContractConfigurator.RP0
         protected double maxVerticalSpeed;
         protected double rateWindowSeconds;
         protected float updateFrequency;
-        protected bool debug;
 
         public override bool Load(ConfigNode configNode)
         {
             bool valid = base.Load(configNode);
 
-            valid &= ConfigNodeUtil.ParseValue<Resource>(configNode, "resource", x => resource = x.res, this);
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "requiredRange", x => requiredRange = x, this, 0.0, x => Validation.GT(x, 0.0));
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "holdSeconds", x => holdSeconds = x, this, SustainedCruise.DEFAULT_HOLD, x => Validation.GT(x, 0.0));
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "minSpeed", x => minSpeed = x, this, 0.0, x => Validation.GE(x, 0.0));
@@ -28,15 +25,14 @@ namespace ContractConfigurator.RP0
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "maxVerticalSpeed", x => maxVerticalSpeed = x, this, double.MaxValue);
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "rateWindowSeconds", x => rateWindowSeconds = x, this, SustainedCruise.DEFAULT_RATE_WINDOW, x => Validation.GT(x, 0.0));
             valid &= ConfigNodeUtil.ParseValue<float>(configNode, "updateFrequency", x => updateFrequency = x, this, SustainedCruise.DEFAULT_UPDATE_FREQUENCY, x => Validation.GT(x, 0.0f));
-            valid &= ConfigNodeUtil.ParseValue<bool>(configNode, "debug", x => debug = x, this, false);
 
             return valid;
         }
 
         public override ContractParameter Generate(Contract contract)
         {
-            return new SustainedCruise(title, resource, requiredRange, holdSeconds, minSpeed, maxSpeed,
-                                       minVerticalSpeed, maxVerticalSpeed, rateWindowSeconds, updateFrequency, debug);
+            return new SustainedCruise(title, requiredRange, holdSeconds, minSpeed, maxSpeed,
+                                       minVerticalSpeed, maxVerticalSpeed, rateWindowSeconds, updateFrequency);
         }
     }
 }

--- a/Source/CC_RP0/ParameterFactory/SustainedCruiseFactory.cs
+++ b/Source/CC_RP0/ParameterFactory/SustainedCruiseFactory.cs
@@ -1,0 +1,42 @@
+using Contracts;
+
+namespace ContractConfigurator.RP0
+{
+    public class SustainedCruiseFactory : ParameterFactory
+    {
+        protected PartResourceDefinition resource;
+        protected double requiredRange;
+        protected double holdSeconds;
+        protected double minSpeed;
+        protected double maxSpeed;
+        protected double minVerticalSpeed;
+        protected double maxVerticalSpeed;
+        protected double rateWindowSeconds;
+        protected float updateFrequency;
+        protected bool debug;
+
+        public override bool Load(ConfigNode configNode)
+        {
+            bool valid = base.Load(configNode);
+
+            valid &= ConfigNodeUtil.ParseValue<Resource>(configNode, "resource", x => resource = x.res, this);
+            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "requiredRange", x => requiredRange = x, this, 0.0, x => Validation.GT(x, 0.0));
+            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "holdSeconds", x => holdSeconds = x, this, SustainedCruise.DEFAULT_HOLD, x => Validation.GT(x, 0.0));
+            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "minSpeed", x => minSpeed = x, this, 0.0, x => Validation.GE(x, 0.0));
+            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "maxSpeed", x => maxSpeed = x, this, double.MaxValue);
+            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "minVerticalSpeed", x => minVerticalSpeed = x, this, double.MinValue);
+            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "maxVerticalSpeed", x => maxVerticalSpeed = x, this, double.MaxValue);
+            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "rateWindowSeconds", x => rateWindowSeconds = x, this, SustainedCruise.DEFAULT_RATE_WINDOW, x => Validation.GT(x, 0.0));
+            valid &= ConfigNodeUtil.ParseValue<float>(configNode, "updateFrequency", x => updateFrequency = x, this, SustainedCruise.DEFAULT_UPDATE_FREQUENCY, x => Validation.GT(x, 0.0f));
+            valid &= ConfigNodeUtil.ParseValue<bool>(configNode, "debug", x => debug = x, this, false);
+
+            return valid;
+        }
+
+        public override ContractParameter Generate(Contract contract)
+        {
+            return new SustainedCruise(title, resource, requiredRange, holdSeconds, minSpeed, maxSpeed,
+                                       minVerticalSpeed, maxVerticalSpeed, rateWindowSeconds, updateFrequency, debug);
+        }
+    }
+}

--- a/Source/CC_RP0/ParameterFactory/SustainedCruiseFactory.cs
+++ b/Source/CC_RP0/ParameterFactory/SustainedCruiseFactory.cs
@@ -6,9 +6,9 @@ namespace ContractConfigurator.RP0
     {
         protected double requiredRange;
         protected double minSpeed;
-        protected double maxSpeed;
-        protected double minVerticalSpeed;
-        protected double maxVerticalSpeed;
+        protected double? maxSpeed;
+        protected double? minVerticalSpeed;
+        protected double? maxVerticalSpeed;
         protected double rateWindowSeconds;
         protected float updateFrequency;
 
@@ -18,9 +18,15 @@ namespace ContractConfigurator.RP0
 
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "requiredRange", x => requiredRange = x, this, 0.0, x => Validation.GT(x, 0.0));
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "minSpeed", x => minSpeed = x, this, 0.0, x => Validation.GE(x, 0.0));
-            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "maxSpeed", x => maxSpeed = x, this, double.MaxValue);
-            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "minVerticalSpeed", x => minVerticalSpeed = x, this, double.MinValue);
-            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "maxVerticalSpeed", x => maxVerticalSpeed = x, this, double.MaxValue);
+            maxSpeed = null;
+            if (configNode.HasValue("maxSpeed"))
+                valid &= ConfigNodeUtil.ParseValue<double>(configNode, "maxSpeed", x => maxSpeed = x, this, double.MaxValue, x => Validation.GT(x, minSpeed));
+            minVerticalSpeed = null;
+            if (configNode.HasValue("minVerticalSpeed"))
+                valid &= ConfigNodeUtil.ParseValue<double>(configNode, "minVerticalSpeed", x => minVerticalSpeed = x, this);
+            maxVerticalSpeed = null;
+            if (configNode.HasValue("maxVerticalSpeed"))
+                valid &= ConfigNodeUtil.ParseValue<double>(configNode, "maxVerticalSpeed", x => maxVerticalSpeed = x, this);
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "rateWindowSeconds", x => rateWindowSeconds = x, this, SustainedCruise.DEFAULT_RATE_WINDOW, x => Validation.GT(x, 0.0));
             valid &= ConfigNodeUtil.ParseValue<float>(configNode, "updateFrequency", x => updateFrequency = x, this, SustainedCruise.DEFAULT_UPDATE_FREQUENCY, x => Validation.GT(x, 0.0f));
 

--- a/Source/CC_RP0/ParameterFactory/SustainedCruiseFactory.cs
+++ b/Source/CC_RP0/ParameterFactory/SustainedCruiseFactory.cs
@@ -16,17 +16,11 @@ namespace ContractConfigurator.RP0
         {
             bool valid = base.Load(configNode);
 
-            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "requiredRange", x => requiredRange = x, this, 0.0, x => Validation.GT(x, 0.0));
+            valid &= ConfigNodeUtil.ParseValue<double>(configNode, "requiredRange", x => requiredRange = x, this, x => Validation.GT(x, 0.0));
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "minSpeed", x => minSpeed = x, this, 0.0, x => Validation.GE(x, 0.0));
-            maxSpeed = null;
-            if (configNode.HasValue("maxSpeed"))
-                valid &= ConfigNodeUtil.ParseValue<double>(configNode, "maxSpeed", x => maxSpeed = x, this, double.MaxValue, x => Validation.GT(x, minSpeed));
-            minVerticalSpeed = null;
-            if (configNode.HasValue("minVerticalSpeed"))
-                valid &= ConfigNodeUtil.ParseValue<double>(configNode, "minVerticalSpeed", x => minVerticalSpeed = x, this);
-            maxVerticalSpeed = null;
-            if (configNode.HasValue("maxVerticalSpeed"))
-                valid &= ConfigNodeUtil.ParseValue<double>(configNode, "maxVerticalSpeed", x => maxVerticalSpeed = x, this);
+            valid &= ConfigNodeUtil.ParseValue(configNode, "maxSpeed", x => maxSpeed = x, this, (double?)null, x => !x.HasValue || Validation.GT(x.Value, minSpeed));
+            valid &= ConfigNodeUtil.ParseValue(configNode, "minVerticalSpeed", x => minVerticalSpeed = x, this, (double?)null);
+            valid &= ConfigNodeUtil.ParseValue(configNode, "maxVerticalSpeed", x => maxVerticalSpeed = x, this, (double?)null);
             valid &= ConfigNodeUtil.ParseValue<double>(configNode, "rateWindowSeconds", x => rateWindowSeconds = x, this, SustainedCruise.DEFAULT_RATE_WINDOW, x => Validation.GT(x, 0.0));
             valid &= ConfigNodeUtil.ParseValue<float>(configNode, "updateFrequency", x => updateFrequency = x, this, SustainedCruise.DEFAULT_UPDATE_FREQUENCY, x => Validation.GT(x, 0.0f));
 


### PR DESCRIPTION
Adds a `SustainedCruise` Contract Configurator parameter (in CC_RP0) for
sustained-cruise / endurance objectives, so endurance contracts don't have to
require flying a long real-time `Duration`.

The active vessel must hold ALL of these **simultaneously and continuously** for
`holdSeconds`:

- surface speed within `[minSpeed, maxSpeed]`,
- vertical speed within `[minVerticalSpeed, maxVerticalSpeed]`,
- projected **range** >= `requiredRange`.

Any violation resets the continuous-hold timer, so the conditions can't be
satisfied separately ("cheesed").

Endurance is measured as **range** rather than time:
`range = speed * fuel / burnRate`, computed with the Breguet range equation so
it credits the craft getting lighter as fuel burns. This rewards flying faster
and more efficiently (e.g. higher, where jets burn less). Burn rate is averaged
over a rolling `rateWindowSeconds` and only sampled while at cruise speed, so the
rate is representative.

Config fields: `resource`, `requiredRange` (m), `holdSeconds` (def 300),
`minSpeed`/`maxSpeed`, `minVerticalSpeed`/`maxVerticalSpeed`, `rateWindowSeconds`
(def 30), `updateFrequency` (def 0.5), `debug` (def false). Follows the existing
ReachMach parameter/factory pattern.

Intended for the Advanced X-Planes supersonic contracts (those contract changes
are kept separate as they depend on KSP-RO/RP-1#2828).
