### PR TITLE
Prevent undefined behaviour when LC is dismantled while under construction

### DIFF
--- a/Source/RP0/SpaceCenter/LaunchComplex/LCLaunchPad.cs
+++ b/Source/RP0/SpaceCenter/LaunchComplex/LCLaunchPad.cs
@@ -160,6 +160,15 @@ namespace RP0
                         }
                     }
 
+                    foreach (var cons in currentLC.PadConstructions)
+                    {
+                        if (cons.id == id)
+                        {
+                            failReason = "pad is under construction";
+                            return false;
+                        }
+                    }
+
                     foreach (VesselProject vessel in currentLC.Warehouse)
                     {
                         if (vessel.launchSiteIndex >= idx) vessel.launchSiteIndex--;

--- a/Source/RP0/SpaceCenter/LaunchComplex/LaunchComplex.cs
+++ b/Source/RP0/SpaceCenter/LaunchComplex/LaunchComplex.cs
@@ -374,6 +374,17 @@ namespace RP0
             else
                 LCEfficiency.ClearEmpty();
 
+            foreach (var cons in SpaceCenterManagement.Instance.ActiveSC.LCConstructions)
+            {
+                if (cons.lcID == ID)
+                    cons.Cancel();
+            }
+
+            foreach (var cons in PadConstructions)
+            {
+                cons.Cancel();
+            }
+
             foreach (var lp in LaunchPads)
                 SpaceCenterManagement.Instance.UnregsiterLP(lp);
 

--- a/Source/RP0/UI/KCT/GUI_BuildList.cs
+++ b/Source/RP0/UI/KCT/GUI_BuildList.cs
@@ -1697,7 +1697,7 @@ namespace RP0
                             }
                         }
 
-                        if (lpCount > 1 && GUILayout.Button(new GUIContent("Dismantle", "Permanently dismantle this pad"), GUILayout.ExpandWidth(false)))
+                        if (lpCount > 1 && pad.isOperational && GUILayout.Button(new GUIContent("Dismantle", "Permanently dismantle this pad"), GUILayout.ExpandWidth(false)))
                         {
                             ksc.SwitchLaunchComplex(i);
                             lc.SwitchLaunchPad(j);

--- a/Source/RP0/UI/KCT/GUI_DismantlePadOrLC.cs
+++ b/Source/RP0/UI/KCT/GUI_DismantlePadOrLC.cs
@@ -73,6 +73,7 @@ namespace RP0
                 if (activeLC.PadConstructions.Count > 0)
                 {
                     ScreenMessages.PostScreenMessage("Dismantle failed: a pad is currently under construction. Cancel construction first.", 5f, ScreenMessageStyle.UPPER_CENTER);
+                    return;
                 }
 
                 for (int i = activeLC.LaunchPads.Count - 1; i >= 0; --i)

--- a/Source/RP0/UI/KCT/GUI_DismantlePadOrLC.cs
+++ b/Source/RP0/UI/KCT/GUI_DismantlePadOrLC.cs
@@ -61,6 +61,20 @@ namespace RP0
                     return;
                 }
 
+                foreach (var cons in SpaceCenterManagement.Instance.ActiveSC.LCConstructions)
+                {
+                    if (cons.lcID == activeLC.ID)
+                    {
+                        ScreenMessages.PostScreenMessage("Dismantle failed: Launch Complex is currently under construction. Cancel construction first.", 5f, ScreenMessageStyle.UPPER_CENTER);
+                        return;
+                    }
+                }
+
+                if (activeLC.PadConstructions.Count > 0)
+                {
+                    ScreenMessages.PostScreenMessage("Dismantle failed: a pad is currently under construction. Cancel construction first.", 5f, ScreenMessageStyle.UPPER_CENTER);
+                }
+
                 for (int i = activeLC.LaunchPads.Count - 1; i >= 0; --i)
                 {
                     LCLaunchPad lpToDel = activeLC.LaunchPads[i];


### PR DESCRIPTION
https://discord.com/channels/319857228905447436/512556137380315139/1512505950463070310 (reproduction)
https://discord.com/channels/319857228905447436/512556137380315139/1521754770765906063 (save and logs)

If an LC is Dismantled while it is actively under construction, `SpaceCenterManagement.ProgressBuildTime` hits an NRE while processing the completion of the dismantled LC construction, which prevents any progress towards research, fund target, and staff target (which all occur after processing constructions).

To remedy this, this PR causes dismantling to fail if the LC or any of its pads are under construction.