### PR TITLE
Apply leader effects for integration + rollout time in integration info

### DIFF
--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -23,6 +23,10 @@ namespace RP0
         private static readonly GUIContent _gcSwitchToHangar = new GUIContent("Switch to Hangar", "A Launch Complex is currently selected; this will switch to the Hangar, needed for planes.");
         private static List<string> vesselFailedChecks = new List<string>();
 
+        // Rollout Rate effects should not change when this window is open.
+        private static double _cachedRolloutRateLeader = double.NegativeInfinity;
+        public static double cachedRolloutRateLeader => _cachedRolloutRateLeader.IsFinite() ? _cachedRolloutRateLeader : (_cachedRolloutRateLeader = CurrencyUtils.Rate(TransactionReasonsRP0.RateRollout));
+
         public static void DrawEditorGUI(int windowID)
         {
             if (EditorLogic.fetch == null)
@@ -55,11 +59,11 @@ namespace RP0
         private static void RenderBuildMode()
         {
             double buildPoints = SpaceCenterManagement.Instance.EditorVessel.buildPoints;
-            double bpLeaderEffect = SpaceCenterManagement.Instance.EditorVessel.LeaderEffect;
+            double bpLeaderEffect = SpaceCenterManagement.Instance.EditorVessel.LeaderEffect
+                * SpaceCenterManagement.Instance.ActiveSC.ActiveLC.StrategyRateMultiplier;
             double effic = SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Efficiency;
             double rateWithCurEngis = KCTUtilities.GetBuildRate(SpaceCenterManagement.Instance.ActiveSC.ActiveLC, SpaceCenterManagement.Instance.EditorVessel.mass, SpaceCenterManagement.Instance.EditorVessel.buildPoints, SpaceCenterManagement.Instance.EditorVessel.humanRated, 0)
-                * effic
-                * SpaceCenterManagement.Instance.ActiveSC.ActiveLC.StrategyRateMultiplier;
+                * effic;
             int engineersUsed = Math.Min(
                 SpaceCenterManagement.Instance.ActiveSC.ActiveLC.MaxEngineersFor(SpaceCenterManagement.Instance.EditorVessel.mass, SpaceCenterManagement.Instance.EditorVessel.buildPoints, SpaceCenterManagement.Instance.EditorVessel.humanRated),
                 SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Engineers
@@ -72,9 +76,9 @@ namespace RP0
                 GUILayout.Label($"BP Cost: {buildPoints:N0}");
                 GUILayout.Label($"EC: {SpaceCenterManagement.Instance.EditorVessel.effectiveCost:N0}");
             }
-
-            double mult = SpaceCenterManagement.Instance.ActiveSC.ActiveLC.StrategyRateMultiplier * bpLeaderEffect;
-            GUILayout.Label($"Leader Effect on Integration Rate: {LocalizationHandler.FormatRatioAsPercent(mult)}");
+            
+            if (Math.Abs(bpLeaderEffect - 1) > 0.001d)
+                GUILayout.Label($"Leader Effect on Integration Rate: {LocalizationHandler.FormatRatioAsPercent(bpLeaderEffect)}");
 
             if (double.TryParse(BuildRateForDisplay, out double bR))
             {
@@ -87,7 +91,7 @@ namespace RP0
 
                 if (SpaceCenterManagement.EditorRolloutBP > 0)
                 {
-                    double rolloutBR = bR / SpaceCenterManagement.Instance.ActiveSC.ActiveLC.StrategyRateMultiplier * CurrencyUtils.Rate(TransactionReasonsRP0.RateRollout);
+                    double rolloutBR = bR * cachedRolloutRateLeader;
                     GUILayout.Label($"Rollout Time: {(bR > 0 ? KSPUtil.PrintDateDeltaCompact(SpaceCenterManagement.EditorRolloutBP / rolloutBR, true, false) : "infinity")} at {effic:P0}");
                 }
             }
@@ -348,14 +352,14 @@ namespace RP0
         {
             VesselProject editedVessel = SpaceCenterManagement.Instance.EditedVessel;
             double fullVesselBP = SpaceCenterManagement.Instance.EditorVessel.buildPoints;
-            double bpLeaderEffect = SpaceCenterManagement.Instance.EditorVessel.LeaderEffect;
+            double bpLeaderEffect = SpaceCenterManagement.Instance.EditorVessel.LeaderEffect * editedVessel.LC.StrategyRateMultiplier;
             double effic = editedVessel.LC.Efficiency;
             KCTUtilities.GetShipEditProgress(editedVessel, out double newProgressBP, out double originalCompletionPercent, out double newCompletionPercent);
             GUILayout.Label($"Original: {Math.Max(0, originalCompletionPercent):P2}");
             GUILayout.Label($"Edited: {newCompletionPercent:P2}");
             
             double rateWithCurEngis = KCTUtilities.GetBuildRate(editedVessel.LC, SpaceCenterManagement.Instance.EditorVessel.mass, SpaceCenterManagement.Instance.EditorVessel.buildPoints, SpaceCenterManagement.Instance.EditorVessel.humanRated, 0)
-                * effic * editedVessel.LC.StrategyRateMultiplier;
+                * effic;
 
             RenderBuildRateInputRow(fullVesselBP, rateWithCurEngis);
 
@@ -368,7 +372,10 @@ namespace RP0
                 {
                     double brTrue = bR / effic;
                     for (int i = 0; i < idx; ++i)
-                        editedVessel.LC.BuildList[i].CalculateTimeLeftForBuildRate(editedVessel.buildPoints - editedVessel.progress, brTrue * editedVessel.LC.BuildList[i].LeaderEffect, startingEff, out startingEff);
+                    {
+                        VesselProject ship = editedVessel.LC.BuildList[i];
+                        ship.CalculateTimeLeftForBuildRate(ship.buildPoints - ship.progress, brTrue * ship.LeaderEffect, startingEff, out startingEff);
+                    }
                 }
 
                 double buildPoints = Math.Abs(fullVesselBP - newProgressBP);
@@ -383,7 +390,7 @@ namespace RP0
 
                 if (SpaceCenterManagement.EditorRolloutBP > 0)
                 {
-                    double rolloutBR = bR / editedVessel.LC.StrategyRateMultiplier * CurrencyUtils.Rate(TransactionReasonsRP0.RateRollout);
+                    double rolloutBR = bR * cachedRolloutRateLeader;
                     GUILayout.Label($"Rollout Time: {RP0DTUtils.GetFormattedTime(SpaceCenterManagement.EditorRolloutBP / (rolloutBR / effic * rolloutEff) , 0, false)} at {rolloutEff:P0}");
                 }
             }

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -24,9 +24,19 @@ namespace RP0
         private static List<string> vesselFailedChecks = new List<string>();
 
         // Rollout Rate effects should not change when this window is open.
-        private static double _cachedRolloutRateLeader = double.NegativeInfinity;
-        public static double cachedRolloutRateLeader => _cachedRolloutRateLeader.IsFinite() ? _cachedRolloutRateLeader : (_cachedRolloutRateLeader = CurrencyUtils.Rate(TransactionReasonsRP0.RateRollout));
-
+        private static double _cachedRolloutRateLeader = -1;
+        public static double CachedRolloutRateLeader 
+        { 
+            get 
+            {
+                if (_cachedRolloutRateLeader < 0 || _rolloutTimeNeedsUpdate)
+                {
+                    _cachedRolloutRateLeader = CurrencyUtils.Rate(TransactionReasonsRP0.RateRollout);
+                    _rolloutTimeNeedsUpdate = false;
+                }
+                return _cachedRolloutRateLeader;
+            }
+        }
         public static void DrawEditorGUI(int windowID)
         {
             if (EditorLogic.fetch == null)
@@ -76,7 +86,7 @@ namespace RP0
                 GUILayout.Label($"BP Cost: {buildPoints:N0}");
                 GUILayout.Label($"EC: {SpaceCenterManagement.Instance.EditorVessel.effectiveCost:N0}");
             }
-            
+
             if (Math.Abs(bpLeaderEffect - 1) > 0.001d)
                 GUILayout.Label($"Leader Effect on Integration Rate: {LocalizationHandler.FormatRatioAsPercent(bpLeaderEffect)}");
 
@@ -91,7 +101,7 @@ namespace RP0
 
                 if (SpaceCenterManagement.EditorRolloutBP > 0)
                 {
-                    double rolloutBR = bR * cachedRolloutRateLeader;
+                    double rolloutBR = bR * CachedRolloutRateLeader;
                     GUILayout.Label($"Rollout Time: {(bR > 0 ? KSPUtil.PrintDateDeltaCompact(SpaceCenterManagement.EditorRolloutBP / rolloutBR, true, false) : "infinity")} at {effic:P0}");
                 }
             }
@@ -370,7 +380,7 @@ namespace RP0
                 int idx = editedVessel.LC.BuildList.IndexOf(editedVessel);
                 if (idx != -1 && bR > 0d && effic < LCEfficiency.MaxEfficiency)
                 {
-                    double brTrue = bR / effic;
+                    double brTrue = bR / effic * editedVessel.LC.StrategyRateMultiplier;
                     for (int i = 0; i < idx; ++i)
                     {
                         VesselProject ship = editedVessel.LC.BuildList[i];
@@ -390,7 +400,7 @@ namespace RP0
 
                 if (SpaceCenterManagement.EditorRolloutBP > 0)
                 {
-                    double rolloutBR = bR * cachedRolloutRateLeader;
+                    double rolloutBR = bR * CachedRolloutRateLeader;
                     GUILayout.Label($"Rollout Time: {RP0DTUtils.GetFormattedTime(SpaceCenterManagement.EditorRolloutBP / (rolloutBR / effic * rolloutEff) , 0, false)} at {rolloutEff:P0}");
                 }
             }
@@ -495,7 +505,7 @@ namespace RP0
                 var ship = SpaceCenterManagement.Instance.EditorVessel;
                 var deltaToMaxEngineers = int.MaxValue - SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Engineers;
                 bR = KCTUtilities.GetBuildRate(SpaceCenterManagement.Instance.ActiveSC.ActiveLC, ship.mass, buildPoints, ship.humanRated, deltaToMaxEngineers)
-                    * SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Efficiency * SpaceCenterManagement.Instance.ActiveSC.ActiveLC.StrategyRateMultiplier;
+                    * SpaceCenterManagement.Instance.ActiveSC.ActiveLC.Efficiency;
                 BuildRateForDisplay = bR.ToString();
             }
 

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -73,18 +73,22 @@ namespace RP0
                 GUILayout.Label($"EC: {SpaceCenterManagement.Instance.EditorVessel.effectiveCost:N0}");
             }
 
