### PR TITLE
Fix incorrect Flight Director effects

### DIFF
--- a/GameData/RP-1/Strategies/Leaders/LeadersFlightDirectors.cfg
+++ b/GameData/RP-1/Strategies/Leaders/LeadersFlightDirectors.cfg
@@ -130,7 +130,7 @@ STRATEGY
 		multiplier = 1.05
 		transactionReasons
 		{
-			item = CrewTraining
+			item = RateTraining
 		}
 	}
 	EFFECT
@@ -352,7 +352,7 @@ STRATEGY
 		multiplier = 1.05
 		transactionReasons
 		{
-			item = RateVesselPrep
+			item = RateRollout
 		}
 	}
 	EFFECT
@@ -440,7 +440,7 @@ STRATEGY
 		multiplier = 0.95
 		transactionReasons
 		{
-			item = CrewTraining
+			item = RateTraining
 		}
 	}
 }
@@ -524,7 +524,7 @@ STRATEGY
 		flipPositive = True
 		transactionReasons
 		{
-			item = StructureConstructionAll
+			item = StructureConstructionLC
 			item = Tooling
 		}
 	}


### PR DESCRIPTION
fix:
Gagarin and Slayton actually affect training rate
Kranz only affects VAB rollout, as stated
Kalam only affects LC construction not all buildings, as stated

closes #2790 