### PR TITLE
Clarify some RP1CollectScience parameters

### DIFF
--- a/GameData/RP-1/Contracts/Earth Observation 1/EOSIRRad1.cfg
+++ b/GameData/RP-1/Contracts/Earth Observation 1/EOSIRRad1.cfg
@@ -112,7 +112,7 @@ CONTRACT_TYPE
 		situation = InSpaceLow
 		experiment = RP0infraredRad1
 		fractionComplete = 0.5
-		title = Transmit 50% of infrared weather data from low orbit
+		title = Transmit 50% total Infrared Radiometry science from LEO
 	}
 	PARAMETER
 	{

--- a/GameData/RP-1/Contracts/Earth Observation 1/EOSIRRad2.cfg
+++ b/GameData/RP-1/Contracts/Earth Observation 1/EOSIRRad2.cfg
@@ -126,6 +126,6 @@ CONTRACT_TYPE
 		fractionComplete = 0.75
 		fractionCompleteBiome = 0.9
 		minSubjectsToComplete = 4
-		title = Transmit 75% of LEO infrared radiometry data from at least 4 biomes
+		title = Transmit 75% total Infrared Radiometry science from LEO, and complete 90% in each of 4 biomes
 	}
 }

--- a/GameData/RP-1/Contracts/Earth Observation 1/EOSIRRad3.cfg
+++ b/GameData/RP-1/Contracts/Earth Observation 1/EOSIRRad3.cfg
@@ -127,6 +127,6 @@ CONTRACT_TYPE
 		fractionComplete = 0.9
 		fractionCompleteBiome = 0.95
 		minSubjectsToComplete = 8
-		title = Transmit 90% of LEO infrared radiometry data from at least 8 biomes
+		title = Transmit 90% total Infrared Radiometry science from LEO, and complete 95% in each of 8 biomes
 	}
 }

--- a/GameData/RP-1/Contracts/Earth Observation 2/EOS2Nimbus1.cfg
+++ b/GameData/RP-1/Contracts/Earth Observation 2/EOS2Nimbus1.cfg
@@ -130,7 +130,7 @@ CONTRACT_TYPE
 			{
 				name = CollectIR
 				type = RP1CollectScience
-				title = Transmit 90% of LEO infrared radiometry data from at least 8 biomes
+				title = Transmit 90% total Infrared Radiometry 2 science from LEO, and complete 95% in each of 8 biomes
 				targetBody = HomeWorld()
 				situation = InSpaceLow
 				experiment = RP0infraredRad2

--- a/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
+++ b/GameData/RP-1/Contracts/Lunar Surface Probes/MoonOrbiter.cfg
@@ -108,7 +108,7 @@ CONTRACT_TYPE
 			fractionComplete = 0.5
 			fractionCompleteBiome = 0.9
 			minSubjectsToComplete = 4
-			title = Collect at least 60% total Video Imaging 2 science from low space around the moon, and complete 90% in each of 4 lunar biomes.
+			title = Collect at least 50% total Video Imaging 2 science from low space around the moon, and complete 90% in each of 4 lunar biomes.
 		}
 		
 		PARAMETER


### PR DESCRIPTION
Hopefully this alleviates some of the confusion about the Infrared Radiometry contract completion conditions in EEOS. Also changes a Nimbus1 parameter in EOS2 to use the same wording.

Also, ULSE's First Lunar Orbiter and Mapper contract had an incorrect percentage in the parameter title. (Unless it was intended to be 60% originally.)