### PR TITLE
Account for lack of efficiency gain when rushing an LC

### DIFF
--- a/Source/RP0/SpaceCenter/LaunchComplex/LCEfficiency.cs
+++ b/Source/RP0/SpaceCenter/LaunchComplex/LCEfficiency.cs
@@ -176,14 +176,14 @@ namespace RP0
         /// <param name="newEff"></param>
         /// <param name="startingEfficiency"></param>
         /// <returns></returns>
-        public double PredictWeightedEfficiency(double tdelta, double portionEngineers, out double newEff, double startingEfficiency = -1d)
+        public double PredictWeightedEfficiency(bool isRushing, double tdelta, double portionEngineers, out double newEff, double startingEfficiency = -1d)
         {
             if (startingEfficiency < 0d)
                 startingEfficiency = _efficiency;
 
             newEff = startingEfficiency;
 
-            if (tdelta < 86400d || startingEfficiency >= _MaxEfficiency)
+            if (isRushing || tdelta < 86400d || startingEfficiency >= _MaxEfficiency)
                 return tdelta;
 
             int steps = defaultSteps;

--- a/Source/RP0/SpaceCenter/Projects/LCOpsProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/LCOpsProject.cs
@@ -159,7 +159,7 @@ namespace RP0
             double portion = LC.Engineers / (double)LC.MaxEngineers;
             for (int i = 0; i < 4; ++i)
             {
-                timeLeft =  bpDivRate / LC.EfficiencySource.PredictWeightedEfficiency(timeLeft, portion, out newEff, LC.Efficiency);
+                timeLeft =  bpDivRate / LC.EfficiencySource.PredictWeightedEfficiency(LC.IsRushing, timeLeft, portion, out newEff, LC.Efficiency);
             }
             return timeLeft;
         }

--- a/Source/RP0/SpaceCenter/Projects/VesselProject.cs
+++ b/Source/RP0/SpaceCenter/Projects/VesselProject.cs
@@ -1423,7 +1423,7 @@ namespace RP0
             double portion = LC.Engineers / (double)LC.MaxEngineers;
             for (int i = 0; i < 4; ++i)
             {
-                timeLeft = bp / (rate * LC.EfficiencySource.PredictWeightedEfficiency(timeLeft, portion, out newEff, startingEff));
+                timeLeft = bp / (rate * LC.EfficiencySource.PredictWeightedEfficiency(LC.IsRushing, timeLeft, portion, out newEff, startingEff));
             }
             return timeLeft;
         }


### PR DESCRIPTION
RP-1 would previously assume that the efficiency would continue to increase even if an LC project was being rushed (which halts LC efficiency gain), which led to underestimates of how long the project would actually take. The date would then update to be closer to the real time as you approached it.

Before:
<img width="1520" height="853" alt="image" src="https://github.com/user-attachments/assets/10cd3fc1-f283-453c-acf9-ff1d7ca8bc73" />

After:
<img width="1521" height="855" alt="image" src="https://github.com/user-attachments/assets/98d3a570-d047-49c2-a37a-86dccc3f62d1" />

(the end time is the same in both cases, march 16 1951 10:39:43, the before just predicts it wrong and then later updates to be more correct)