### PR TITLE
Silence alarms and crew/maintenance processing during sim time jumps

### DIFF
--- a/Source/RP0/Crew/CrewHandler.cs
+++ b/Source/RP0/Crew/CrewHandler.cs
@@ -177,6 +177,12 @@ namespace RP0.Crew
             if (_isFirstLoad)
                 return;
 
+            // Don't advance crew state (retirements, inactivity, expirations) during a simulation.
+            // An SCM sim can jump UT forward by years; processing it here fires retirement popups
+            // for time that isn't really passing. Sim state is reverted on exit regardless.
+            if (SpaceCenterManagement.Instance?.IsSimulatedFlight == true)
+                return;
+
             Profiler.BeginSample("RP0ProcessCrew");
             double time = Planetarium.GetUniversalTime();
             ProcessRetirements(time);

--- a/Source/RP0/Maintenance/MaintenanceHandler.cs
+++ b/Source/RP0/Maintenance/MaintenanceHandler.cs
@@ -411,6 +411,11 @@ namespace RP0
             if (HighLogic.CurrentGame == null)
                 return;
 
+            // Skip maintenance/upkeep/reputation processing while simulating; an SCM sim can jump
+            // UT forward by years and this would churn funds/rep against time that isn't passing.
+            if (SpaceCenterManagement.Instance?.IsSimulatedFlight == true)
+                return;
+
             if (_frameCount++ < 2)
             {
                 return;
@@ -453,6 +458,10 @@ namespace RP0
 
         public void FixedUpdate()
         {
+            // See Update(): don't process crew/maintenance during a simulation time jump.
+            if (SpaceCenterManagement.Instance?.IsSimulatedFlight == true)
+                return;
+
             double UT = Planetarium.GetUniversalTime();
             if (_lastUpdateFixed == 0)
                 _lastUpdateFixed = UT;

--- a/Source/RP0/Maintenance/MaintenanceHandler.cs
+++ b/Source/RP0/Maintenance/MaintenanceHandler.cs
@@ -542,7 +542,7 @@ namespace RP0
             }
 
             // Finally, update all builds
-            SpaceCenterManagement.Instance.ProgressBuildTime(UTDiff);
+            SpaceCenterManagement.Instance?.ProgressBuildTime(UTDiff);
         }
 
         public void OnDestroy()

--- a/Source/RP0/ModIntegrations/AlarmHelper.cs
+++ b/Source/RP0/ModIntegrations/AlarmHelper.cs
@@ -77,6 +77,49 @@ namespace RP0.ModIntegrations
         }
 
         /// <summary>
+        /// Disarms every alarm that would fire at or before <paramref name="throughUT"/> so it can't
+        /// fire during an SCM simulation time jump: KAC / the stock alarm clock watch the real UT and
+        /// will trigger every alarm the jump passes over. The sim reverts to the pre-sim backup on
+        /// exit (see KCTUtilities.LoadSimulationSave), so alarm state is restored then; this just
+        /// silences them during the jump. Safe to call repeatedly.
+        /// </summary>
+        /// <param name="throughUT">The UT the jump lands on; only alarms due at or before this are touched.</param>
+        public static void SuppressAllAlarmActions(double throughUT)
+        {
+            // Only alarms due by throughUT can fire during the jump; leave the rest armed so a mishap
+            // that skips the sim revert (e.g. a manual save mid-sim) can't leave every alarm the
+            // player owns silently disabled.
+            //
+            // Gate on AssemblyExists (KAC installed), NOT UseKAC/APIReady: this runs during the sim's
+            // flight-scene load, and KAC clears APIReady across scene transitions, so UseKAC would be
+            // false here and we'd fall through to the (empty) stock branch. The KAC alarm list is
+            // static and stays mutable through the transition.
+            //
+            // We set Enabled=false rather than the AlarmAction: KAC's firing loop ignores the legacy
+            // AlarmAction field and gates triggering on Enabled (KerbalAlarmClock.cs), so disabling
+            // is what actually stops the warp kill / message / sound.
+            if (KACWrapper.AssemblyExists && KACWrapper.KAC != null)
+            {
+                foreach (KACAlarm alarm in KACWrapper.KAC.Alarms.ToList())
+                {
+                    if (alarm.AlarmTime <= throughUT)
+                        alarm.Enabled = false;
+                }
+            }
+            else
+            {
+                if (AlarmClockScenario.Instance == null) return;
+                foreach (AlarmTypeBase alarm in AlarmClockScenario.Instance.alarms.Values)
+                {
+                    if (alarm.ut > throughUT) continue;
+                    alarm.actions.warp = AlarmActions.WarpEnum.DoNothing;
+                    alarm.actions.message = AlarmActions.MessageEnum.No;
+                    alarm.actions.playSound = false;
+                }
+            }
+        }
+
+        /// <summary>
         /// Finds the alarm with a certain id and updates its properties.
         /// </summary>
         /// <returns>

