### PR TITLE
Change Rollout Time estimate to use estimated post-integration efficiency

### DIFF
--- a/Source/RP0/UI/KCT/GUI_Editor.cs
+++ b/Source/RP0/UI/KCT/GUI_Editor.cs
@@ -92,17 +92,19 @@ namespace RP0
 
             if (double.TryParse(BuildRateForDisplay, out double bR))
             {
+                double postEffic = effic;
                 double buildTime = bR > 0d
                     ? (effic >= LCEfficiency.MaxEfficiency
                         ? buildPoints / (bR * bpLeaderEffect)
-                        : SpaceCenterManagement.Instance.EditorVessel.CalculateTimeLeftForBuildRate(buildPoints, bR / effic * bpLeaderEffect, effic, out _))
+                        : SpaceCenterManagement.Instance.EditorVessel.CalculateTimeLeftForBuildRate(buildPoints, bR / effic * bpLeaderEffect, effic, out postEffic))
                     : 0d;
                 GUILayout.Label($"Integration Time: {(bR > 0 ? KSPUtil.PrintDateDeltaCompact(buildTime, true, false) : "infinity")} at {effic:P0}");
 
                 if (SpaceCenterManagement.EditorRolloutBP > 0)
                 {
-                    double rolloutBR = bR * CachedRolloutRateLeader;
-                    GUILayout.Label($"Rollout Time: {(bR > 0 ? KSPUtil.PrintDateDeltaCompact(SpaceCenterManagement.EditorRolloutBP / rolloutBR, true, false) : "infinity")} at {effic:P0}");
+                    double rolloutBR = bR * CachedRolloutRateLeader / effic * postEffic;
+                    GUILayout.Label(new GUIContent($"Rollout Time: {(bR > 0 ? KSPUtil.PrintDateDeltaCompact(SpaceCenterManagement.EditorRolloutBP / rolloutBR, true, false) : "infinity")} at {postEffic:P0}",
+                        "Uses the predicted efficiency after integration is complete."));
                 }
             }
             else


### PR DESCRIPTION
<img width="977" height="430" alt="image" src="https://github.com/user-attachments/assets/1bc0955b-6c15-4ad3-85e6-986e81bca5d1" />
<img width="493" height="109" alt="image" src="https://github.com/user-attachments/assets/48e5b681-f2ed-4239-9d27-0a87a33f3573" />
There's a slight discrepancy due to efficiency gain not precisely lining up. It still appears to remain an overestimate of the actual rollout time.