+            double mult = SpaceCenterManagement.Instance.ActiveSC.ActiveLC.StrategyRateMultiplier * bpLeaderEffect;
+            GUILayout.Label($"Leader Effect on Integration Rate: {LocalizationHandler.FormatRatioAsPercent(mult)}");
+
             if (double.TryParse(BuildRateForDisplay, out double bR))
             {
                 double buildTime = bR > 0d
                     ? (effic >= LCEfficiency.MaxEfficiency
                         ? buildPoints / (bR * bpLeaderEffect)
-                        : SpaceCenterManagement.Instance.EditorVessel.CalculateTimeLeftForBuildRate(buildPoints, bR / effic, effic, out _))
+                        : SpaceCenterManagement.Instance.EditorVessel.CalculateTimeLeftForBuildRate(buildPoints, bR / effic * bpLeaderEffect, effic, out _))
                     : 0d;
                 GUILayout.Label($"Integration Time: {(bR > 0 ? KSPUtil.PrintDateDeltaCompact(buildTime, true, false) : "infinity")} at {effic:P0}");
 
                 if (SpaceCenterManagement.EditorRolloutBP > 0)
                 {
-                    GUILayout.Label($"Rollout Time: {(bR > 0 ? KSPUtil.PrintDateDeltaCompact(SpaceCenterManagement.EditorRolloutBP / bR, true, false) : "infinity")} at {effic:P0}");
+                    double rolloutBR = bR / SpaceCenterManagement.Instance.ActiveSC.ActiveLC.StrategyRateMultiplier * CurrencyUtils.Rate(TransactionReasonsRP0.RateRollout);
+                    GUILayout.Label($"Rollout Time: {(bR > 0 ? KSPUtil.PrintDateDeltaCompact(SpaceCenterManagement.EditorRolloutBP / rolloutBR, true, false) : "infinity")} at {effic:P0}");
                 }
             }
             else