--- a/Source/RP0/ModIntegrations/KACWrapper.cs
+++ b/Source/RP0/ModIntegrations/KACWrapper.cs
@@ -383,6 +383,7 @@ namespace RP0
                     AlarmTimeProperty = KACAlarmType.GetProperty("AlarmTimeUT");
                     AlarmMarginField = KACAlarmType.GetField("AlarmMarginSecs");
                     AlarmActionField = KACAlarmType.GetField("AlarmAction");
+                    EnabledField = KACAlarmType.GetField("Enabled");
                     RemainingField = KACAlarmType.GetField("Remaining");
 
                     XferOriginBodyNameField = KACAlarmType.GetField("XferOriginBodyName");
@@ -492,12 +493,26 @@ namespace RP0
 
                 private FieldInfo AlarmActionField;
                 /// <summary>
-                /// What should the Alarm Clock do when the alarm fires
+                /// What should the Alarm Clock do when the alarm fires.
+                /// NOTE: KAC's firing loop does NOT read this; it acts on the alarm's Actions object.
+                /// This maps to KAC's legacy/vestigial "AlarmAction" field and is effectively inert.
+                /// Use <see cref="Enabled"/> to actually stop an alarm from firing.
                 /// </summary>
                 public AlarmActionEnum AlarmAction
                 {
                     get { return (AlarmActionEnum)AlarmActionField.GetValue(actualAlarm); }
                     set { AlarmActionField.SetValue(actualAlarm, (Int32)value); }
+                }
+
+                private FieldInfo EnabledField;
+                /// <summary>
+                /// Whether the alarm is armed. KAC gates triggering on this, so setting it false
+                /// stops the alarm from firing entirely (no warp kill, message, or sound).
+                /// </summary>
+                public Boolean Enabled
+                {
+                    get { return EnabledField == null || (Boolean)EnabledField.GetValue(actualAlarm); }
+                    set { if (EnabledField != null) EnabledField.SetValue(actualAlarm, value); }
                 }
 
                 private FieldInfo RemainingField;

--- a/Source/RP0/SpaceCenter/SpaceCenterManagement.cs
+++ b/Source/RP0/SpaceCenter/SpaceCenterManagement.cs
@@ -427,6 +427,9 @@ namespace RP0
                                 }
                             }
                             RP0Debug.Log($"Setting simulation UT to {SimulationParams.SimulationUT}");
+                            // Silence KAC / stock alarms due within the jump window so they don't all
+                            // fire across the skipped time. Restored from the pre-sim backup on exit.
+                            ModIntegrations.AlarmHelper.SuppressAllAlarmActions(SimulationParams.SimulationUT);
                             if (!ModUtils.IsPrincipiaInstalled)
                                 Planetarium.SetUniversalTime(SimulationParams.SimulationUT);
                             else


### PR DESCRIPTION
An SCM simulation can jump UT forward by years. That fired every KAC alarm the jump crossed and popped crew-retirement notifications for time that isn't really passing.

- CrewHandler.Process and MaintenanceHandler.Update/FixedUpdate bail out when IsSimulatedFlight, so retirement/inactivity/upkeep don't process against the skipped time.
- AlarmHelper.SuppressAllAlarmActions(throughUT) disarms alarms due within the jump window before the UT is set; restored from the pre-sim backup on exit. KAC path sets Enabled=false (its firing loop ignores the legacy AlarmAction field the wrapper bound); gated on AssemblyExists since APIReady is false during the scene load.
- KACWrapper: expose the alarm Enabled field.