@@ -104,7 +108,7 @@ namespace RP0
             {
                 double effectiveEngCount = bR / rateWithCurEngis * engineersUsed;
                 double salaryPerDayAboveIdle = Database.SettingsSC.salaryEngineers * (1d / 365.25d) * (1d - Database.SettingsSC.EngineerIdleSalaryMult);
-                double cost = buildPoints / bR / 86400d * effectiveEngCount * salaryPerDayAboveIdle;
+                double cost = buildPoints / (bR * bpLeaderEffect) / 86400d * effectiveEngCount * salaryPerDayAboveIdle;
                 GUILayout.Label(new GUIContent($"Net Salary: √{-CurrencyUtils.Funds(TransactionReasonsRP0.SalaryEngineers, -cost):N1}", "The extra salary paid above the idle rate for these engineers"));
             }
 
@@ -364,14 +368,14 @@ namespace RP0
                 {
                     double brTrue = bR / effic;
                     for (int i = 0; i < idx; ++i)
-                        editedVessel.LC.BuildList[i].CalculateTimeLeftForBuildRate(editedVessel.buildPoints - editedVessel.progress, brTrue, startingEff, out startingEff);
+                        editedVessel.LC.BuildList[i].CalculateTimeLeftForBuildRate(editedVessel.buildPoints - editedVessel.progress, brTrue * editedVessel.LC.BuildList[i].LeaderEffect, startingEff, out startingEff);
                 }
 
                 double buildPoints = Math.Abs(fullVesselBP - newProgressBP);
                 double buildTime = bR > 0d
                     ? (effic >= LCEfficiency.MaxEfficiency
                         ? buildPoints / (bR * bpLeaderEffect)
-                        : editedVessel.CalculateTimeLeftForBuildRate(buildPoints, bR / effic, startingEff, out rolloutEff))
+                        : editedVessel.CalculateTimeLeftForBuildRate(buildPoints, bR / effic * bpLeaderEffect, startingEff, out rolloutEff))
                     : double.NaN;
                 GUILayout.Label(new GUIContent($"Remaining: {RP0DTUtils.GetFormattedTime(buildTime, 0, false)}", 
                     idx == -1 ? "Time left takes efficiency increase into account based on assuming vessel will be placed at head of integration list" :
@@ -379,7 +383,8 @@ namespace RP0
 
                 if (SpaceCenterManagement.EditorRolloutBP > 0)
                 {
-                    GUILayout.Label($"Rollout Time: {RP0DTUtils.GetFormattedTime(SpaceCenterManagement.EditorRolloutBP / (bR / effic * rolloutEff) , 0, false)} at {rolloutEff:P0}");
+                    double rolloutBR = bR / editedVessel.LC.StrategyRateMultiplier * CurrencyUtils.Rate(TransactionReasonsRP0.RateRollout);
+                    GUILayout.Label($"Rollout Time: {RP0DTUtils.GetFormattedTime(SpaceCenterManagement.EditorRolloutBP / (rolloutBR / effic * rolloutEff) , 0, false)} at {rolloutEff:P0}");
                 }
             }
             else

--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -25,7 +25,7 @@ namespace RP0
 
         // Rollout Rate effects should not change when this window is open.
         private static double _cachedRolloutRateLeader = -1;
-        public static double CachedRolloutRateLeader 
+        private static double CachedRolloutRateLeader 
         { 
             get 
             {

--- a/Source/RP0/UI/KCT/GUI_Main.cs
+++ b/Source/RP0/UI/KCT/GUI_Main.cs
@@ -21,6 +21,7 @@ namespace RP0
         private static bool _unlockEditor;
         private static bool _isKSCLocked = false;
         private static bool _inSCSubscene = false;
+        private static bool _rolloutTimeNeedsUpdate = true;
         public static bool InSCSubscene => _inSCSubscene;
         private static readonly List<GameScenes> _validScenes = new List<GameScenes> { GameScenes.FLIGHT, GameScenes.EDITOR, GameScenes.SPACECENTER, GameScenes.TRACKSTATION };
         private static GUIStyle _styleLabelRightAlign;
@@ -51,6 +52,8 @@ namespace RP0
 
                 if (GUIStates.ShowEditorGUI)
                     EditorWindowPosition = DrawWindowWithTooltipSupport(EditorWindowPosition, "DrawEditorGUI", "Integration Info", DrawEditorGUI);
+                else
+                    _rolloutTimeNeedsUpdate = true; // as a simpler workaround, assume that the rollout effect needs updating if Editor GUI isn't already open
                 if (GUIStates.ShowSimulationGUI)
                     _simulationWindowPosition = DrawWindowWithTooltipSupport(_simulationWindowPosition, "DrawSimGUI", "Simulation", DrawSimulationWindow);
                 if (GUIStates.ShowSimConfig)

--- a/Source/RP0/UI/KCT/GUI_Personnel.cs
+++ b/Source/RP0/UI/KCT/GUI_Personnel.cs
@@ -189,7 +189,7 @@ namespace RP0
             VesselProject b = hasVessel ? currentLC.BuildList[0] : null;
             double rateFull = KCTUtilities.GetBuildRate(0, type, currentLC, hasVessel ? b.humanRated : currentLC.IsHumanRated, assignDelta);
             double rate = rateFull * efficiency;
-            double leaderMult = stratMult * b.LeaderEffect;
+            double leaderMult = b == null ? 1 : (stratMult * b.LeaderEffect);
 
             GUILayout.BeginHorizontal();
             if (hasVessel && Math.Abs(leaderMult - 1) > 0.001)

--- a/Source/RP0/UI/KCT/GUI_Personnel.cs
+++ b/Source/RP0/UI/KCT/GUI_Personnel.cs
@@ -185,57 +185,44 @@ namespace RP0
             }
             GUILayout.EndHorizontal();
 
-            
-            if (currentLC.CanIntegrate && currentLC.BuildList.Count > 0)
-            {
-                VesselProject b = currentLC.BuildList[0];
-                double rateFull = KCTUtilities.GetBuildRate(0, type, currentLC, b.humanRated, assignDelta);
-                double rate = rateFull * efficiency;
-                double leaderMult = stratMult * b.LeaderEffect;
-                    
-                GUILayout.BeginHorizontal();
-                if (Math.Abs(leaderMult - 1) > 0.001)
-                    GUILayout.Label($"Vessel Rate (with Leaders): {rateFull:N3} => {rate:N3} => {rate * leaderMult:N3} BP/sec", GetLabelRightAlignStyle());
-                else
-                    GUILayout.Label($"Vessel Rate: {rateFull:N3} => {rate:N3} BP/sec", GetLabelRightAlignStyle());
-                GUILayout.EndHorizontal();
+            bool hasVessel = currentLC.CanIntegrate && currentLC.BuildList.Count > 0;
+            VesselProject b = hasVessel ? currentLC.BuildList[0] : null;
+            double rateFull = KCTUtilities.GetBuildRate(0, type, currentLC, hasVessel ? b.humanRated : currentLC.IsHumanRated, assignDelta);
+            double rate = rateFull * efficiency;
+            double leaderMult = stratMult * b.LeaderEffect;
 
-                GUILayout.BeginHorizontal();
+            GUILayout.BeginHorizontal();
+            if (hasVessel && Math.Abs(leaderMult - 1) > 0.001)
+                GUILayout.Label($"Vessel Rate (with Leaders): {rateFull:N3} => {rate:N3} => {rate * leaderMult:N3} BP/sec", GetLabelRightAlignStyle());
+            else
+                GUILayout.Label($"Vessel Rate: {rateFull:N3} => {rate:N3} BP/sec", GetLabelRightAlignStyle());
+            GUILayout.EndHorizontal();
+
+            GUILayout.BeginHorizontal();
+            if (hasVessel)
+            {
                 GUILayout.Label($"Current Vessel: {b.shipName}");
 
                 int engCap = currentLC.MaxEngineersFor(b);
                 if (engCap != currentLC.MaxEngineers)
                     GUILayout.Label($"(max of {engCap} eng.)");
 
-                int delta = assignDelta;
-                if (engCap < currentLC.Engineers + assignDelta)
-                    delta = engCap - currentLC.Engineers;
-                double buildRate = KCTUtilities.GetBuildRate(0, b.Type, currentLC, b.humanRated, delta) * leaderMult;
+                double buildRate = KCTUtilities.GetBuildRate(0, b.Type, currentLC, b.humanRated, assignDelta) * leaderMult;
                 double bpLeft = b.buildPoints - b.progress;
                 GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(b.CalculateTimeLeftForBuildRate(bpLeft, buildRate, efficiency, out _), "PersonnelVessel"), GetLabelRightAlignStyle());
             }
             else
             {
-                double rateFull = KCTUtilities.GetBuildRate(0, type, currentLC, currentLC.IsHumanRated, assignDelta);
-                double rate = rateFull * efficiency;
-                GUILayout.BeginHorizontal();
-                GUILayout.Label($"Vessel Rate: {rateFull:N3} => {rate:N3} BP/sec", GetLabelRightAlignStyle());
-                GUILayout.EndHorizontal();
-
-                GUILayout.BeginHorizontal();
                 LCOpsProject lcp = LCOpsProject.GetFirstCompleting(currentLC);
                 if (lcp != null)
                 {
                     int engCap = lcp.IsCapped ? currentLC.MaxEngineersFor(lcp.mass, lcp.vesselBP, lcp.isHumanRated) : int.MaxValue;
                     GUILayout.Label($"Current Project: {lcp.Name} {(lcp.AssociatedVP == null ? string.Empty : lcp.AssociatedVP.shipName)}");
                     
-                    int delta = assignDelta;
-                    if (engCap < currentLC.Engineers + assignDelta)
-                        delta = engCap - currentLC.Engineers;
                     if (engCap < int.MaxValue && engCap != currentLC.MaxEngineers)
                         GUILayout.Label($"(max of {engCap} eng.)");
 
-                    double buildRate = lcp.GetBuildRate(delta);
+                    double buildRate = lcp.GetBuildRate(assignDelta);
                     double bpLeft = (lcp.IsReversed ? 0 : lcp.BP) - lcp.progress;
                     GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(bpLeft / buildRate, "PersonnelVessel"), GetLabelRightAlignStyle());
                 }

--- a/Source/RP0/UI/KCT/GUI_Personnel.cs
+++ b/Source/RP0/UI/KCT/GUI_Personnel.cs
@@ -185,16 +185,21 @@ namespace RP0
             }
             GUILayout.EndHorizontal();
 
-            double rateFull = KCTUtilities.GetBuildRate(0, type, currentLC, currentLC.IsHumanRated, assignDelta) * stratMult;
+            double rateFull = KCTUtilities.GetBuildRate(0, type, currentLC, currentLC.IsHumanRated, assignDelta);
             double rate = rateFull * efficiency;
-            GUILayout.BeginHorizontal();
-            GUILayout.Label($"Vessel Rate: {rateFull:N3} => {rate:N3} BP/sec", GetLabelRightAlignStyle());
-            GUILayout.EndHorizontal();
-
-            GUILayout.BeginHorizontal();
             if (currentLC.CanIntegrate && currentLC.BuildList.Count > 0)
             {
                 VesselProject b = currentLC.BuildList[0];
+                double leaderMult = stratMult * b.LeaderEffect;
+                    
+                GUILayout.BeginHorizontal();
+                if (Math.Abs(leaderMult - 1) > 0.001)
+                    GUILayout.Label($"Efficiency & Leader Effect: {rateFull:N3} => {rate:N3} => {rate * leaderMult:N3} BP/sec", GetLabelRightAlignStyle());
+                else
+                    GUILayout.Label($"Efficiency Effect: {rateFull:N3} => {rate:N3} BP/sec", GetLabelRightAlignStyle());
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
                 GUILayout.Label($"Current Vessel: {b.shipName}");
 
                 int engCap = currentLC.MaxEngineersFor(b);
@@ -204,13 +209,17 @@ namespace RP0
                 int delta = assignDelta;
                 if (engCap < currentLC.Engineers + assignDelta)
                     delta = engCap - currentLC.Engineers;
-                double buildRate = KCTUtilities.GetBuildRate(0, b.Type, currentLC, b.humanRated, delta)
-                    * efficiency * stratMult;
+                double buildRate = KCTUtilities.GetBuildRate(0, b.Type, currentLC, b.humanRated, delta) * leaderMult;
                 double bpLeft = b.buildPoints - b.progress;
-                GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(bpLeft / buildRate, "PersonnelVessel"), GetLabelRightAlignStyle());
+                GUILayout.Label(RP0DTUtils.GetColonFormattedTimeWithTooltip(b.CalculateTimeLeftForBuildRate(bpLeft, buildRate, efficiency, out _), "PersonnelVessel"), GetLabelRightAlignStyle());
             }
             else
             {
+                GUILayout.BeginHorizontal();
+                GUILayout.Label($"Efficiency Effect: {rateFull:N3} => {rate:N3} BP/sec", GetLabelRightAlignStyle());
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
                 LCOpsProject lcp = LCOpsProject.GetFirstCompleting(currentLC);
                 if (lcp != null)
                 {

--- a/Source/RP0/UI/KCT/GUI_Personnel.cs
+++ b/Source/RP0/UI/KCT/GUI_Personnel.cs
@@ -185,18 +185,19 @@ namespace RP0
             }
             GUILayout.EndHorizontal();
 
-            double rateFull = KCTUtilities.GetBuildRate(0, type, currentLC, currentLC.IsHumanRated, assignDelta);
-            double rate = rateFull * efficiency;
+            
             if (currentLC.CanIntegrate && currentLC.BuildList.Count > 0)
             {
                 VesselProject b = currentLC.BuildList[0];
+                double rateFull = KCTUtilities.GetBuildRate(0, type, currentLC, b.humanRated, assignDelta);
+                double rate = rateFull * efficiency;
                 double leaderMult = stratMult * b.LeaderEffect;
                     
                 GUILayout.BeginHorizontal();
                 if (Math.Abs(leaderMult - 1) > 0.001)
-                    GUILayout.Label($"Efficiency & Leader Effect: {rateFull:N3} => {rate:N3} => {rate * leaderMult:N3} BP/sec", GetLabelRightAlignStyle());
+                    GUILayout.Label($"Vessel Rate (with Leaders): {rateFull:N3} => {rate:N3} => {rate * leaderMult:N3} BP/sec", GetLabelRightAlignStyle());
                 else
-                    GUILayout.Label($"Efficiency Effect: {rateFull:N3} => {rate:N3} BP/sec", GetLabelRightAlignStyle());
+                    GUILayout.Label($"Vessel Rate: {rateFull:N3} => {rate:N3} BP/sec", GetLabelRightAlignStyle());
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
@@ -215,8 +216,10 @@ namespace RP0
             }
             else
             {
+                double rateFull = KCTUtilities.GetBuildRate(0, type, currentLC, currentLC.IsHumanRated, assignDelta);
+                double rate = rateFull * efficiency;
                 GUILayout.BeginHorizontal();
-                GUILayout.Label($"Efficiency Effect: {rateFull:N3} => {rate:N3} BP/sec", GetLabelRightAlignStyle());
+                GUILayout.Label($"Vessel Rate: {rateFull:N3} => {rate:N3} BP/sec", GetLabelRightAlignStyle());
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();


### PR DESCRIPTION
When LC efficiency is not maximum, the displays in the Integration Info panel do not consider the LeaderEffect, This PR makes the net effect of leaders on integration rate visible in the Integration Info panel, and modifies all the values in the panel to account for all leader effects (including conditional ones!) properly.
<img width="1042" height="293" alt="image" src="https://github.com/user-attachments/assets/06f68db3-9921-4ba5-9c7e-f9808723bec0" />
